### PR TITLE
Bugfix/pid assignment

### DIFF
--- a/config/initializers/assign_pid.rb
+++ b/config/initializers/assign_pid.rb
@@ -5,7 +5,7 @@ module ActiveFedora
     	if ns = Avalon::Configuration.lookup('fedora.namespace')
     		pid_opts[:namespace] = ns
     	end
-      @pid ||= ActiveFedora::Base.connection_for_pid('0').mint
+      @pid ||= ActiveFedora::Base.connection_for_pid('0').mint pid_opts
     end
   end
 end

--- a/spec/lib/avalon/assign_pid_spec.rb
+++ b/spec/lib/avalon/assign_pid_spec.rb
@@ -1,0 +1,28 @@
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'spec_helper'
+
+describe 'PID Assignment' do
+  let(:repo)      { ActiveFedora::Base.connection_for_pid(0) }
+  let(:namespace) { Avalon::Configuration.lookup('fedora.namespace') }
+  let(:pid)       { "#{namespace}:12345" }
+  
+  it "should assign a PID in the correct namespace" do
+    expect(repo).to receive(:mint).with({ namespace: namespace }).and_return(pid)
+    mo = MediaObject.new
+    mo.send(:assign_pid)
+    expect(mo.pid).to eq(pid)
+  end
+end


### PR DESCRIPTION
This is a high-priority fix. All new objects are being assigned PIDs in Fedora's default namespace.
