### PR TITLE
Fix undefined method '/' error when the master file is still accessible

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -461,7 +461,7 @@ class MasterFile < ActiveFedora::Base
       new_height += 1 if new_height.odd?
       aspect = new_width/new_height
 
-      frame_source = find_frame_source(options)
+      frame_source = find_frame_source(offset: offset)
       Tempfile.open([base,'.jpg']) do |jpeg|
         file_source = File.join(File.dirname(jpeg.path),"#{File.basename(jpeg.path,File.extname(jpeg.path))}#{File.extname(frame_source[:source])}")
         File.symlink(frame_source[:source],file_source)


### PR DESCRIPTION
I couldn't think of a good test for this.  I'm reusing the offset variable which is setup earlier in the method by calling :to_i on options[:offset].  If options[:offset] is a string (which is should be) and the master file is still accessible by avalon then line 470 will attempt to divide the string by 1000.0 leading to a undefined method error.
