### PR TITLE
Rollback DelayedJob to avoid 100% cpu problem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@
   gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'v3.1'
 
   gem 'mediainfo'
+  gem 'delayed_job', '=4.0.4'
   gem 'delayed_job_active_record'
   gem 'whenever', require: false
   gem 'with_locking'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,8 +291,8 @@ GEM
       debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.8)
-    delayed_job (4.0.6)
-      activesupport (>= 3.0, < 5.0)
+    delayed_job (4.0.4)
+      activesupport (>= 3.0, < 4.2)
     delayed_job_active_record (4.0.3)
       activerecord (>= 3.0, < 5.0)
       delayed_job (>= 3.0, < 4.1)
@@ -698,7 +698,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (0.3.43)
+    tzinfo (0.3.44)
     uber (0.0.13)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
@@ -742,6 +742,7 @@ DEPENDENCIES
   compass-susy-plugin (~> 0.9.0)
   daemons
   database_cleaner!
+  delayed_job (= 4.0.4)
   delayed_job_active_record
   devise (~> 3.2.0)
   edtf


### PR DESCRIPTION
This appears to be due to blind reloading introduced in 4.0.5: https://github.com/collectiveidea/delayed_job/issues/776

In the future we should switch to ActiveJob and use a different backend.  We'll need to do this work when we move to Rails 4.2 since DelayedJob 4.0.4 doesn't support it.