### PR TITLE
Improved the "Getting started" documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ For more information and regular project updates visit the [Avalon blog](http://
 Instructions on how to get a local installation of Avalon Media System installed on your system are available for [Linux](https://wiki.dlib.indiana.edu/display/VarVideo/Getting+Started+(Linux)) and [OS X](https://wiki.dlib.indiana.edu/display/VarVideo/Getting+Started+(OS+X)).
 
 # Getting started
+The following steps will let you run the avalon stack locally in order to 
+explore the out-of-the-box functionality or do basic development.
+
+* Ensure that you're running one of the Ruby versions listed in under rvm in ".travis.yml".
 * ```git submodule init```
 * ```git submodule update```
 * Install [Mediainfo cli](http://mediainfo.sourceforge.net)
 * Copy config/avalon.yml.example to config/avalon.yml and [change](https://wiki.dlib.indiana.edu/display/VarVideo/Configuration+Files#ConfigurationFiles-config%2Favalon.yml) as necessary
+* Copy config/authentication.yml.example to config/authentication.yml
+* Copy config/controlled_vocabulary.yml.example to config/controlled_vocabulary.yml
+* ```rake avalon:services:start```
 * ```rake db:migrate```
 * ```rake db:test:prepare```
 * ```rake spec```
-* ```rake avalon:services:start```
 * ```rails s```

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,0 +1,4 @@
+development:
+    secret_key_base: replace this value with one from "rake secret"
+test:
+    secret_key_base: replace this value with one from "rake secret"


### PR DESCRIPTION
Two minor documentation issues made testing changes to the new (3.2) version trickier than it ought to be.

Specifically there's no reminder about what version of Ruby is required and there's no real advice about how to get around to having a valid secrets.yml file.  I think these modest changes to the documentation and example files could help.  It may also be useful to add documenation about secrets.yml to the configuration files page on the wiki.

https://wiki.dlib.indiana.edu/display/VarVideo/Configuration+Files#ConfigurationFiles-config%2Ffedora.yml