### PR TITLE
Only check for nil instead of blank

### DIFF
--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -61,16 +61,16 @@ require 'avalon/dropbox'
     deleted_parts = []
     if not files.blank?
       files.each_pair do |pid,part|
-        selected_part = mediaobject.parts.to_a.find{|p| p.pid == pid}
+        selected_part = MasterFile.find(pid)
 
         if selected_part
           if part[:remove]
             deleted_parts << selected_part
             selected_part.destroy
           else
-            selected_part.label = part[:label] unless part[:label].blank?
-            selected_part.permalink = part[:permalink] unless part[:permalink].blank?
-            selected_part.poster_offset = part[:poster_offset] unless part[:poster_offset].blank?
+            selected_part.label = part[:label] unless part[:label].nil?
+            selected_part.permalink = part[:permalink] unless part[:permalink].nil?
+            selected_part.poster_offset = part[:poster_offset] unless part[:poster_offset].nil?
             unless selected_part.save
               context[:error] ||= []
               context[:error] << "#{selected_part.pid}: #{selected_part.errors.to_a.first.gsub(/(\d+)/) { |m| m.to_i.to_hms }}"

--- a/spec/models/file_upload_step_spec.rb
+++ b/spec/models/file_upload_step_spec.rb
@@ -16,12 +16,16 @@ require 'spec_helper'
 
 describe FileUploadStep do
   describe '#update_master_files' do
-    let(:masterfile) {FactoryGirl.create(:master_file)}
-    let(:mediaobject) {FactoryGirl.create(:media_object, parts: [masterfile])}
-    let(:step_context) { {mediaobject: mediaobject, parts: {masterfile.pid => {label: 'new label'}}} }
+    let!(:masterfile) {FactoryGirl.create(:master_file, label: 'foo')}
+    let!(:mediaobject) {FactoryGirl.create(:media_object, parts: [masterfile])}
     it 'should not regenerate a section permalink when the label is changed' do
-      expect(masterfile).to_not receive(:permalink=)
+      step_context = {mediaobject: mediaobject, parts: {masterfile.pid => {label: 'new label'}}}
       expect{FileUploadStep.new.update_master_files(step_context)}.to_not change{masterfile.permalink}
+    end
+    it 'should be able to set a blank label' do
+      step_context = {mediaobject: mediaobject, parts: {masterfile.pid => {label: ''}}}
+      FileUploadStep.new.update_master_files(step_context)
+      expect(masterfile.reload.label).to be_nil
     end
   end
 end


### PR DESCRIPTION
For some reason, the added test failed unless the master file was explicitly retrieved from fedora instead of using the associated reference (https://github.com/avalonmediasystem/avalon/compare/develop...bugfix/VOV-3084?expand=1#diff-3331c1a5d3bf69306eed4f9ec77ab02eL64)
