### PR TITLE
Add migration for bookmark polymorphic types

### DIFF
--- a/db/migrate/20140903161907_add_polymorphic_type_to_bookmarks.blacklight.rb
+++ b/db/migrate/20140903161907_add_polymorphic_type_to_bookmarks.blacklight.rb
@@ -1,9 +1,0 @@
-# This migration comes from blacklight (originally 20140320000000)
-# -*- encoding : utf-8 -*-
-class AddPolymorphicTypeToBookmarks < ActiveRecord::Migration
-  def change
-    add_column(:bookmarks, :document_type, :string)
-    
-    add_index :bookmarks, :user_id
-  end
-end


### PR DESCRIPTION
This one is from blacklight and doesn't cause rake spec to error, yet allows tests to pass on travis.
