### PR TITLE
Further refine seek playback

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -63,8 +63,7 @@ class MasterFilesController < ApplicationController
       media_object = MediaObject.find(@masterfile.mediaobject_id)
       authorize! :edit, media_object, message: "You do not have sufficient privileges to add files"
 
-      file = params[:Filedata]
-      @masterfile.structuralMetadata.content = File.open(File.realpath(file.path))
+      @masterfile.structuralMetadata.content =  params[:Filedata].open
       unless @masterfile.save
         flash[:error] = "There was a problem storing the file"
       end

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -98,7 +98,7 @@ module MediaObjectsHelper
      end
 
      def hide_sections? sections
-       sections.blank? or (sections.length == 1 && sections.first.get_structural_metadata.nil?)
+       sections.blank? or (sections.length == 1 && sections.first.structuralMetadata.toXML.nil?)
      end
 
      def structure_html section, index, show_progress
@@ -116,7 +116,7 @@ EOF
 EOF
        progress_div = show_progress ? '<div class="status-detail alert progress-indented" style="display: none"></div>' : ''
 
-       sm = section.get_structural_metadata
+       sm = section.structuralMetadata.toXML
 
        # If there is no structural metadata associated with this masterfile return the stream info
        if sm.nil?

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -98,7 +98,7 @@ module MediaObjectsHelper
      end
 
      def hide_sections? sections
-       sections.blank? or (sections.length == 1 && sections.first.structuralMetadata.toXML.nil?)
+       sections.blank? or (sections.length == 1 && sections.first.structuralMetadata.to_xml.nil?)
      end
 
      def structure_html section, index, show_progress
@@ -116,7 +116,7 @@ EOF
 EOF
        progress_div = show_progress ? '<div class="status-detail alert progress-indented" style="display: none"></div>' : ''
 
-       sm = section.structuralMetadata.toXML
+       sm = section.structuralMetadata.to_xml
 
        # If there is no structural metadata associated with this masterfile return the stream info
        if sm.nil?

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -27,7 +27,7 @@ class MasterFile < ActiveFedora::Base
   include Permalink
   include VersionableModel
 
-  has_metadata name: "structuralMetadata", :type => ActiveFedora::Datastream
+  has_metadata name: "structuralMetadata", :type => StructuralMetadata, :mimeType => "text/xml"
   
   WORKFLOWS = ['fullaudio', 'avalon', 'avalon-skip-transcoding', 'avalon-skip-transcoding-audio']
 
@@ -162,16 +162,6 @@ class MasterFile < ActiveFedora::Base
       self.mediaobject.parts_with_order += [self]
       self.mediaobject.parts += [self]
     end
-  end
-
-  def set_structural_metadata path
-    self.structuralMetadata.content = File.open(path)
-    self.structuralMetadata.mimeType = "text/xml"
-  end
-
-  def get_structural_metadata
-    sm = Nokogiri::XML(self.structuralMetadata.content) { |config| config.noblanks }
-    sm.xpath('//Item').empty? ? nil : sm
   end
 
   def delete 

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -14,7 +14,7 @@
 
 class StructuralMetadata < ActiveFedora::Datastream
 
-  def toXML
+  def to_xml
     sm = Nokogiri::XML(self.content) { |config| config.noblanks }
     sm.xpath('//Item').empty? ? nil : sm
   end

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -1,0 +1,22 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class StructuralMetadata < ActiveFedora::Datastream
+
+  def toXML
+    sm = Nokogiri::XML(self.content) { |config| config.noblanks }
+    sm.xpath('//Item').empty? ? nil : sm
+  end
+
+end

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -80,25 +80,21 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if @currentStream.present? and @currentStream.derivatives.present? %>
   <script>
     var updating_segment = false;
