### PR TITLE
[VOV-1922] Close the uploaded tempfile to prevent handle leakage

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -481,6 +481,7 @@ class MasterFile < ActiveFedora::Base
     self.poster_offset = [2000,mediainfo.duration.to_i].min
 
     self.file_size = file.size.to_s
+    file.close
 
     logger.debug "<< File location #{ file_location } >>"
     logger.debug "<< Filesize #{ file_size } >>"


### PR DESCRIPTION
Rails is getting confused by our renaming/copying of the uploaded tempfile, and holding the handle open. This causes blocking when the redirect request tries to use the same worker thread on the server.
