### PR TITLE
Make sure that it is always possible to sign in / sign out 

### DIFF
--- a/app/views/modules/_global_navigation.html.erb
+++ b/app/views/modules/_global_navigation.html.erb
@@ -28,7 +28,7 @@
       <form action="/" method="get" class="navbar-search pull-right">
         <input type="text" class="search-query" name="q" placeholder="Search">
       </form>
-      <ul class="nav visible-phone">
+      <ul class="nav hidden-desktop">
         <li class="divider" />
         <%= link_to_if user_signed_in?, 'Sign out', destroy_user_session_path do %>
           <%# Fallback if the test above fails %>


### PR DESCRIPTION
Regardless of the viewport size when the navigation menu collapses it should pull in the authentication options. In larger views it will be an orange button in the upper right corner. In condensed views it should appear below search in the dropdown.

![desktop](https://f.cloud.github.com/assets/1493179/304600/d69528a6-9640-11e2-998d-967d239da224.png)
![tablet](https://f.cloud.github.com/assets/1493179/304602/d6aa2526-9640-11e2-8d8b-61c29a7f227a.png)
![phone](https://f.cloud.github.com/assets/1493179/304601/d6a0a942-9640-11e2-88da-d4e7b3d2cf6a.png)
