### PR TITLE
Raise exception if processing is already underway when calling #process

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -194,15 +194,14 @@ class MasterFile < ActiveFedora::Base
   end
 
   def process
-    args = {    "url" => "file://" + URI.escape(file_location),
-                "title" => pid,
-                "flavor" => "presenter/source",
-                "filename" => File.basename(file_location),
-                'workflow' => self.workflow_name,
-            }
-
-    m = MatterhornJobs.new
-    m.send_request args
+    raise "MasterFile is already being processed" if status_code.present? && !finished_processing?
+    Delayed::Job.enqueue MatterhornIngestJob.new({
+      'url' => "file://" + URI.escape(file_location),
+      'title' => pid,
+      'flavor' => "presenter/source",
+      'filename' => File.basename(file_location),
+      'workflow' => self.workflow_name,
+    })
   end
 
   def status?(value)

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -14,7 +14,6 @@
 
 FactoryGirl.define do
   factory :master_file do
-    status_code {Faker::Lorem.word}
     file_location {'/path/to/video.mp4'}
     percent_complete {"#{rand(100)}"}
     workflow_name 'avalon'
@@ -22,6 +21,7 @@ FactoryGirl.define do
 
     factory :master_file_with_derivative do
       workflow_name 'avalon'
+      status_code 'SUCCEEDED'
       after(:create) do |mf|
         mf.derivatives += [FactoryGirl.create(:derivative)]
         mf.save

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -13,6 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 require 'spec_helper'
+require 'rubyhorn/rest_client/exceptions'
 
 describe MasterFile do
 
@@ -115,6 +116,42 @@ describe MasterFile do
       it 'returns true for failed' do
         master_file.status_code = ['FAILED']
         master_file.finished_processing?.should be true
+      end
+    end
+  end
+
+  describe '#process' do
+    let!(:master_file) { FactoryGirl.create(:master_file) }
+    let(:ingest_job) { MatterhornIngestJob.new({title: master_file.pid}) }
+    before do
+      allow(MatterhornIngestJob).to receive(:new).and_return(ingest_job)
+      allow(ingest_job).to receive(:perform)
+      Delayed::Worker.delay_jobs = false
+    end
+    it 'starts a Matterhorn workflow' do
+      master_file.process
+      expect(ingest_job).to have_received(:perform)
+    end
+    describe 'already processing' do
+      before do
+        master_file.status_code = 'RUNNING'
+      end
+      it 'should not start a Matterhorn workflow' do
+        expect{master_file.process}.to raise_error(RuntimeError)
+        expect(ingest_job).not_to have_received(:perform)
+      end
+    end
+    describe 'failure' do
+      before do
+        Rubyhorn.stub_chain(:client, :addMediaPackageWithUrl).and_raise(Rubyhorn::RestClient::Exceptions::ServerError, "FAILED")
+      Delayed::Worker.delay_jobs = true
+      end
+      it 'should set the status to FAILED when the request to Matterhorn fails' do
+        master_file.process
+        #Have to manually tell delayed_job to do the work because callback doesn't get fired with delay_jobs = false
+        Delayed::Worker.new.work_off
+        master_file.reload
+        expect(master_file.status_code).to eq('FAILED')
       end
     end
   end


### PR DESCRIPTION
Refactored MatterhornJobs to reflect how it is being used and do things in a more delayed_job sort of a way.
