### PR TITLE
Remove unit drop-down from edit collections as editor 

### DIFF
--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -1,7 +1,9 @@
 <%= twitter_bootstrap_form_for @collection, remote: true, html: { modal: true } do |f| %>
   <%= f.text_field :name, class: 'span5' %>
   <%= f.text_area :description, rows: 3, class: 'span5'  %>
-  <%= f.select(:unit, "Unit", Admin::Collection.units) %>
-    <%= f.submit class: 'btn btn-primary btn-stateful-loading', data: {loading_text: 'Saving...'} %>
-    <a href="#" data-dismiss="modal" aria-hidden="true" class="btn">Cancel</a>
+	<% if can? :update_unit, @collection %>
+		<%= f.select(:unit, "Unit", Admin::Collection.units) %>
+	<% end %>	
+	<%= f.submit class: 'btn btn-primary btn-stateful-loading', data: {loading_text: 'Saving...'} %>
+	<a href="#" data-dismiss="modal" aria-hidden="true" class="btn">Cancel</a>
 <% end %>


### PR DESCRIPTION
When logged in as an editor the unit select drop-down menu item will not appear in the edit collections pop-up.
