### PR TITLE
Bugfix/vov 3604 chris

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -94,7 +94,14 @@ class MasterFilesController < ApplicationController
     media_object = MediaObject.find(@masterfile.mediaobject_id)
     authorize! :edit, media_object, message: "You do not have sufficient privileges to add files"
     if params[:master_file].present? && params[:master_file][:structure].present?
+      unless StructuralMetadata.content_valid? params[:master_file][:structure].open
+        flash[:error] = "File was not valid XML or did not contain required elements."
+        redirect_to :back
+        return
+      end
       @masterfile.structuralMetadata.content = params[:master_file][:structure].open
+      @masterfile.structuralMetadata.mimeType = "text/xml"
+      @masterfile.structuralMetadata.save
     else
       @masterfile.structuralMetadata.delete
     end

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -100,8 +100,6 @@ class MasterFilesController < ApplicationController
         return
       end
       @masterfile.structuralMetadata.content = params[:master_file][:structure].open
-      @masterfile.structuralMetadata.mimeType = "text/xml"
-      @masterfile.structuralMetadata.save
     else
       @masterfile.structuralMetadata.delete
     end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -27,7 +27,7 @@ class MasterFile < ActiveFedora::Base
   include Permalink
   include VersionableModel
 
-  has_metadata name: "structuralMetadata", :type => StructuralMetadata, :mimeType => "text/xml"
+  has_metadata name: "structuralMetadata", :type => StructuralMetadata
   
   WORKFLOWS = ['fullaudio', 'avalon', 'avalon-skip-transcoding', 'avalon-skip-transcoding-audio']
 

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -13,22 +13,20 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class StructuralMetadata < ActiveFedora::Datastream
+  include ActiveFedora::Datastreams::NokogiriDatastreams
 
-  def parse_xml
-    Nokogiri::XML(self.content) { |config| config.noblanks }
+  def mimeType
+    'text/xml'
   end
 
-  def to_xml
-    self.valid? ? self.parse_xml : nil
+  delegate :xpath, to: :ng_xml
+
+  def self.content_valid? content
+    Nokogiri::XML(content).xpath('//Item').present?
   end
 
   def valid?
-    self.class.content_valid? self.content
-  end
-
-  def self.content_valid? content
-    sm = Nokogiri::XML(content) { |config| config.noblanks }
-    sm.xpath('//Item').present?
+    xpath('//Item').present?
   end
 
 end

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -14,9 +14,21 @@
 
 class StructuralMetadata < ActiveFedora::Datastream
 
+  def parse_xml
+    Nokogiri::XML(self.content) { |config| config.noblanks }
+  end
+
   def to_xml
-    sm = Nokogiri::XML(self.content) { |config| config.noblanks }
-    sm.xpath('//Item').empty? ? nil : sm
+    self.valid? ? self.parse_xml : nil
+  end
+
+  def valid?
+    self.class.content_valid? self.content
+  end
+
+  def self.content_valid? content
+    sm = Nokogiri::XML(content) { |config| config.noblanks }
+    sm.xpath('//Item').present?
   end
 
 end

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -57,9 +57,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 	    <% end %>
           </div>
           <br class="clear"/>
-          <% sm = section.structuralMetadata.to_xml %>
-          <% if sm.present? %>
-          <%   sectionnode = sm.xpath('//Item') %>
+          <% if section.structuralMetadata.present? %>
+          <%   sectionnode = section.structuralMetadata.xpath('//Item') %>
           <%   if sectionnode.children.present? %>
           <%     sectionlabel = sectionnode.attribute('label').value %> 
           <%     contents, tracknumber = parse_section section, sectionnode.first, index, "" %>

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -267,6 +267,7 @@ describe MasterFilesController do
     
     it "should populate structuralMetadata datastream with xml" do
       expect(master_file.structuralMetadata.to_xml.xpath('//Item').length).to be(1)
+      expect(master_file.structuralMetadata.valid?).to be true
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil
     end
@@ -275,10 +276,10 @@ describe MasterFilesController do
       post 'attach_structure', id: master_file.id
       master_file.reload
       expect(master_file.structuralMetadata.to_xml).to be_nil
+      expect(master_file.structuralMetadata.valid?).to be false
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil
     end
-
   end
   
 end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -266,7 +266,7 @@ describe MasterFilesController do
     end
     
     it "should populate structuralMetadata datastream with xml" do
-      expect(master_file.structuralMetadata.to_xml.xpath('//Item').length).to be(1)
+      expect(master_file.structuralMetadata.xpath('//Item').length).to be(1)
       expect(master_file.structuralMetadata.valid?).to be true
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil
@@ -275,7 +275,8 @@ describe MasterFilesController do
       # remove the contents of the datastream
       post 'attach_structure', id: master_file.id
       master_file.reload
-      expect(master_file.structuralMetadata.to_xml).to be_nil
+      expect(master_file.structuralMetadata.new?).to be true
+      expect(master_file.structuralMetadata.empty?).to be true
       expect(master_file.structuralMetadata.valid?).to be false
       expect(flash[:errors]).to be_nil
       expect(flash[:notice]).to be_nil


### PR DESCRIPTION
Use AF::NokogiriDatastream to handle change tracking and provide easier access to xpath by delegating it to ng_xml.