### PR TITLE
Ignore errors while purging encode and log warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/rubyhorn.git
-  revision: acc4424c0c3de19e465b6635988c85b98f649c2a
+  revision: 288b2d7d45aeb10122827aa2a9cc9c84bb3eb53d
   specs:
     rubyhorn (0.0.6)
       activesupport
@@ -134,9 +134,10 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra-labs/active-encode.git
-  revision: d839b50471e72fc0d70ca4aece1ea5816f22b2ff
+  revision: a8ce099afa94244bd0d77d99a5118ab044e95083
   specs:
     active-encode (0.0.1)
+      activemodel
       activesupport
 
 GIT
@@ -312,6 +313,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dropbox-sdk (1.6.4)
       json
@@ -378,6 +381,8 @@ GEM
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -409,7 +414,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    json (1.8.2)
+    json (1.8.3)
     json-ld (1.1.8)
       rdf (~> 1.1, >= 1.1.7)
     jwt (1.3.0)
@@ -459,14 +464,14 @@ GEM
       rack-contrib (~> 1.1)
       railties (>= 3.0.0, < 5.0.0)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mimemagic (0.2.1)
     mini_portile (0.6.2)
     minitest (4.7.5)
     modal_logic (0.0.8)
       handlebars_assets (= 0.14.1)
       rails (>= 4)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-digest_auth (1.4)
@@ -581,7 +586,8 @@ GEM
     rdf-xsd (1.1.3)
       rdf (~> 1.1, >= 1.1.9)
     ref (1.0.5)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retriable (1.4.1)
@@ -824,3 +830,6 @@ DEPENDENCIES
   whenever
   with_locking
   xray-rails
+
+BUNDLED WITH
+   1.10.4

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -176,8 +176,13 @@ class MasterFile < ActiveFedora::Base
     self.derivatives.map(&:destroy)
 
     # Stops all processing and deletes the workflow
-    ActiveEncode::Base.find(workflow_id).purge! if workflow_id.present?
-
+    if workflow_id.present?
+      begin
+        ActiveEncode::Base.find(workflow_id).purge!
+      rescue Rubyhorn::RestClient::Exceptions::ServerError
+        logger.warn "Error purging encode #{workflow_id} for MasterFile #{id}"
+      end
+    end
     clear_association_cache
     
     super


### PR DESCRIPTION
It appears that ActiveEncode isn't able to update the matterhorn workflow after retracting derivatives maybe because of a race condition. Avalon has been changed to ignore and move on but this leaves inconsistent metadata in matterhorn's workflow because it still thinks the tracks exist but they have been deleted.