### PR TITLE
Order groups in power order; remove collection_manager

### DIFF
--- a/config/avalon.yml.example
+++ b/config/avalon.yml.example
@@ -22,7 +22,7 @@ development:
     rtmp_base: 'rtmp://localhost/avalon'
     http_base: 'http://localhost:3000/streams'
   groups:
-    system_groups: [administrator, manager, collection_manager, group_manager]
+    system_groups: [administrator, group_manager, manager]
 test:
   dropbox:
     path: '/srv/avalon/dropbox/'
@@ -47,4 +47,4 @@ test:
     rtmp_base: 'rtmp://localhost/avalon'
     http_base: 'http://localhost:3000/streams'
   groups:
-    system_groups: [administator, manager, collection_manager, group_manager]
+    system_groups: [administator, group_manager, manager]


### PR DESCRIPTION
See comments on VOV-1954 for more information on this change.  Will require this edit in avalon.yml on preexisting systems.  I'm not sure if this is already in migrations or if it needs to be included in upgrade documentation.
