### PR TITLE
Use ActiveEncode to create encoding jobs [VOV-3407]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,8 @@
   #gem 'devise-guests'
   gem 'haml'
 
-  gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git", tag: 'v3.2'
+  gem 'active-encode', git: "https://github.com/projecthydra-labs/active-encode.git"
+  gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
   gem 'validates_email_format_of'
   gem 'loofah'
   gem 'omniauth-identity'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,8 +121,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/rubyhorn.git
-  revision: a1c32d1f788b9d93b28f4eeb7cfc9b30f1935a81
-  tag: v3.2
+  revision: acc4424c0c3de19e465b6635988c85b98f649c2a
   specs:
     rubyhorn (0.0.6)
       activesupport
@@ -132,6 +131,13 @@ GIT
       net-http-digest_auth
       om
       rest-client
+
+GIT
+  remote: https://github.com/projecthydra-labs/active-encode.git
+  revision: d839b50471e72fc0d70ca4aece1ea5816f22b2ff
+  specs:
+    active-encode (0.0.1)
+      activesupport
 
 GIT
   remote: https://github.com/projecthydra/hydra-head.git
@@ -698,7 +704,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (0.3.43)
+    tzinfo (0.3.44)
     uber (0.0.13)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
@@ -725,6 +731,7 @@ PLATFORMS
 
 DEPENDENCIES
   about_page!
+  active-encode!
   activerecord-jdbcsqlite3-adapter
   activerecord-session_store
   avalon-about!

--- a/app/controllers/derivatives_controller.rb
+++ b/app/controllers/derivatives_controller.rb
@@ -29,8 +29,8 @@ class DerivativesController < ApplicationController
       resp = { :authorized => StreamToken.validate_token(params[:token]) }
       
       respond_to do |format|
-        format.urlencoded { render :text => resp.to_query, :content_type => :urlencoded, :status => :accepted }
-        format.text       { render :text => resp[:authorized], :status => :accepted }
+        format.urlencoded { resp[:authorized] = resp[:authorized].join(';'); render :text => resp.to_query, :content_type => :urlencoded, :status => :accepted }
+        format.text       { render :text => resp[:authorized].join("\n"), :status => :accepted }
         format.xml        { render :xml  => resp, :root => :response, :status => :accepted }
         format.json       { render :json => resp, :status => :accepted }
       end

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -36,7 +36,7 @@ class MasterFilesController < ApplicationController
   def embed
     @masterfile = MasterFile.find(params[:id])
     if can? :read, @masterfile.mediaobject
-      @token = @masterfile.nil? ? "" : StreamToken.find_or_create_session_token(session, @masterfile.mediapackage_id)
+      @token = @masterfile.nil? ? "" : StreamToken.find_or_create_session_token(session, @masterfile.pid)
       @stream_info = @masterfile.stream_details(@token, default_url_options[:host])
     end
     respond_to do |format|
@@ -192,46 +192,6 @@ class MasterFilesController < ApplicationController
     	format.html { redirect_to edit_media_object_path(params[:container_id], step: 'file-upload') }
     	format.js { }
     end
-  end
-
-  def update
-    master_file = MasterFile.find(params[:id])
-
-    if params[:workflow_id].present?
-      master_file.workflow_id ||= params[:workflow_id]
-      workflow = begin
-        Rubyhorn.client.instance_xml(params[:workflow_id])
-      rescue Rubyhorn::RestClient::Exceptions::HTTPNotFound
-        nil
-      end
-      if workflow
-        master_file.update_progress!(params, workflow)
-      else
-        master_file.status_code = 'STOPPED'
-        master_file.save
-      end
-
-      # If Matterhorn reports that the processing is complete then we need
-      # to prepare Fedora by pulling several important values closer to the
-      # interface. This will speed up searching, allow for on-the-fly quality
-      # switching, and avoids hitting Matterhorn repeatedly when loading up
-      # a list of search results
-      if master_file.status_code.eql? 'SUCCEEDED'
-        master_file.update_progress_on_success!(workflow)
-      end
-
-      # We handle the case where the item was batch ingested. If so the
-      # update method needs to kick off an email letting the uploader know it is
-      # ready to be previewed
-      ingest_batch = IngestBatch.find_ingest_batch_by_media_object_id( master_file.mediaobject.id )
-      if ingest_batch && ! ingest_batch.email_sent? && ingest_batch.finished?
-        IngestBatchMailer.status_email(ingest_batch.id).deliver
-        ingest_batch.email_sent = true
-        ingest_batch.save!
-      end
-    end
-
-    render nothing: true
   end
 
   # When destroying a file asset be sure to stop it first

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -53,7 +53,7 @@ class MediaObjectsController < ApplicationController
 
     if 'preview' == @active_step 
       @currentStream = params[:content] ? set_active_file(params[:content]) : @masterFiles.first
