### PR TITLE
Use Blacklight's helper for page titles and add search constraints

### DIFF
--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -34,4 +34,27 @@ module Blacklight::LocalBlacklightHelper
     truncate(field, length: 200) unless field.blank?
   end
 
+  def constraints_filters_string filters
+    return if filters.nil?
+    filters.map {|facet, values| contstraints_filter_string(facet, values)}.join(' / ')
+  end
+
+  def contstraints_filter_string(facet, values)
+    facet_config = facet_configuration_for_field(facet)
+
+    case values.size
+    when 1
+      "#{facet_field_label(facet_config.key)}: #{facet_display_value(facet, values.first)}"
+    when 2 #if multiple facet selection enabled
+      "#{facet_field_label(facet_config.key)}: #{facet_display_value(facet, values.first)} or #{facet_display_value(facet, values.last)}"
+    else #if multiple facet selection enabled
+      "#{facet_field_label(facet_config.key)}: #{values.size} selected"
+    end
+  end
+
+  def constraints_string(localized_params = params)
+    result = [localized_params[:q], constraints_filters_string(localized_params[:f])].keep_if(&:present?).join(" / ")
+    result = t('blacklight.search.filters.none') if result.empty?
+    result
+  end
 end

--- a/app/views/admin/collections/index.html.erb
+++ b/app/views/admin/collections/index.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  Collections
-<% end %>
+<% @page_title = t('collections.title', :application_name => application_name) %>
 
 <div class='container-fluid'>
   <div class="row col-md-9 col-lg-8">

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  <%= @collection.name %>
-<% end %>
+<% @page_title = t('collections.show.title', :collection_name => @collection.name, :application_name => application_name) %>
 
 <div class="container-fluid">
     <div class="well">

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  <%= @group.name %>
-<% end %>
+<% @page_title = t('groups.show.title', :group_name => @group.name, :application_name => application_name) %>
 
 <div class="container-fluid">
   <%= render "form"%>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  Groups
-<% end %>
+<% @page_title = t('groups.title', :application_name => application_name) %>
 
 <div class="row col-md-9 col-lg-8">
   <div class="container-fluid">

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,25 @@
+<h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
+
+<% @page_title = t('blacklight.search.title', :constraints => constraints_string, :application_name => application_name) %>
+
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= auto_discovery_link_tag(:rss, url_for(params.merge(:format => 'rss')), :title => t('blacklight.search.rss_feed') ) %>
+  <%= auto_discovery_link_tag(:atom, url_for(params.merge(:format => 'atom')), :title => t('blacklight.search.atom_feed') ) %>
+<% end -%>
+
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/comments/create.html.erb
+++ b/app/views/comments/create.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  Contact Us
-<% end %>
+<% @page_title = t('contact.title', :application_name => application_name) %>
 
 <div class="container-fluid">
   <h2>Contact Us</h2>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  Contact Us
-<% end %>
+<% @page_title = t('contact.title', :application_name => application_name) %>
 
 <div class="container-fluid">
 

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -18,15 +18,8 @@ Unless required by applicable law or agreed to in writing, software distributed
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>
-      <%= yield :title %>
-      <% if content_for? :title %>
-         - <%= application_name %>
-      <% else %>
-        <%= application_name %>
-      <% end %>
-    </title>
-
+    <title><%= render_page_title %></title>
+ 
    <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "application", media: "all" %>

--- a/app/views/media_objects/edit.html.erb
+++ b/app/views/media_objects/edit.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  <%= @mediaobject.title || @mediaobject.pid %> - <%= HYDRANT_STEPS.get_step(@active_step).title %>
-<% end %>
+<% @page_title = t('media_objects.edit.title', :media_object_title => (@mediaobject.title || @mediaobject.pid), :step_title => HYDRANT_STEPS.get_step(@active_step).title, :application_name => application_name) %>
 
 <div class="container-fluid">
   <div class="row">

--- a/app/views/media_objects/show.html.erb
+++ b/app/views/media_objects/show.html.erb
@@ -13,9 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :title do %>
-  <%= @mediaobject.title || @mediaobject.pid %>
-<% end %>
+<% @page_title = t('media_objects.show.title', :media_object_title => (@mediaobject.title || @mediaobject.pid), :application_name => application_name) %>
 
 <div class="container-fluid" >
   <%= render 'administrative_links' %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -33,6 +33,7 @@ en:
     back_to_bookmarks: 'Back to Selected Items'
 
     search:
+      title: '%{constraints} - %{application_name} Search'
       bookmarks:
         present: "Selected"
         absent: "Select"
@@ -41,6 +42,8 @@ en:
         title: 'Browse By'
       facets-workflow:
         title: 'Limit to'
+      filters:
+        none: 'Browse'
 
     tools:
       publish: "Publish"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,3 +151,22 @@ en:
       Select an Avalon group from the dropdown list below to grant it access to an item or collection.
     class: |
       Enter an external group to grant it access to an item or collection. This group might represent students in a course or members of an institution-specific group.
+
+  contact:
+    title: 'Contact Us - %{application_name}'
+
+  groups:
+    title: 'Groups - %{application_name}'
+    show:
+      title: '%{group_name} - Groups - %{application_name}'
+
+  collections:
+    title: 'Collections - %{application_name}'
+    show:
+      title: '%{collection_name} - Collections - %{application_name}'
+
+  media_objects:
+    edit:
+      title: '%{step_title} - %{media_object_title} - %{application_name}'
+    show:
+      title: '%{media_object_title} - %{application_name}'


### PR DESCRIPTION
This standardizes our page titles and adds search constraints to the page title using a format similar to amazon.  This work should be turned into a PR upstream to blacklight which we can make use of once merged and released.