### PR TITLE
Fix migration script for Masterfile.display_aspect_ratio

### DIFF
--- a/db/migrate/20131218142013_add_display_aspect_ratio_to_master_file.rb
+++ b/db/migrate/20131218142013_add_display_aspect_ratio_to_master_file.rb
@@ -16,11 +16,11 @@ class AddDisplayAspectRatioToMasterFile < ActiveRecord::Migration
           end
         ensure
           if ratio.nil? 
-            logger.warn("#{masterfile.pid} aspect ratio not found")
-          else
-            masterfile.display_aspect_ratio = ratio.split(/[x:]/).collect(&:to_f).reduce(:/).to_s 
-            masterfile.save(validate: false)
+            ratio = "4:3"
+            logger.warn("#{masterfile.pid} aspect ratio not found - setting to default 4:3")
           end
+          masterfile.display_aspect_ratio = ratio.split(/[x:]/).collect(&:to_f).reduce(:/).to_s 
+          masterfile.save(validate: false)
         end
       end
     end


### PR DESCRIPTION
If there is no workflow to reference to find the display_aspect ratio, Mediainfo is ran on the absolute_location of a derivative instead.
If that fails, the user is warned that setting the display_aspect_ratio failed for that pid.
