### PR TITLE
Restore flash notice

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -105,7 +105,11 @@ class Admin::CollectionsController < ApplicationController
     ["manager", "editor", "depositor"].each do |title|
       if params["submit_add_#{title}"].present? 
         if params["add_#{title}"].present? && can?("update_#{title.pluralize}".to_sym, @collection)
-          @collection.send "add_#{title}".to_sym, params["add_#{title}"]
+          begin
+            @collection.send "add_#{title}".to_sym, params["add_#{title}"]
+          rescue ArgumentError => e
+            flash[:notice] = e.message
+          end
         else
           flash[:notice] = "#{title.titleize} can't be blank."
         end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -31,6 +31,15 @@ describe Admin::CollectionsController, type: :controller do
       manager.should be_in(collection.managers)
     end
 
+    it "should not add users to manager role" do
+      login_as(:administrator)
+      user = FactoryGirl.create(:user)
+      put 'update', id: collection.id, submit_add_manager: 'Add', add_manager: user.username
+      collection.reload
+      user.should_not be_in(collection.managers)
+      flash[:notice].should_not be_empty
+    end
+
     it "should remove users from manager role" do
       login_as(:administrator)
       #initial_manager = FactoryGirl.create(:manager).username


### PR DESCRIPTION
This restores the being/rescue block which catches the case when trying to add managers who aren't in the managers group.  The flash notice renders a bit oddly on this page and should get fixed.  Ideally, I think it would be best to refactor such that the error would be on the collection object instead of in the flash notice.
