### PR TITLE
Switch to hydra gem upgrading components and getting rid of deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
   gem 'rails', '~>3.2.3'
   gem 'builder', '~>3.0.0'
 
-  gem 'hydra-head', '~> 6.3.0'
+  gem 'hydra', "~> 6.1.0"
   gem 'hydra-migrate', '>=0.2.0'
   gem 'bcrypt-ruby', '~> 3.0.0'
 
@@ -15,7 +15,6 @@
   gem 'media_element_thumbnail_selector', git: 'https://github.com/avalonmediasystem/media-element-thumbnail-selector' # HEAD , tag: 'avalon-r2'
   gem 'mediaelement-skin-avalon', git:'https://github.com/avalonmediasystem/mediaelement-skin-avalon.git' # HEAD , tag: 'avalon-r2'
   gem 'mediaelement-title', git:'https://github.com/avalonmediasystem/mediaelement-title.git' # HEAD
-  gem 'hydra-migrate', '>=0.2.0'
   
   gem 'modal_logic'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.2)
     ensure_valid_encoding (0.5.3)
-    equivalent-xml (0.3.0)
+    equivalent-xml (0.4.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.0.2)
@@ -264,23 +264,35 @@ GEM
     highline (1.6.20)
     hike (1.2.3)
     hooks (0.3.3)
-    hydra-access-controls (6.3.4)
-      active-fedora (~> 6.1)
+    hydra (6.1.0)
+      active-fedora (~> 6.7.0)
+      blacklight (~> 4.5.0)
+      hydra-head (~> 6.4.0)
+      jettywrapper (~> 1.5.0)
+      nokogiri (~> 1.6.0)
+      nom-xml (~> 0.5.1)
+      om (~> 3.0.3)
+      rails (>= 3.2.15, < 5.0)
+      rsolr (~> 1.0.9)
+      rubydora (~> 1.6.5)
+      solrizer (~> 3.1.0)
+    hydra-access-controls (6.4.1)
+      active-fedora (~> 6.6)
       activesupport
       blacklight (~> 4.0)
       cancan
       deprecation
-    hydra-core (6.3.4)
+    hydra-core (6.4.1)
       active-fedora
       blacklight (~> 4.0)
       block_helpers
       deprecation (>= 0.0.5)
-      hydra-access-controls (= 6.3.4)
+      hydra-access-controls (= 6.4.1)
       jettywrapper (>= 1.4.1)
       rails (>= 3.2.3, < 5)
-    hydra-head (6.3.4)
-      hydra-access-controls (= 6.3.4)
-      hydra-core (= 6.3.4)
+    hydra-head (6.4.1)
+      hydra-access-controls (= 6.4.1)
+      hydra-core (= 6.4.1)
       rails (>= 3.2.6)
     hydra-migrate (0.3.0)
       active-fedora (>= 6.0)
@@ -340,7 +352,7 @@ GEM
     net-ssh (2.7.0)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    nokogiri (1.6.0)
+    nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     nom-xml (0.5.1)
       activesupport
@@ -398,7 +410,7 @@ GEM
     raindrops (0.12.0)
     rake (10.1.0)
     rb-fsevent (0.9.3)
-    rdf (1.1.0)
+    rdf (1.1.0.1)
     rdf-rdfxml (1.0.1)
       rdf (>= 1.0)
       rdf-xsd (>= 1.0)
@@ -540,7 +552,7 @@ DEPENDENCIES
   handlebars_assets
   headless
   hooks
-  hydra-head (~> 6.3.0)
+  hydra (~> 6.1.0)
   hydra-migrate (>= 0.2.0)
   iconv
   jdbc-sqlite3

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -19,9 +19,8 @@ require 'avalon/controlled_vocabulary'
 require 'avalon/sanitizer'
 
 class Admin::Collection < ActiveFedora::Base
-  include Hydra::ModelMixins::CommonMetadata
+  include Hydra::AccessControls::Permissions
   include ActiveFedora::Associations
-  include Hydra::ModelMixins::RightsMetadata
   include Hydra::ModelMixins::HybridDelegator
   include Hydra::ModelMixins::Migratable
 

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -19,8 +19,7 @@ require 'avalon/file_resolver'
 class MasterFile < ActiveFedora::Base
   include ActiveFedora::Associations
   include Hydra::ModelMethods
-  include Hydra::ModelMixins::CommonMetadata
-  include Hydra::ModelMixins::RightsMetadata
+  include Hydra::AccessControls::Permissions
   include Hydra::ModelMixins::Migratable
   include Hooks
   include Rails.application.routes.url_helpers

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -12,13 +12,11 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-#require 'hydra/rights_metadata'
 
 class MediaObject < ActiveFedora::Base
-  include Hydra::ModelMixins::CommonMetadata
+  include Hydra::AccessControls::Permissions
   include Hydra::ModelMethods
   include ActiveFedora::Associations
-  include Hydra::ModelMixins::RightsMetadata
   include Avalon::Workflow::WorkflowModelMixin
   include Hydra::ModelMixins::Migratable
 

--- a/config/initializers/hydra_config.rb
+++ b/config/initializers/hydra_config.rb
@@ -1,4 +1,4 @@
-require "hydra"
+require 'hydra/head' unless defined? Hydra
 
 # The following lines determine which user attributes your hydrangea app will use
 # This configuration allows you to use the out of the box ActiveRecord associations between users and user_attributes

--- a/spec/validators/uniqueness_validator_spec.rb
+++ b/spec/validators/uniqueness_validator_spec.rb
@@ -20,7 +20,7 @@ describe "UniquenessValidator" do
   let(:validator) {UniquenessValidator.new({:attributes => {}, :solr_name => solr_field})}
 
   before(:each) do
-    @record = stub(pid:"avalon:1")
+    @record = double(pid:"avalon:1")
     @record.stub("errors").and_return([])
   end
 
@@ -35,14 +35,14 @@ describe "UniquenessValidator" do
   end
 
   it "should not return errors when field is unique but record is the same" do
-    doc = stub(pid: "avalon:1")
+    doc = double(pid: "avalon:1")
     validator.stub("find_doc").and_return(doc)
     @record.should_not_receive('errors')
     validator.validate_each(@record, "title", "new_title")
   end
 
   it "should return erros when field is not unique" do
-    doc = stub(pid: "avalon:2")
+    doc = double(pid: "avalon:2")
     validator.stub("find_doc").and_return(doc)
     @record.errors.should_receive('add')
     validator.validate_each(@record, "title", "old_title")
@@ -53,20 +53,20 @@ describe "UniquenessValidator" do
     let (:value) {"old_title"}
 
     it "should use the solr field name and supplied values" do
-      relation = stub()
+      relation = double()
       relation.stub("first")
       klass.should_receive("where").once.with(solr_field => value).and_return(relation)
       validator.find_doc(klass, value)
     end
     it "should return one record when present" do
-      doc = stub(pid: "avalon:1")
-      relation = stub()
+      doc = double(pid: "avalon:1")
+      relation = double()
       relation.stub("first").and_return(doc)
       klass.stub("where").and_return(relation)
       validator.find_doc(klass, value).should be_an_instance_of klass
     end
     it "should return nil when not present" do
-      relation = stub()
+      relation = double()
       relation.stub("first").and_return(nil)
       klass.stub("where").and_return(relation)
       validator.find_doc(klass, value).should be_nil


### PR DESCRIPTION
This gets us the latest hydra 6.4 components even though the hydra gem is version 6.1.0
