### PR TITLE
Bugfix/mediainfo other stream type

### DIFF
--- a/config/initializers/mediainfo_other_stream.rb
+++ b/config/initializers/mediainfo_other_stream.rb
@@ -1,0 +1,19 @@
+# Monkey patch Mediainfo so it doesn't choke on stream type 'Other'
+
+require 'mediainfo'
+unless Mediainfo::SECTIONS.include? :other
+  Mediainfo::SECTIONS << :other
+  class Mediainfo::OtherStream < Mediainfo::Stream
+    mediainfo_attr_reader :stream_id, "ID"
+    mediainfo_attr_reader :type
+  end
+  
+  class Mediainfo::Stream
+    def other?; :other == @stream_type; end
+  end
+  
+  class Mediainfo
+    def other; @other_proxy ||= StreamProxy.new(self, :other); end
+    def other?; streams.any? { |x| x.other? }; end
+  end
+end


### PR DESCRIPTION
Fix for:

```
NoMethodError: undefined method `other?' for #<Mediainfo:0x000000055bda60>
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/mediainfo-0.7.2/lib/mediainfo.rb:504:in `block in parse!'
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/mediainfo-0.7.2/lib/mediainfo.rb:503:in `each'
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/mediainfo-0.7.2/lib/mediainfo.rb:503:in `parse!'
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/mediainfo-0.7.2/lib/mediainfo.rb:412:in `raw_response='
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/mediainfo-0.7.2/lib/mediainfo.rb:405:in `initialize'
    from (irb):2:in `new'
    from (irb):2
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/railties-3.2.18/lib/rails/commands/console.rb:47:in `start'
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/railties-3.2.18/lib/rails/commands/console.rb:8:in `start'
    from /var/www/avalon/shared/gems/ruby/1.9.1/gems/railties-3.2.18/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```
