### PR TITLE
Add minter_state.yml to shared children

### DIFF
--- a/config/deploy/avalon.rb
+++ b/config/deploy/avalon.rb
@@ -34,6 +34,7 @@ set(:shared_children) {
     config/environments/development.rb
     config/fedora.yml 
     config/matterhorn.yml 
+    config/minter_state.yml
     config/role_map_#{fetch(:rails_env)}.yml 
     config/solr.yml
     Gemfile.local 


### PR DESCRIPTION
This should help keep mallorn, pawpaw and other systems from having problems after cap deploys.  Post-R3 it would be nice to have a story to remove these IU specific pieces of the cap deploy configs.
