### PR TITLE
Subvert all normal callbacks the update the player UI until after play for Android devices

### DIFF
--- a/app/assets/javascripts/android_pre_play.js
+++ b/app/assets/javascripts/android_pre_play.js
@@ -1,0 +1,68 @@
+  var avalonStartTime = 0;
+  var avalonDuration = 0;
+  var originalSetCurrentTime;
+  var originalGetCurrentTime;
+
+  function androidPrePlay(startTime, duration, player){
+    avalonStartTime = startTime;
+    avalonDuration = duration;
+    originalSetCurrentTime = player.setCurrentTime;
+    player.setCurrentTime = androidSetCurrentTime;
+    //player.media.setCurrentTime = androidSetCurrentTime;
+    originalGetCurrentTime = player.getCurrentTime;
+    player.getCurrentTime = androidGetCurrentTime;
+    player.media.addEventListener('play', androidFirstPlay, true);
+  }
+ 
+  function durationChanged () {
+    console.log(currentPlayer.media.duration);
+    if (currentPlayer.media.duration == 0)
+      return;
+    currentPlayer.setCurrentTime(avalonStartTime);
+    console.log(currentPlayer.media.duration + " " + currentPlayer.getCurrentTime() + " " + currentPlayer.media.seeking);
+    currentPlayer.media.removeEventListener('durationchange', durationChanged);
+  }
+
+  function androidSetCurrentTime (time) {
+    //don't actually call media.currentTime but update everything else manually
+    console.log('androidSetCurrentTime: ' + time);
+    avalonStartTime = time;
+    androidSetCurrentRail(time);
+    androidUpdateCurrent(time);
+    update_active_stream();
+  }
+
+  function androidGetCurrentTime () {
+    return avalonStartTime;
+  }
+
+  function androidSetCurrentRail (time) {
+    var total = currentPlayer.controls.find('.mejs-time-total');
+    var handle = currentPlayer.controls.find('.mejs-time-handle');
+    var current = currentPlayer.controls.find('.mejs-time-current');
+    
+    // update bar and handle
+    if (total && handle) {
+      var
+        newWidth = Math.round(total.width() * time / avalonDuration),
+        handlePos = newWidth - Math.round(handle.outerWidth(true) / 2);
+
+        current.width(newWidth);
+        handle.css('left', handlePos);
+    }
+  }
+
+  function androidUpdateCurrent (time) {
+    var currenttime = currentPlayer.currenttime;
+    if (currenttime) {
+      currenttime.html(mejs.Utility.secondsToTimeCode(time, currentPlayer.options.alwaysShowHours || avalonDuration > 3600, currentPlayer.options.showTimecodeFrameCount,  currentPlayer.options.framesPerSecond || 25));
+    }
+  }
+
+  function androidFirstPlay () {
+    currentPlayer.setCurrentTime = originalSetCurrentTime;
+    //currentPlayer.media.setCurrentTime = originalSetCurrentTime;
+    currentPlayer.getCurrentTime = originalGetCurrentTime;
+    currentPlayer.media.addEventListener('durationchange', durationChanged, true);
+    currentPlayer.media.removeEventListener("play", androidFirstPlay);
+  }

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -69,6 +69,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
   <%= javascript_include_tag "mediaelement_rails/mediaelement-and-player" =%>
   <%= javascript_include_tag 'switch_streams' %> 
+  <%= javascript_include_tag 'android_pre_play' %> 
   <%= javascript_include_tag 'mediaelement-qualityselector/mep-feature-qualities' %> 
   <%= javascript_include_tag 'me-thumb-selector' %>
   <%= javascript_include_tag 'mediaelement-skin-avalon/mep-feature-responsive' %>
@@ -111,6 +112,9 @@ Unless required by applicable law or agreed to in writing, software distributed
               currentPlayer.media.removeEventListener('loadedmetadata', loadedmetadata);
             }, true);
             mediaElement.addEventListener('timeupdate', update_active_stream, true ); 
+	    if (mejs.MediaFeatures.isAndroid) {
+              androidPrePlay(<%= f_start %>, <%= @currentStream ? (@currentStream.duration.to_f / 1000).round : -1 %>, player);
+	    }
           }
         });
   </script>


### PR DESCRIPTION
These changes override the methods used for updating the progress bar and current time until first play on Android devices.  This makes the UI look responsive to structure clicks and media fragment urls, but does not address slider clicks.  It also does not update the still image for the video but leaves the poster image in place.  This approach was taken because Android isn't properly handling seeks and seek events.