### PR TITLE
add exception for when the current object isn't available

### DIFF
--- a/app/views/media_objects/_share.html.erb
+++ b/app/views/media_objects/_share.html.erb
@@ -39,7 +39,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <p class="muted">Copy the text below to embed this resource</p>
       <textarea class="span6" rows="3" id="embed-part" onClick="this.select();"><%= @currentStream.embed_code(MasterFile::EMBED_SIZE[:medium], request.host_with_port) %></textarea>
     <% else %>
-      <p class="muted">After processing has started the embedded link will be available.</p>
+      <p class="muted"> <%= I18n.t('media_object.empty_share_link_notice') %> </p>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
       taken: "is taken."
   media_object:
     empty_share_link: ""
+    empty_share_link_notice: "After processing has started the embedded link will be available."
   metadata_tip:
     abstract: |
       Summary provides a space for describing the contents of the item. Examples 


### PR DESCRIPTION
The tab is blank when 1) an asset has not been attached to the media object 2) the workflow hasn't started for an attached file.
