### PR TITLE
Allow courses to be specified by label or title if the ID isn't yet initialized

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,4 +20,14 @@ class Course < ActiveRecord::Base
       { id: course.context_id, display: course.title }
     }
   end
+  
+  def fix_object_rights!
+    remove_groups = [label, title].select(&:present?)
+    criteria = remove_groups.collect { |val| %{read_access_group_ssim:"#{val}"} }.join(' OR ')
+    ActiveFedora::Base.where(criteria).each do |obj|
+      obj.read_groups -= remove_groups
+      obj.read_groups += [context_id] unless obj.read_groups.include?(context_id)
+      obj.save(validate: false)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,10 +47,11 @@ class User < ActiveRecord::Base
     end
     
     class_id = auth_hash.extra.context_id
-    if Course.find_by_context_id(class_id).nil?
-      class_name = auth_hash.extra.context_name
-      Course.create :context_id => class_id, :label => auth_hash.extra.consumer.context_label, :title => class_name unless class_name.nil?
-    end
+    class_label = auth_hash.extra.consumer.context_label
+    class_name = auth_hash.extra.context_name
+    course = Course.find_by_context_id(class_id) ||
+             Course.create(:context_id => class_id, :label => class_label, :title => class_name)
+    course.fix_object_rights!
     result = 
       User.find_by_username(auth_hash.uid) ||
       User.find_by_email(auth_hash.info.email) ||

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -18,5 +18,6 @@ FactoryGirl.define do
   factory :course do
     context_id 'abcdef0123456789'
     label 'Existing Test Course'
+    title 'EX_TST_CRSE'
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,44 @@
+# Copyright 2011-2014, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'spec_helper'
+
+describe Course do
+  let! (:course)        { FactoryGirl.create(:course)       }
+  let! (:media_objects) { [FactoryGirl.create(:media_object),FactoryGirl.create(:media_object)] }
+  
+  context "Pre-existing MediaObjects" do
+    before :each do
+      media_objects[0].read_groups = [course.label]
+      media_objects[1].read_groups = [course.title]
+      media_objects.each(&:save)
+    end
+    
+    it "#fix_object_rights!" do
+      media_objects.each do |mo|
+        mo.reload
+        expect(mo.read_groups).not_to include(course.context_id)
+      end
+      
+      course.fix_object_rights!
+      
+      media_objects.each do |mo|
+        mo.reload
+        expect(mo.read_groups).not_to include(course.label)
+        expect(mo.read_groups).not_to include(course.title)
+        expect(mo.read_groups).to     include(course.context_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
All course Collections and MediaObjects will have label/title replaced by ID the first time the course is launched via LTI.
