### PR TITLE
Remove unused dropbox credentials from config file

### DIFF
--- a/config/avalon.yml.example
+++ b/config/avalon.yml.example
@@ -2,8 +2,6 @@ development:
   dropbox:
     path: '/srv/avalon/dropbox/'
     upload_uri: 'sftp://localhost/srv/avalon/dropbox'
-    username: 'avalon'
-    password: 'avalon'
     notification_email_address: ''
   matterhorn:
     root: 'http://localhost:8080/'
@@ -31,8 +29,6 @@ test:
   dropbox:
     path: '/srv/avalon/dropbox/'
     upload_uri: 'sftp://localhost/srv/avalon/dropbox'
-    username: 'test'
-    password: 'test'
     notification_email_address: ''
   matterhorn:
     root: 'http://localhost:8080/'


### PR DESCRIPTION
These aren't referenced anywhere so they should be removed to avoid clutter and confusion.
