### PR TITLE
Allow for specifying protocol for generated urls

### DIFF
--- a/config/avalon.yml.example
+++ b/config/avalon.yml.example
@@ -5,6 +5,7 @@ development:
   domain:
     host: localhost
     port: 3000
+    protocol: http
   dropbox:
     path: '/srv/avalon/dropbox/'
     upload_uri: 'sftp://localhost/srv/avalon/dropbox'

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -2,7 +2,7 @@ server_options = Avalon::Configuration.lookup('domain')
 
 if server_options
   server_options.symbolize_keys!
-  server_options.slice!(:host, :port)
+  server_options.slice!(:host, :port, :protocol)
 
   Rails.application.routes.default_url_options.merge!( server_options )
   ActionMailer::Base.default_url_options.merge!( server_options )


### PR DESCRIPTION
This change makes it possible to force all urls avalon generates to use https by setting the protocol in avalon.yml.  This comes up in particular for urls in emails sent from systems not responding to http on port 443.  Delayed job needs to be restarted after changing this property in order for the emails to be fixed.