### PR TITLE
cleaning this up so that it reorders master files correctly

### DIFF
--- a/app/models/structure_step.rb
+++ b/app/models/structure_step.rb
@@ -1,31 +1,26 @@
-	class StructureStep < Hydrant::Workflow::BasicStep
-                def initialize(step = 'structure', title = "Structure", summary = "Organization of resources", template = 'structure')
-                  super
-                end
+  class StructureStep < Hydrant::Workflow::BasicStep
+    def initialize(step = 'structure', title = "Structure", summary = "Organization of resources", template = 'structure')
+      super
+    end
 
-		def execute context
-		  mediaobject = context[:mediaobject]
+    def execute context
+      media_object = context[:mediaobject]
 
-        if !context[:masterfile_ids].nil?
-          masterFiles = []
-          context[:masterfile_ids].each do |mf_id|
-            mf = MasterFile.find(mf_id)
-            masterFiles << mf
-          end
+        if ! context[:masterfile_ids].nil?
 
-          # Clean out the parts
-          masterFiles.each do |mf|
-            mediaobject.parts_remove mf
-          end
-          mediaobject.save(validate: false)
+          # gather the parts in the right order
+          # in this situation we cannot use MatterFile.find([]) because
+          # it will not return the results in the correct order
+          master_files = context[:masterfile_ids].map{ |masterfile_id| MasterFile.find(masterfile_id) }
+
+          # remove the parts
+          media_object.parts.clear
           
-          # Puts parts back in order
-          masterFiles.each do |mf|
-            mf.container = mediaobject
-            mf.save
-          end
-          mediaobject.save(validate: false)
+          # re-add the parts that are now in the right order
+          media_object.parts = master_files
+
+          media_object.save 
         end
-		  context
-		end
-	end
+      context
+    end
+  end


### PR DESCRIPTION
When dragging a file to move it in the structure step:

Completed 500 Internal Server Error in 96ms

NoMethodError (undefined method `parts_remove' for #<MediaObject:903833388499498721 @pid="changeme:6" >):
  app/models/structure_step.rb:18:in`block in execute'
  app/models/structure_step.rb:17:in `each'
  app/models/structure_step.rb:17:in`execute'
