### PR TITLE
Add quality to session

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -209,6 +209,11 @@ class MediaObjectsController < ApplicationController
     params.merge!({mediaobject: model_object, user: user_key, ability: current_ability})
   end
 
+  def set_session_quality
+    session[:quality] = params[:quality] if params[:quality].present?
+    render nothing: true
+  end
+
   protected
   
   def load_master_files

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -74,7 +74,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           features: <%=features.inspect.html_safe%>,
           audioHeight: 50,
           iOSDisplayedDuration: <%= @masterfile ? @masterfile.duration.to_i / 1000 : -1 %>,
-          startQuality: '<%= Avalon::Configuration.lookup('streaming.default_quality') %>',
+          startQuality: '<%= session['quality'].present? ? session['quality'] : Avalon::Configuration.lookup('streaming.default_quality') %>',
           title: '<%= @masterfile.label %>',
           titleLink: '<%= media_object_url(@masterfile.mediaobject) %>',
           logoAction: 'popup',

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -77,7 +77,6 @@ Unless required by applicable law or agreed to in writing, software distributed
     features << 'thumbnailSelector' if can? :edit, @mediaobject
     features.concat ['fullscreen','responsive']
   %>
-
   <script>
     currentPlayer = new MediaElementPlayer('#video-tag', 
         { mode: 'auto_plugin',
@@ -88,7 +87,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           features: <%=features.inspect.html_safe%>,
           audioHeight: <%= MasterFile::AUDIO_HEIGHT %>,
           mobileDisplayedDuration: <%= @currentStream ? (@currentStream.duration.to_f / 1000).round : -1 %>,
-          startQuality: '<%= Avalon::Configuration.lookup('streaming.default_quality') %>'
+          startQuality: '<%= session['quality'].present? ? session['quality'] : Avalon::Configuration.lookup('streaming.default_quality') %>'
         });
   </script>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Avalon::Application.routes.draw do
       post '/bookmarks/publish', as: :publish_bookmarks
       post '/bookmarks/unpublish', as: :unpublish_bookmarks
 
+  post '/media_objects/set_session_quality'
+
   #Blacklight catalog routes
   blacklight_for :catalog
   #match "catalog/facet/:id", :to => 'catalog#facet', :as => 'catalog_facet', via: [:get]


### PR DESCRIPTION
Requires change to mediaelement-qualityselector gem currently in branch bugfix/VOV-3367.