### PR TITLE
Expose Permalink URL helper

### DIFF
--- a/app/models/concerns/permalink.rb
+++ b/app/models/concerns/permalink.rb
@@ -27,14 +27,17 @@ module Permalink
     def initialize
       @proc = Proc.new { |obj, target| nil }
     end
-
-    def permalink_for(obj)
-      url = case obj
+  
+    def avalon_url_for(obj)
+      case obj
       when MediaObject then media_object_url(obj.pid)
       when MasterFile  then pid_section_media_object_url(obj.mediaobject.pid, obj.pid)
       else raise ArgumentError, "Cannot make permalink for #{obj.class}"
       end
-      @proc.call(obj, url)
+    end
+    
+    def permalink_for(obj)
+      @proc.call(obj, avalon_url_for(obj))
     end
   end
 
@@ -42,7 +45,11 @@ module Permalink
   def self.permalink_for(obj)
     @@generator.permalink_for(obj)
   end
-    
+  
+  def self.url_for(obj)
+    @@generator.avalon_url_for(obj)
+  end
+  
   # Permalink.on_generate do |obj|
   #   permalink = (... generate permalink ...)
   #   return permalink

--- a/spec/models/concerns/permalink_spec.rb
+++ b/spec/models/concerns/permalink_spec.rb
@@ -35,6 +35,16 @@ describe Permalink do
     end
 
     context 'creating permalink' do
+      let(:media_object) { FactoryGirl.build(:media_object) }
+      
+      it 'should get the absolute path to the object' do
+        allow(media_object).to receive(:pid).and_return('avalon:item')
+        allow(master_file).to receive(:pid).and_return('avalon:section')
+        master_file.mediaobject = media_object
+        expect(Permalink.url_for(media_object)).to eq('http://test.host/media_objects/avalon:item')
+        expect(Permalink.url_for(master_file)).to eq('http://test.host/media_objects/avalon:item/section/avalon:section')
+      end
+      
       it 'permalink_for raises ArgumentError if not passed mediaobject or masterfile' do
         expect{Permalink.permalink_for(Object.new)}.to raise_error(ArgumentError)
       end      


### PR DESCRIPTION
The NU Permalink Handle implementation needs to be able to get the full URL of an object outside the scope of the `permalink_for` callback. I see no reason not to expose it. I realize this change may be out of scope for today's release, but it's so low-impact I hope we can make an exception for the sake of my sanity in getting NU's production system up cleanly.
