### PR TITLE
Validate the uniqueness of a group name

### DIFF
--- a/app/models/admin/group.rb
+++ b/app/models/admin/group.rb
@@ -24,6 +24,10 @@ class Admin::Group
   # as more thought is put into the process of providing a comment
   attr_accessor :name, :users
   validates :name, :presence => true 
+  validate do |group|
+   found_group = Admin::Group.find(group.name)
+   self.errors.add(:name, :taken, value: group.name) if !found_group.nil? && found_group != group
+  end
 
   def self.non_system_groups
     groups = all
@@ -82,6 +86,10 @@ class Admin::Group
     g = super
     g.new_record = true
     g
+  end
+
+  def self.first
+    Admin::Group.find(RoleControls.roles.first)
   end
 
   def self.abstract_class?
@@ -192,6 +200,10 @@ class Admin::Group
 
   def saved= val 
     @saved = val
+  end
+
+  def == g2
+    !g2.nil? && (self.name == g2.name) && (self.users == g2.users)
   end
 
   # Check to see if the name is static based on its inclusion in the system

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -16,6 +16,7 @@ require 'spec_helper'
 
 describe Admin::Group do
   it {should validate_presence_of(:name)}
+  it {should validate_uniqueness_of(:name)}
   describe "non system groups" do
     it "should not have system groups" do
       groups = Admin::Group.non_system_groups


### PR DESCRIPTION
I did this validator inline because we plan on ditching this class and didn't want to create another validator class if it was going to be abandoned soon.  Equality was added to support the validator and #first added for the shoulda matcher to work properly.
