### PR TITLE
Only call setters if there are actual values present

### DIFF
--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -68,9 +68,9 @@ require 'avalon/dropbox'
             deleted_parts << selected_part
             selected_part.destroy
           else
-            selected_part.label = part[:label]
-            selected_part.permalink = part[:permalink]
-            selected_part.poster_offset = part[:poster_offset]
+            selected_part.label = part[:label] unless part[:label].blank?
+            selected_part.permalink = part[:permalink] unless part[:permalink].blank?
+            selected_part.poster_offset = part[:poster_offset] unless part[:poster_offset].blank?
             unless selected_part.save
               context[:error] ||= []
               context[:error] << "#{selected_part.pid}: #{selected_part.errors.to_a.first.gsub(/(\d+)/) { |m| m.to_i.to_hms }}"

--- a/spec/models/file_upload_step_spec.rb
+++ b/spec/models/file_upload_step_spec.rb
@@ -1,0 +1,27 @@
+# Copyright 2011-2014, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'spec_helper'
+
+describe FileUploadStep do
+  describe '#update_master_files' do
+    let(:masterfile) {FactoryGirl.create(:master_file)}
+    let(:mediaobject) {FactoryGirl.create(:media_object, parts: [masterfile])}
+    let(:step_context) { {mediaobject: mediaobject, parts: {masterfile.pid => {label: 'new label'}}} }
+    it 'should not regenerate a section permalink when the label is changed' do
+      expect(masterfile).to_not receive(:permalink=)
+      expect{FileUploadStep.new.update_master_files(step_context)}.to_not change{masterfile.permalink}
+    end
+  end
+end


### PR DESCRIPTION
Without this fix any update to the label, permalink, or thumbnail/poster offset would reset the others to nil.  If the permalink gets set to nil it will regenerate causing it to get a totally new permalink.
