### PR TITLE
Fix facet label wrapping with javascript

### DIFF
--- a/app/assets/javascripts/avalon.js
+++ b/app/assets/javascripts/avalon.js
@@ -19,6 +19,15 @@
  * Rails and causes it to redirect to the wrong place. */
 $(document).ready(function() {
   Blacklight.do_search_context_behavior = function() {}
+  // adjust width of facet columns to fit their contents
+  function longer (a,b){ return b.textContent.length - a.textContent.length; }
+  $('ul.facet-values, ul.pivot-facet').map(function(){
+      var longest = $(this).find('.facet-count span').sort(longer).first();
+      var clone = longest.clone().css('visibility','hidden');
+      $('body').append(clone);
+      $(this).find('.facet-count').first().width(clone.width());
+      clone.remove();
+  });
 
   $( document ).on('click', '.btn-stateful-loading', function() { $(this).button('loading'); });    
 
@@ -69,8 +78,8 @@ $(document).ready(function() {
   if ( $( ".avalon-player" ).length == 0 ) {
     keyboardAccess();
   }
-
 });
+
 
 var keyboardAccess = function() {
     var interactive_elements = [ "a", "input", "button", "textarea" ];

--- a/app/assets/stylesheets/avalon.css.scss
+++ b/app/assets/stylesheets/avalon.css.scss
@@ -565,11 +565,11 @@ a[data-trigger='submit'] {
 }
 
 .facet-values {
+  display: table;
+  table-layout: fixed;
   //set hyphen definitions at this (display:block) level
-  //The fact that there are two word-break declarations in a row is a hack, not a mistake.
-  //Firefox doesn't support word-break: break-word, which is what we want, so this lets it fall back to keep-all.
+  -ms-word-break: keep-all;
   word-break: keep-all;
-  word-break: break-word;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   -ms-hyphens: auto;
@@ -580,6 +580,8 @@ a[data-trigger='submit'] {
 }
 
 .facet-values .facet-label {
+  display: table-cell;
+  position: relative;
   //override any blacklight hyphen definitions made at this (display:inline) level
   word-break: inherit;
   -webkit-hyphens: inherit;
@@ -587,35 +589,21 @@ a[data-trigger='submit'] {
   -ms-hyphens: inherit;
   -o-hyphens: inherit;
   hyphens: inherit;
-  //for IE to correctly wrap long words, container must have fixed width
-  display: inline-block;
-  width: 78%;
-  position: relative;
   padding-right: 20px;
-  @media (max-width: 600px) {
-    max-width: 250px;
-  }
-  @media (min-width: 600px) and (max-width: $screen-sm-min){
-    max-width: 550px;
-  }
+
   .remove {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 0.5em;
     text-indent: 0;
   }
 }
 
 .facet-count {
-  float: right;
-  width: 20%;
+  text-align: right;
+  width: 5em;
 }
 
-//left panel on large screens should be extra small, not so for extended facet list
-.panel-body .facet-values .facet-label {
-  @media (min-width: $screen-sm-min){
-  }
-}
 .facets .panel-group .panel {
   margin-top: 0px;
 }

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -61,4 +61,12 @@ module Blacklight::LocalBlacklightHelper
     result = t('blacklight.search.filters.none') if result.empty?
     result
   end
+
+  def render_facet_count(num, options = {})
+    classes = (options[:classes] || [])
+    content_tag("div", :class => "facet-count") do
+      content_tag("span", t('blacklight.search.facets.count', :number => number_with_delimiter(num)), :class => classes)
+    end
+  end
+
 end


### PR DESCRIPTION
This aligns with a pending blacklight pull request (https://github.com/projectblacklight/blacklight/pull/1224/files).

The problem this solves is that some browsers (IE and maybe others) cannot calculate where to break a word if its container doesn't have a predictable size (like in the table-layout used here). The solution sets table-layout to fixed and sets the size of the facet-count column. This way the facet-label column has a predictable size that can be used to break words.