-      @token = @currentStream.nil? ? "" : StreamToken.find_or_create_session_token(session, @currentStream.mediapackage_id)
+      @token = @currentStream.nil? ? "" : StreamToken.find_or_create_session_token(session, @currentStream.pid)
       @currentStreamInfo = @currentStream.nil? ? {} : @currentStream.stream_details(@token, default_url_options[:host])
 
       if (not @masterFiles.empty? and @currentStream.blank?)
@@ -232,7 +232,7 @@ class MediaObjectsController < ApplicationController
       
     @masterFiles = load_master_files
     @currentStream = params[:content] ? set_active_file(params[:content]) : @masterFiles.first
-    @token = @currentStream.nil? ? "" : StreamToken.find_or_create_session_token(session, @currentStream.mediapackage_id)
+    @token = @currentStream.nil? ? "" : StreamToken.find_or_create_session_token(session, @currentStream.pid)
     # This rescue statement seems a bit dodgy because it catches *all*
     # exceptions. It might be worth refactoring when there are some extra
     # cycles available.

--- a/app/models/active_encode_job.rb
+++ b/app/models/active_encode_job.rb
@@ -1,0 +1,34 @@
+module ActiveEncodeJob
+  module Core
+    def error(job, exception)
+      master_file = MasterFile.find(job.payload_object.master_file_id)
+      # add message here to update master file
+      master_file.status_code = 'FAILED'
+      master_file.error = exception.message
+      master_file.save
+    end
+  end
+
+  class Create < Struct.new(:master_file_id, :encode)
+    include ActiveEncodeJob::Core
+    def perform
+      unless encode.created?
+        Delayed::Worker.logger.info "Creating! #{encode.inspect} for MasterFile #{master_file_id}"
+        MasterFile.find(master_file_id).update_progress_with_encode!(encode.create!).save
+        Delayed::Job.enqueue(ActiveEncodeJob::Update.new(master_file_id), run_at: 10.seconds.from_now)
+      end
+    end
+  end
+
+  class Update < Struct.new(:master_file_id)
+    include ActiveEncodeJob::Core  #I'm not sure if the error callback is really makes sense here!
+    def perform
+      Delayed::Worker.logger.info "Updating encode progress for MasterFile: #{master_file_id}"
+      mf = MasterFile.find(master_file_id)
+      mf.update_progress!
+      mf.save
+      mf.reload
+      Delayed::Job.enqueue(ActiveEncodeJob::Update.new(master_file_id), run_at: 10.seconds.from_now) unless mf.finished_processing?
+    end
+  end
+end

--- a/config/initializers/active_encode.rb
+++ b/config/initializers/active_encode.rb
@@ -1,0 +1,1 @@
+ActiveEncode::Base.engine_adapter = :matterhorn

--- a/config/initializers/delayed_job_worker.rb
+++ b/config/initializers/delayed_job_worker.rb
@@ -1,1 +1,2 @@
-Delayed::Worker.destroy_failed_jobs = false  
+Delayed::Worker.destroy_failed_jobs = false 
+Delayed::Worker.logger = Logger.new(Rails.root.join('log', 'delayed_job.log'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Avalon::Application.routes.draw do
     match '/users/sign_out', :to => "users/sessions#destroy", :as => :destroy_user_session, via: [:get]
   end
   match "/authorize", to: 'derivatives#authorize', via: [:get, :post]
+  match "/authorize/:path", to: 'derivatives#authorize', via: [:get, :post]
   match "/autocomplete", to: 'object#autocomplete', via: [:get]
   match "/oembed", to: 'master_files#oembed', via: [:get]
 
@@ -49,7 +50,7 @@ Avalon::Application.routes.draw do
       put :reassign_collection
     end
   end
-  resources :master_files, except: [:new, :index] do
+  resources :master_files, except: [:new, :index, :update] do
     member do
       get  'thumbnail', :to => 'master_files#get_frame', :defaults => { :type => 'thumbnail' }
       get  'poster',    :to => 'master_files#get_frame', :defaults => { :type => 'poster' }

--- a/db/migrate/20150601145809_active_encode_success.rb
+++ b/db/migrate/20150601145809_active_encode_success.rb
@@ -1,0 +1,16 @@
+class ActiveEncodeSuccess < ActiveRecord::Migration
+  def status_code(opts={})
+    MasterFile.where(status_code_tesim: opts[:from]).each do |mf|
+      mf.status_code = opts[:to]
+      mf.save(validate: false)
+    end
+  end
+  
+  def up
+    status_code from: 'SUCCEEDED', to: 'COMPLETED'
+  end
+  
+  def down
+    status_code from: 'COMPLETED', to: 'SUCCEEDED'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140903161907) do
+ActiveRecord::Schema.define(version: 20150601145809) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",       null: false

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
     depositors {[FactoryGirl.create(:user).username]}
     media_objects {[]}
 
-    ignore { items 0 }
+    transient { items 0 }
     after(:create) do |c, env|
       1.upto(env.items) { FactoryGirl.create(:media_object, collection: c) }
     end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 require 'spec_helper'
-require 'rubyhorn/rest_client/exceptions'
+#require 'rubyhorn/rest_client/exceptions'
 
 describe MasterFile do
 
@@ -34,73 +34,64 @@ describe MasterFile do
     }
 
     it "should know where its (local) masterfile is" do
