### PR TITLE
Lock hydra-head and devise (-> master)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
   gem 'rails', '~>3.2.3'
   gem 'builder', '~>3.0.0'
 
-  gem 'hydra-head', '~> 6.0'
+  gem 'hydra-head', '~> 6.3.0'
   gem 'bcrypt-ruby', '~> 3.0.0'
 
   gem 'avalon-workflow', git: 'https://github.com/avalonmediasystem/avalon-workflow.git', tag: 'avalon-r2'
@@ -36,7 +36,7 @@
   gem 'avalon-about', :git => "https://github.com/avalonmediasystem/avalon-about.git", tag: 'avalon-r2'
 
   # You are free to implement your own User/Authentication solution in its place.
-  gem 'devise'
+  gem 'devise', '~>3.0.3'
   #gem 'devise-guests'
   gem 'haml'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,7 +530,7 @@ DEPENDENCIES
   database_cleaner!
   debugger
   delayed_job_active_record
-  devise
+  devise (~> 3.0.3)
   email_spec
   equivalent-xml
   execjs
@@ -542,7 +542,7 @@ DEPENDENCIES
   haml
   handlebars_assets
   headless
-  hydra-head (~> 6.0)
+  hydra-head (~> 6.3.0)
   hydra-migrate (>= 0.2.0)
   iconv
   jdbc-sqlite3


### PR DESCRIPTION
Lock hydra-head to 6.3.x and devise to 3.0.x until we fix compatibility issues and deprecations.
