### PR TITLE
Add feedback when invalid structure file is uploaded

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -94,7 +94,14 @@ class MasterFilesController < ApplicationController
     media_object = MediaObject.find(@masterfile.mediaobject_id)
     authorize! :edit, media_object, message: "You do not have sufficient privileges to add files"
     if params[:master_file].present? && params[:master_file][:structure].present?
+      unless StructuralMetadata.content_valid? params[:master_file][:structure].open
+        flash[:error] = "File was not valid XML or did not contain required elements."
+        redirect_to :back
+        return
+      end
       @masterfile.structuralMetadata.content = params[:master_file][:structure].open
+      @masterfile.structuralMetadata.mimeType = "text/xml"
+      @masterfile.structuralMetadata.save
     else
       @masterfile.structuralMetadata.delete
     end

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -14,9 +14,21 @@
 
 class StructuralMetadata < ActiveFedora::Datastream
 
+  def parse_xml
+    Nokogiri::XML(self.content) { |config| config.noblanks }
+  end
+
   def to_xml
-    sm = Nokogiri::XML(self.content) { |config| config.noblanks }
-    sm.xpath('//Item').empty? ? nil : sm
+    self.valid? ? self.parse_xml : nil
+  end
+
+  def valid?
+    self.class.content_valid? self.content
+  end
+
+  def self.content_valid? content
+    sm = Nokogiri::XML(content) { |config| config.noblanks }
+    sm.xpath('//Item').present?
   end
 
 end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -267,6 +267,7 @@ describe MasterFilesController do
     
     it "should populate structuralMetadata datastream with xml" do
       expect(master_file.structuralMetadata.to_xml.xpath('//Item').length).to be(1)
+      expect(master_file.structuralMetadata.valid?).to be true
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil
     end
@@ -275,10 +276,10 @@ describe MasterFilesController do
       post 'attach_structure', id: master_file.id
       master_file.reload
       expect(master_file.structuralMetadata.to_xml).to be_nil
+      expect(master_file.structuralMetadata.valid?).to be false
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil
     end
-
   end
   
 end


### PR DESCRIPTION
The @masterfile.structuralMetadata.save in line 104 is what fixed it.