### PR TITLE
Make sure ActionMailer gets the SMTP settings right.

### DIFF
--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,3 +1,4 @@
 unless Rails.env.test?
-  Avalon::Application.config.action_mailer.smtp_settings = Avalon::Configuration.lookup('email.mailer.smtp')
+  Avalon::Application.config.action_mailer.smtp_settings = Avalon::Configuration.lookup('email.mailer.smtp').symbolize_keys
+  ActionMailer::Base.smtp_settings = Avalon::Application.config.action_mailer.smtp_settings
 end


### PR DESCRIPTION
Somewhere along the way, ActionMailer became trickier to configure from an initializer (as opposed to from an `environments/*.rb` file). This fixes things to work with `avalon.yml`, but we should _probably_ remove mailer configuration from `avalon.yml` and just direct people to configure ActionMailer the normal way. For one thing, this "feature" is extremely limiting in that it won't support any delivery methods other than SMTP. I can't even remember why we did it in the first place.