-      subject.file_location.should == '/foo/bar/baz/quux.mp4'
-      subject.absolute_location.should == 'file:///foo/bar/baz/quux.mp4'
+      expect(subject.file_location).to eq '/foo/bar/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'file:///foo/bar/baz/quux.mp4'
     end
 
     it "should know where its (Samba remote) masterfile is" do
       Avalon::FileResolver.any_instance.stub(:mounts) { 
         ["//user@some.server.at.an.example.edu/stuff on /foo/bar (smbfs, nodev, nosuid, mounted by user)"]
       }
-
-      subject.absolute_location.should == 'smb://some.server.at.an.example.edu/stuff/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'smb://some.server.at.an.example.edu/stuff/baz/quux.mp4'
     end
 
     it "should know where its (CIFS remote) masterfile is" do
       Avalon::FileResolver.any_instance.stub(:mounts) { 
         ["//user@some.server.at.an.example.edu/stuff on /foo/bar (cifs, nodev, nosuid, mounted by user)"]
       }
-
-      subject.absolute_location.should == 'cifs://some.server.at.an.example.edu/stuff/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'cifs://some.server.at.an.example.edu/stuff/baz/quux.mp4'
     end
 
     it "should know where its (NFS remote) masterfile is" do
       Avalon::FileResolver.any_instance.stub(:mounts) { 
         ["some.server.at.an.example.edu:/stuff on /foo/bar (nfs, nodev, nosuid, mounted by user)"]
       }
-
-      subject.absolute_location.should == 'nfs://some.server.at.an.example.edu/stuff/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'nfs://some.server.at.an.example.edu/stuff/baz/quux.mp4'
     end
 
     it "should follow the file to a new location" do
-      subject.absolute_location.should == 'file:///foo/bar/baz/quux.mp4'
       subject.file_location = "/tmp/baz/quux.mp4"
-      subject.absolute_location.should == 'file:///tmp/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'file:///tmp/baz/quux.mp4'
     end
 
     it "should accept configurable overrides" do
       Avalon::FileResolver.any_instance.stub(:overrides) {
         { '/foo/bar/' => 'http://repository.example.edu/foothings/' }
       }
-      subject.absolute_location.should == 'http://repository.example.edu/foothings/baz/quux.mp4'
+      expect(subject.absolute_location).to eq 'http://repository.example.edu/foothings/baz/quux.mp4'
     end
 
     it "should accept an empty file location" do
       subject.file_location = ""
-      subject.absolute_location.should be_empty
+      expect(subject.absolute_location).to be_empty
     end
 
     it "should accept a nil file location" do
       subject.file_location = nil
-      subject.absolute_location.should be_nil
+      expect(subject.absolute_location).to be_nil
     end
   end
 
   describe "masterfiles=" do
+    let(:derivative) {Derivative.create}
+    let(:master_file) {FactoryGirl.create(:master_file)}
     it "should set hasDerivation relationships on self" do
-      derivative = Derivative.new
-      mf = FactoryGirl.build(:master_file)
-      mf.save
-      derivative.save
+      master_file.relationships(:is_derivation_of).size.should == 0
 
