### PR TITLE
Override #has_facet_values? which checks if/unless clauses and facet counts

### DIFF
--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -12,7 +12,11 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-module Blacklight::LocalBlacklightHelper 
+module Blacklight::LocalBlacklightHelper
+  def has_facet_values? fields = facet_field_names, options = {}
+    facets_from_request(fields).any? { |display_facet| !display_facet.items.empty? && should_render_facet?(display_facet) }
+  end
+
   def facet_field_names group=nil
     blacklight_config.facet_fields.select { |facet,opts| group == opts[:group] }.keys
   end


### PR DESCRIPTION
This is a corner case in upstream blacklight but maybe should be contributed or the existing #has_facet_values? should be altered to include this displayable check.