-    var offset = <%= f_start %>;
-    var set_offset = function(event){
-      currentOffset = currentPlayer.getCurrentTime();
-      if (currentOffset != offset) {
-        currentPlayer.setCurrentTime(offset);
-      }
-    }
+    var iwaspaused = true;
+
     var update_active_stream = function(event){
       if (!updating_segment) {
         updating_segment = true;
         active_segment = $('a.current-stream').data('segment')
-        AvalonStreams.setActiveSection(active_segment);
+        if (typeof(active_segment) != 'undefined') AvalonStreams.setActiveSection(active_segment);
         updating_segment = false;
       }
     }
     seeked_handler = function(event){
-      currentPlayer.pause();
+      if (iwaspaused) currentPlayer.pause();
     }
     seeking_handler = function(event){
+      iwaspaused = currentPlayer.media.paused;
       currentPlayer.play();
     }
     currentPlayer = new MediaElementPlayer('#video-tag', 
@@ -112,7 +108,10 @@ Unless required by applicable law or agreed to in writing, software distributed
           mobileDisplayedDuration: <%= @currentStream ? (@currentStream.duration.to_f / 1000).round : -1 %>,
           startQuality: '<%= current_quality(@currentStreamInfo) %>',
           success: function (mediaElement, domObject, player) {
-            mediaElement.addEventListener('loadedmetadata', set_offset, true);
+            mediaElement.addEventListener('loadedmetadata', function loadedmetadata () {
+              currentPlayer.setCurrentTime(<%= f_start %>);
+              currentPlayer.media.removeEventListener('loadedmetadata', loadedmetadata);
+            }, true);
             mediaElement.addEventListener('timeupdate', update_active_stream, true ); 
             mediaElement.addEventListener('seeked', seeked_handler, true);
             mediaElement.addEventListener('seeking', seeking_handler, true);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Avalon::Application.routes.draw do
       post 'poster',    :to => 'master_files#set_frame', :defaults => { :type => 'poster', :format => 'html' }
       post 'still',     :to => 'master_files#set_frame', :defaults => { :format => 'html' }
       get :embed
+      post 'attach_structure', :to => 'master_files#attach_structure'
     end
   end
 

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -265,7 +265,7 @@ describe MasterFilesController do
       @file = fixture_file_upload('/structure.xml', 'text/xml')
       post 'attach_structure', Filedata: @file, id: master_file.id
       master_file.reload
-      master_file.structuralMetadata.toXML.xpath('//Item').length.should == 1
+      master_file.structuralMetadata.to_xml.xpath('//Item').length.should == 1
       flash[:errors].should be_nil        
       flash[:notice].should be_nil        
     end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -251,5 +251,25 @@ describe MasterFilesController do
       end
     end
   end
+
+  describe "#attach_structure" do
+    let!(:media_object) {FactoryGirl.create(:media_object_with_master_file)}
+    let!(:content_provider) {login_user media_object.collection.managers.first}
+    let!(:master_file) {media_object.parts.first}
+
+    before(:each) do
+      login_user media_object.collection.managers.first
+    end
+    
+    it "should populate structuralMetadata datastream with xml" do
+      @file = fixture_file_upload('/structure.xml', 'text/xml')
+      post 'attach_structure', Filedata: @file, id: master_file.id
+      master_file.reload
+      master_file.structuralMetadata.toXML.xpath('//Item').length.should == 1
+      flash[:errors].should be_nil        
+      flash[:notice].should be_nil        
+    end
+
+  end
   
 end

--- a/spec/fixtures/structure.xml
+++ b/spec/fixtures/structure.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Music for Piano; http://server1.variations2.indiana.edu/variations/cgi-bin/access.pl?id=BFJ6801 -->
+<Item label="CD 1">
+    <Div label="Copland, Three Piano Excerpts from Our Town">
+        <Span label="Track 1. Story of Our Town" begin="0" end="0:09.99"/>
+        <Span label="Track 2. Conversation at the Soda Fountain" begin="0:10" end="0:19.99"/>
+        <Span label="Track 3. The Resting Place on the Hill" begin="0:20" end="0:29.99"/>
+    </Div>
+    <Div label="Copland, Four Episodes from Rodeo">
+        <Span label="Track 4. Buckaroo Holiday" begin="0:30" end="0:39.99"/>
+        <Span label="Track 5. Corral Nocturne" begin="0:40" end="0:49.99"/>
+        <Span label="Track 6. Saturday Night Waltz" begin="0:50" end="0:59.99"/>
+        <Span label="Track 7. Hoe-Down" begin="1:00" end="1:09.99"/>
+    </Div>
+    <Span label="Track 8. Copland, Piano Variations " begin="1:10" end="1:19.99"/>
+    <Div label="Copland, Four Piano Blues">
+        <Span label="Track 9. For Leo Smit: Freely poetic" begin="1:20" end="1:29.99"/>
+        <Span label="Track 10. For Andor Foldes: Soft and languid" begin="1:30" end="1:39.99"/>
+        <Span label="Track 11. For Willian Kapell: Muted and sensuous" begin="1:40" end="1:49.99"/>
+        <Span label="Track 12. For John Kirkpatrick: WIth bounce" begin="1:50" end="1:59.99"/>
+    </Div>
+    <Span label="Track 13. Copland, Danzon Cubano" begin="2:00" end="2:30"/>
+</Item>


### PR DESCRIPTION
To avoid event listener conflicts and avoid reliance on global variables for jumping to offsets, use listeners that remove themselves after running.