-      mf.relationships(:is_derivation_of).size.should == 0
-
-      mf.derivatives += [derivative]
+      master_file.derivatives += [derivative]
 
       derivative.relationships(:is_derivation_of).size.should == 1
-      derivative.relationships(:is_derivation_of).first.should == mf.internal_uri
-
-      #derivative.relationships_are_dirty.should be true
+      derivative.relationships(:is_derivation_of).first.should == master_file.internal_uri
     end
   end
 
@@ -108,11 +99,11 @@ describe MasterFile do
     describe 'classifying statuses' do
       let(:master_file){ MasterFile.new }
       it 'returns true for stopped' do
-        master_file.status_code = 'STOPPED'
+        master_file.status_code = 'CANCELLED'
         master_file.finished_processing?.should be true
       end
       it 'returns true for succeeded' do
-        master_file.status_code = 'SUCCEEDED'
+        master_file.status_code = 'COMPLETED'
         master_file.finished_processing?.should be true
       end
       it 'returns true for failed' do
@@ -124,37 +115,37 @@ describe MasterFile do
 
   describe '#process' do
     let!(:master_file) { FactoryGirl.create(:master_file) }
-    let(:ingest_job) { MatterhornIngestJob.new({title: master_file.pid}) }
+    let(:encode_job) { ActiveEncodeJob::Create.new(master_file.pid, ActiveEncode::Base.new(nil)) }
     before do
-      allow(MatterhornIngestJob).to receive(:new).and_return(ingest_job)
-      allow(ingest_job).to receive(:perform)
+      allow(ActiveEncodeJob::Create).to receive(:new).and_return(encode_job)
+      allow(encode_job).to receive(:perform)
       Delayed::Worker.delay_jobs = false
     end
     after do
       Delayed::Worker.delay_jobs = true
     end
-    it 'starts a Matterhorn workflow' do
+    it 'starts an ActiveEncode workflow' do
       master_file.process
-      expect(ingest_job).to have_received(:perform)
+      expect(encode_job).to have_received(:perform)
     end
     describe 'already processing' do
       before do
         master_file.status_code = 'RUNNING'
       end
-      it 'should not start a Matterhorn workflow' do
+      it 'should not start an ActiveEncode workflow' do
         expect{master_file.process}.to raise_error(RuntimeError)
-        expect(ingest_job).not_to have_received(:perform)
+        expect(encode_job).not_to have_received(:perform)
       end
     end
     describe 'failure' do
       before do
-        Rubyhorn.stub_chain(:client, :addMediaPackageWithUrl).and_raise(Rubyhorn::RestClient::Exceptions::ServerError, "FAILED")
+        allow(encode_job.encode).to receive(:create!).and_raise(Exception)
         Delayed::Worker.delay_jobs = true
       end
       after do
         Delayed::Worker.delay_jobs = false
       end
-      it 'should set the status to FAILED when the request to Matterhorn fails' do
+      it 'should set the status to FAILED when ActiveEncode::Base#create fails' do
         master_file.process
         #Have to manually tell delayed_job to do the work because callback doesn't get fired with delay_jobs = false
         Delayed::Worker.new.work_off
@@ -168,9 +159,11 @@ describe MasterFile do
     subject(:masterfile) { derivative.masterfile }
     let(:derivative) {FactoryGirl.create(:derivative)}
     it "should delete (VOV-1805)" do
-      Rubyhorn.stub_chain(:client,:delete_track).and_return("http://test.com/retract_rtmp.xml")
-      Rubyhorn.stub_chain(:client,:delete_hls_track).and_return("http://test.com/retract_hls.xml")
-      masterfile
+      #Rubyhorn.stub_chain(:client,:delete_track).and_return("http://test.com/retract_rtmp.xml")
+      #Rubyhorn.stub_chain(:client,:delete_hls_track).and_return("http://test.com/retract_hls.xml")
+      #masterfile
+      allow(derivative).to receive(:delete).and_return true
+      allow(ActiveEncode::Base).to receive(:stop)
       expect { masterfile.delete }.to change { MasterFile.all.count }.by(-1)
     end
 
@@ -341,11 +334,64 @@ describe MasterFile do
           subject.file_location.should == File.join(tempdir,original)
         end
         
-        it "should copy an uploaded file to the Matterhorn media path" do
+        it "should copy an uploaded file to the media path" do
           Avalon::Configuration['matterhorn']['media_path'] = media_path
           subject.file_location.should == File.join(media_path,original)
         end
       end
