### PR TITLE
In the absence of a supplied bib_id label...

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -162,8 +162,6 @@ class MediaObject < ActiveFedora::Base
 
   accepts_nested_attributes_for :parts, :allow_destroy => true
 
-  IDENTIFIER_TYPES =  Avalon::ControlledVocabulary.find_by_name(:identifier_types) || {"other" => "Local"}
-
   def published?
     not self.avalon_publisher.blank?
   end
@@ -243,7 +241,7 @@ class MediaObject < ActiveFedora::Base
     missing_attributes.clear
     # Special case the identifiers and their types
     if values[:bibliographic_id]
-      values[:bibliographic_id] = [[Array(values.delete(:bibliographic_id_label)).first || IDENTIFIER_TYPES.keys[0], Array(values[:bibliographic_id]).first]]
+      values[:bibliographic_id] = [[Array(values.delete(:bibliographic_id_label)).first || ModsDocument::IDENTIFIER_TYPES.keys[0], Array(values[:bibliographic_id]).first]]
     end
     if values[:related_item_url] and values[:related_item_label]
         values[:related_item_url] = values[:related_item_url].zip(values.delete(:related_item_label))

--- a/app/models/mods_document.rb
+++ b/app/models/mods_document.rb
@@ -18,7 +18,9 @@ class ModsDocument < ActiveFedora::OmDatastream
   
   include ModsTemplates
   include ModsBehaviors
-
+  
+  IDENTIFIER_TYPES = Avalon::ControlledVocabulary.find_by_name(:identifier_types) || {"other" => "Local"}
+  
   set_terminology do |t|
     t.root(:path=>'mods',
       :xmlns => 'http://www.loc.gov/mods/v3', 
@@ -201,8 +203,9 @@ class ModsDocument < ActiveFedora::OmDatastream
     EOC
   end
   
-  def populate_from_catalog! bib_id, bib_id_label = 'local'
+  def populate_from_catalog! bib_id, bib_id_label = nil
     if bib_id.present?
+      bib_id_label ||= IDENTIFIER_TYPES.keys.first
       new_record = Avalon::BibRetriever.instance.get_record(bib_id)
       if new_record.present?
         self.ng_xml = Nokogiri::XML(new_record)

--- a/app/views/media_objects/_resource_description.html.erb
+++ b/app/views/media_objects/_resource_description.html.erb
@@ -22,7 +22,7 @@ Unless required by applicable law or agreed to in writing, software distributed
              locals: {form: form, field: :bibliographic_id,
                       options: {display_label: 'Bibliographic ID',
                                 dropdown_field: :bibliographic_id_label, 
-                                dropdown_options: MediaObject::IDENTIFIER_TYPES,
+                                dropdown_options: ModsDocument::IDENTIFIER_TYPES,
                                 extra_classes: Avalon::BibRetriever.configured? ? 'import-button' : nil}} %>
 
   <%= render partial: 'text_field', 


### PR DESCRIPTION
...use the first configured option in the controlled vocabulary.