### PR TITLE
Fix for VOV-3446

### DIFF
--- a/app/assets/stylesheets/avalon.css.scss
+++ b/app/assets/stylesheets/avalon.css.scss
@@ -577,6 +577,15 @@ a[data-trigger='submit'] {
   @media (min-width: 600px) and (max-width: $screen-sm-min){
     max-width: 550px;
   }
+  .selected {
+    display: block;
+    width: 80%;
+    float: left;
+  }
+  .remove {
+    width: 20%;
+    float: right;
+  }
 }
 //left panel on large screens should be extra small, not so for extended facet list
 .panel-body .facet-values .facet-label {


### PR DESCRIPTION
Update CSS for selected facet labels: float the label left and the
remove button to the right, so the remove button stays aligned
correctly.