### PR TITLE
Move MasterFile and Derivative absolute_location out of descMetadata to a dedicate plaintext datastream

### DIFF
--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -97,11 +97,11 @@ class Derivative < ActiveFedora::Base
   end
 
   def absolute_location
-    derivativeFile.url
+    derivativeFile.location
   end
 
   def absolute_location=(value)
-    derivativeFile.url = value
+    derivativeFile.location = value
   end
 
   def tokenized_url(token, mobile=false)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -387,11 +387,11 @@ class MasterFile < ActiveFedora::Base
   end
 
   def absolute_location
-    masterFile.url
+    masterFile.location
   end
 
   def absolute_location=(value)
-    masterFile.url = value
+    masterFile.location = value
   end
 
   def file_location

--- a/app/models/url_datastream.rb
+++ b/app/models/url_datastream.rb
@@ -17,11 +17,11 @@ class UrlDatastream < ActiveFedora::Datastream
     super.merge(:controlGroup => 'M', :mimeType => 'text/url', :label => 'URL')
   end
 
-  def url
+  def location
     self.content
   end
 
-  def url=(value)
+  def location=(value)
     URI.parse(value) unless value.nil?
     self.content = value
   end

--- a/spec/models/url_datastream_spec.rb
+++ b/spec/models/url_datastream_spec.rb
@@ -26,7 +26,7 @@ describe UrlDatastream do
     it "should have default properties" do 
       expect(subject.mimeType).to eq('text/url')
       expect(subject.controlGroup).to eq('M')
-      expect(subject.url).to be_nil
+      expect(subject.location).to be_nil
     end
   end
 
@@ -36,29 +36,29 @@ describe UrlDatastream do
      'nfs://nfs.example.edu/share/foo/bar/baz.jpg',
      'smb://samba.example.edu/share/foo/bar/baz.jpg'].each do |loc|
       it "should accept #{loc}" do
-        subject.url = loc
-        expect(subject.url).to eq(loc)
+        subject.location = loc
+        expect(subject.location).to eq(loc)
       end
     end
 
     it "should require a valid URL" do
-      expect { subject.url = 'blah blah blah' }.to raise_error(URI::InvalidURIError)
+      expect { subject.location = 'blah blah blah' }.to raise_error(URI::InvalidURIError)
     end
   end
 
   describe "initialized" do
     before :each do
-      subject.url = 'file:///path/to/foo/bar/baz.jpg'
+      subject.location = 'file:///path/to/foo/bar/baz.jpg'
       test_object.save
     end
 
     it "should be initialized" do
-      expect(subject.url).to eq('file:///path/to/foo/bar/baz.jpg')
+      expect(subject.location).to eq('file:///path/to/foo/bar/baz.jpg')
     end
 
     it "should be nillable" do
-      subject.url = nil
-      expect(subject.url).to be_nil
+      subject.location = nil
+      expect(subject.location).to be_nil
     end
   end
 end


### PR DESCRIPTION
This will make it easier to retrieve the information and act on it outside of Avalon, without having to know or care about ActiveFedora::SimpleDatastream's XML format.
