### PR TITLE
Don't rely on new_user parameter being present

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -78,7 +78,7 @@ class Admin::GroupsController < ApplicationController
   def update
     #TODO: move RoleControls to Group model
     
-   new_user = params["new_user"].strip
+   new_user = params["new_user"]
    new_group_name = params["group_name"]
    
     @group = Admin::Group.find(params["id"])
@@ -106,7 +106,7 @@ class Admin::GroupsController < ApplicationController
         @group.name = new_group_name.blank? ? params["id"] : params["group_name"]
       end
     end
-    @group.users += [new_user] unless new_user.blank?
+    @group.users += [new_user.strip] unless new_user.blank?
     
     if @group.save
       flash[:notice] = "Successfully updated group \"#{@group.name}\""

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -93,7 +93,7 @@ describe Admin::GroupsController do
         login_as('policy_editor')
         new_group_name = Faker::Lorem.word
 
-        put 'update', group_name: new_group_name, new_user: "", id: group.name
+        put 'update', group_name: new_group_name, id: group.name
     
         new_group = Admin::Group.find(new_group_name)
         new_group.should_not be_nil
@@ -104,7 +104,7 @@ describe Admin::GroupsController do
       
       it "should not be able to rename system groups" do
         login_as('administrator')
-        put 'update', group_name: Faker::Lorem.word, new_user: "", id: 'manager'
+        put 'update', group_name: Faker::Lorem.word, id: 'manager'
         
         Admin::Group.find('manager').should_not be_nil
         flash[:error].should_not be_nil


### PR DESCRIPTION
Seen in demo today, saving an adhoc group in order to change its name causes an exception.
