### PR TITLE
Only use top-level originInfo element in MODS

### DIFF
--- a/app/models/mods_document.rb
+++ b/app/models/mods_document.rb
@@ -70,7 +70,7 @@ class ModsDocument < ActiveFedora::OmDatastream
     t.genre
 
     # Publishing Info
-    t.origin_info(:path => 'originInfo') do
+    t.origin_info(:path => 'mods/oxns:originInfo') do
       t.publisher
       t.place_info(:path => 'place') do
         t.place_term(:path => 'placeTerm')

--- a/lib/avalon/bib_retriever/sru.rb
+++ b/lib/avalon/bib_retriever/sru.rb
@@ -17,7 +17,7 @@ module Avalon
     class SRU < ::Avalon::BibRetriever
       def initialize config
         super
-        @config['query'] ||= 'rec.id=%s'
+        @config['query'] ||= 'rec.id=%{bib_id}'
       end
       
       def get_record(bib_id)
@@ -28,7 +28,7 @@ module Avalon
       
       def url_for(bib_id)
         uri = URI.parse config['url']
-        query_param = config['query'] % bib_id.to_s
+        query_param = config['query'] % { bib_id: bib_id.to_s }
         uri.query = "version=1.1&operation=searchRetrieve&maximumRecords=1&recordSchema=marcxml&query=#{query_param}"
         uri.to_s
       end


### PR DESCRIPTION
This fixes the form save error that showed up in the demo of bibliographic import on Lancelot.