### PR TITLE
Add a URL handler for Wowza

### DIFF
--- a/app/models/url_handler/wowza.rb
+++ b/app/models/url_handler/wowza.rb
@@ -1,0 +1,32 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module UrlHandler
+  class Wowza
+
+    def self.patterns
+      {
+        'rtmp' => {
+          'video' => "<%=prefix%>:<%=media_id%>/<%=stream_id%>/<%=filename%>",
+          'audio' => "<%=prefix%>:<%=media_id%>/<%=stream_id%>/<%=filename%>",
+        },
+        'http' => {
+          'video' => "<%=prefix%>:<%=media_id%>/<%=stream_id%>/<%=filename%>.<%=extension%>/playlist.m3u8",
+          'audio' => "<%=prefix%>:<%=media_id%>/<%=stream_id%>/<%=filename%>.<%=extension%>/playlist.m3u8",
+        }
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
All the other Wowza support gets handled in Matterhorn's `config.properties` and through Wowza's own configuration.