+    end
+  end
+
+  describe "#encoder_class" do
+    subject { FactoryGirl.create(:master_file) }
+    
+    before :all do
+      class WorkflowEncoder < ActiveEncode::Base
+      end
+      
+      module EncoderModule
+        class MyEncoder < ActiveEncode::Base
+        end
+      end
+    end
+    
+    after :all do
+      EncoderModule.send(:remove_const, :MyEncoder)
+      Object.send(:remove_const, :EncoderModule)
+      Object.send(:remove_const, :WorkflowEncoder)
+    end
+    
+    it "should default to ActiveEncode::Base" do
+      expect(subject.encoder_class).to eq(ActiveEncode::Base)
+    end
+    
+    it "should infer the class from a workflow name" do
+      subject.workflow_name = 'workflow_encoder'
+      expect(subject.encoder_class).to eq(WorkflowEncoder)
+    end
+    
+    it "should fall back to ActiveEncode::Base when a workflow class can't be resolved" do
+      subject.workflow_name = 'nonexistent_workflow_encoder'
+      expect(subject.encoder_class).to eq(ActiveEncode::Base)
+    end
+    
+    it "should resolve an explicitly named encoder class" do
+      subject.encoder_classname = 'EncoderModule::MyEncoder'
+      expect(subject.encoder_class).to eq(EncoderModule::MyEncoder)
+    end
+
+    it "should fall back to ActiveEncode::Base when an encoder class can't be resolved" do
+      subject.encoder_classname = 'EncoderModule::NonexistentEncoder'
+      expect(subject.encoder_class).to eq(ActiveEncode::Base)
+    end
+    
+    it "should correctly set the encoder classname from the encoder" do
+      subject.encoder_class = EncoderModule::MyEncoder
+      expect(subject.encoder_classname).to eq('EncoderModule::MyEncoder')
+    end
+    
+    it "should reject an invalid encoder class" do
+      expect { subject.encoder_class = Object }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -309,12 +309,12 @@ describe MediaObject do
 
   describe '#finished_processing?' do
     it 'returns true if the statuses indicate processing is finished' do
-      media_object.parts << MasterFile.new(status_code: 'STOPPED')
-      media_object.parts << MasterFile.new(status_code: 'SUCCEEDED')
+      media_object.parts << MasterFile.new(status_code: 'CANCELLED')
+      media_object.parts << MasterFile.new(status_code: 'COMPLETED')
       media_object.finished_processing?.should be true
     end
     it 'returns true if the statuses indicate processing is not finished' do
-      media_object.parts << MasterFile.new(status_code: 'STOPPED')
+      media_object.parts << MasterFile.new(status_code: 'CANCELLED')
       media_object.parts << MasterFile.new(status_code: 'RUNNING')
       media_object.finished_processing?.should be false
     end

--- a/spec/models/stream_token_spec.rb
+++ b/spec/models/stream_token_spec.rb
@@ -21,7 +21,7 @@ describe StreamToken do
     let(:session) { { :session_id => '00112233445566778899aabbccddeeff' } }
 
     it "should create a token" do
-      StreamToken.find_or_create_session_token(session, target).should =~ /^[0-9a-f]{32}$/
+      StreamToken.find_or_create_session_token(session, target).should =~ /^[0-9a-f]{40}$/
     end
   end
 
@@ -29,7 +29,7 @@ describe StreamToken do
     let(:session) { {} }
 
     it "should create a token" do
-      StreamToken.find_or_create_session_token(session, target).should =~ /^[0-9a-f]{32}$/
+      StreamToken.find_or_create_session_token(session, target).should =~ /^[0-9a-f]{40}$/
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ SimpleCov.start 'rails'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'rspec/its'
 require 'equivalent-xml/rspec_matchers'
 require 'capybara/rspec'
 require 'database_cleaner'


### PR DESCRIPTION
Fix input file in #process for simple case
Upgrade to newer active-encode
Cleanup
Poll ActiveEncode for progress while MasterFile is not #finished_processing?
Hook up progress bar to active-encode
Use active-encode for destroy and other cleanup of destroy/delete
Remove unused route
Update token security to eliminate dependence on mediapackage_id
Fix failing tests
Use newline-delimited authorization responses instead of space-delimited
Use _ssi instead of _tesim for the indexed stream path.
Fix batch ingest tests
Update active-encode to version that prototypes multiple-quality skip transcoding
[VOV-3722] Store encoder class with MasterFile; infer it from workflow name if it doesn't exist
Add migration to change masterfile status SUCCEEDED to COMPLETED and back