### PR TITLE
only run this on the app server

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 set :output, "log/whenever_cron.log"
 
-every 1.minute do
-  rake 'avalon:batch:ingest', :environment => "development"
+every 1.minute, :roles => [:app] do
+  rake 'avalon:batch:ingest'
 end


### PR DESCRIPTION
Made a mistake.  We need this to deploy with Capistrano.

https://github.com/javan/whenever

``` markdown
Here are the basic rules:

If a server's role isn't listed in whenever_roles, it will never have jobs added to its crontab.
If a server's role is listed in the whenever_roles, then it will have all jobs added to its crontab that either list that role in their :roles arg or that don't have a :roles arg.
If a job has a :roles arg but that role isn't in the whenever_roles list, that job will not be deployed to any server.
```
