### PR TITLE
Strip the format from omniauth routes (fixes VOV-2493)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Avalon::Application.routes.draw do
 
   root :to => "catalog#index"
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }, format: false
   devise_scope :user do 
     match '/users/sign_in', :to => "users/sessions#new", :as => :new_user_session
     match '/users/sign_out', :to => "users/sessions#destroy", :as => :destroy_user_session


### PR DESCRIPTION
This appears to fix VOV-2493 as devise will now redirect to 
/users/auth/identity?action=new&controller=users%2Fsessions&format=user
instead of 
users/auth/identity.user?action=new&controller=users%2Fsessions
