### PR TITLE
Prevent an ad hoc group name with bad punctuation

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -67,6 +67,7 @@ class Admin::GroupsController < ApplicationController
     if @group.save
       redirect_to edit_admin_group_path(@group)
     else
+      flash[ :error ] = @group.errors
       redirect_to admin_groups_path
     end 
   end

--- a/app/models/admin/group.rb
+++ b/app/models/admin/group.rb
@@ -24,7 +24,10 @@ class Group
   # For now this list is a hardcoded constant. Eventually it might be more flexible
   # as more thought is put into the process of providing a comment
   attr_accessor :name, :users
-  validates :name, :presence => true 
+  validates :name, :presence => true
+  validates :name, format: {
+    without: /[\.;%\/]/,
+    message: "must not contain any of the following: . ; % /" }
 
   def self.non_system_groups
     groups = all

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -15,7 +15,15 @@
 require 'spec_helper'
 
 describe Admin::Group do
-  it {should validate_presence_of(:name)}
+
+  describe "name" do
+    it { should validate_presence_of( :name )}
+    it { should_not allow_value( 'group.01' ).for( :name )}
+    it { should_not allow_value( 'group;01' ).for( :name )}
+    it { should_not allow_value( 'group%01' ).for( :name )}
+    it { should_not allow_value( 'group/01' ).for( :name )}
+  end
+
   describe "non system groups" do
     it "should not have system groups" do
       groups = Admin::Group.non_system_groups


### PR DESCRIPTION
Add validations to prevent ad hoc group names from containing a period,
percent symbol, semicolon or forward slash and flash an alert to the
user.