### PR TITLE
Pin kaminari at 0.15.x until 0.16 is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@
 
   gem 'hydra', "~> 6.2.0"
   gem 'bcrypt-ruby', '~> 3.0.0'
+  gem 'kaminari', '~> 0.15.0'
 
   gem 'avalon-workflow', git: 'https://github.com/avalonmediasystem/avalon-workflow.git' # HEAD , tag: 'avalon-r3'
   gem 'avalon-batch', '~> 0.3.0', git: "https://github.com/avalonmediasystem/avalon-batch.git" # HEAD , tag: 'avalon-r3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,6 +580,7 @@ DEPENDENCIES
   jettywrapper
   jquery-rails (~> 2.1.4)
   jruby-openssl
+  kaminari (~> 0.15.0)
   letter_opener
   license_header
   loofah


### PR DESCRIPTION
Eliminates `prev_page not found` error when expanding a list of facets
