### PR TITLE
Don't show player until skin and media are initialized.

### DIFF
--- a/app/assets/javascripts/switch_streams.js
+++ b/app/assets/javascripts/switch_streams.js
@@ -47,6 +47,17 @@
       }
     },
 
+    setupCreationTrigger: function(playerThing) {
+      var watchForCreation = function() {
+        if (defined(playerThing) && defined(playerThing.created) && playerThing.created) {
+          $(playerThing).trigger('created')
+        } else {
+          setTimeout(watchForCreation, 100);
+        }
+      }
+      watchForCreation();
+    },
+
     /*
      * This method should take care of the heavy lifting involved in passing a message
      * to the player
@@ -83,12 +94,12 @@
             if (isNaN(initialTime)) initialTime = 0;
             if (exists(currentPlayer.qualities) && (currentPlayer.qualities.length > 0))
               currentPlayer.buildqualities(currentPlayer, currentPlayer.controls, currentPlayer.layers, currentPlayer.media);
-            var loadeddata = function() {
+            $(currentPlayer).one('created', function() {
               currentPlayer.setCurrentTime(initialTime);
-              currentPlayer.media.removeEventListener('loadeddata', loadeddata);
-            };
-            currentPlayer.media.addEventListener('loadeddata', loadeddata, true);
+              $('section#content').css('visibility','visible');
+            });
             currentPlayer.load();
+            this.setupCreationTrigger(currentPlayer);
           }
         }
       }

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -21,7 +21,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% f_start, f_end = parse_media_fragment params['t'] %>
 <div class="row">
   <div class="col-sm-8" id="left_column">
-    <section id="content" class="avalon-player" style="width: 100%" tabIndex="-1">
+    <section id="content" class="avalon-player" style="width: 100%; visibility: hidden;" tabIndex="-1">
       <% if @currentStream.present? and @currentStream.derivatives.present? %>
         <%= stylesheet_link_tag "mediaelement_rails/mediaelementplayer" =%>   
         


### PR DESCRIPTION
MediaElement.js doesn't have a `created` event, so I set up a timeout loop that watches for `player.created` to become true and triggers an event. That allowed me to initialize the player with `visibility: hidden` and show it after the initial heavy lifting is done.