### PR TITLE
Display running operation instead of last completed

### DIFF
--- a/app/assets/javascripts/avalon_process.js.coffee
+++ b/app/assets/javascripts/avalon_process.js.coffee
@@ -46,6 +46,8 @@ class AvalonProgress
         setActive(bar, info.complete < 100 and (info.status == 'RUNNING' or info.status == 'WAITING'))
 
         info_box.html(info.operation) if info.operation?
+        if info.complete == 100
+          info_box.html(info.status)
         updateBar(bar, {success: info.success, danger: info.error})
         if info.status == 'FAILED'
           info_box.html("ERROR: #{info.message}")
@@ -60,6 +62,9 @@ class AvalonProgress
 
     updateBar($('#overall'), {success: info.success, danger: info.error})
     $('#overall').data('status',info)
+    if info.success == 100
+      location.reload()
+
     return info.success + info.error < 100
 
   click_section: (section_id) ->

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -114,7 +114,7 @@ class MediaObjectsController < ApplicationController
         [mf.pid, mf_status]
       }
     ]
-    overall.each { |k,v| overall[k] = [0,[100,v.to_f/@masterFiles.length.to_f].min].max.round }
+    overall.each { |k,v| overall[k] = [0,[100,v.to_f/@masterFiles.length.to_f].min].max.floor }
 
     if overall[:success]+overall[:error] > 100
       overall[:error] = 100-overall[:success]

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -519,13 +519,13 @@ class MasterFile < ActiveFedora::Base
 
     result = Hash.new { |h,k| h[k] = 0 }
     operations.each { |op|
-      op[:pct] = (totals[op[:type]].to_f / operations.select { |o| o[:type] == op[:type] }.count.to_f).ceil
+      op[:pct] = (totals[op[:type]].to_f / operations.select { |o| o[:type] == op[:type] }.count.to_f)
       state = op[:state].downcase.to_sym 
       result[state] += op[:pct]
       result[:complete] += op[:pct] if END_STATES.include?(op[:state])
     }
-    result[:succeeded] += result.delete(:skipped).to_i
-    result.each { |k,v| result[k] = 100 if v > 100 }
+    result[:succeeded] += result.delete(:skipped) unless result[:skipped].nil?
+    result.each {|k,v| result[k] = result[k].round }
     result
   end
 


### PR DESCRIPTION
This is for post-3.1 release.

There is a small bug I noticed while manually testing this.  Sometimes the preview page will not show the last step (Cleaning up) even though the progress bar reports 100%.  It appears that this is a race condition of some kind where there just needs to be another call to progress.json.
