### PR TITLE
Don't prepend the prefix if it is already there

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -614,7 +614,12 @@ class MasterFile < ActiveFedora::Base
   end
 
   def post_processing_move_filename(oldpath, options={})
-    "#{options[:pid].gsub(":","_")}-#{File.basename(oldpath)}"
+    prefix = options[:pid].gsub(":","_")
+    if oldpath.start_with?(prefix)
+      oldpath
+    else 
+      "#{prefix}-#{File.basename(oldpath)}"
+    end
   end
 
   def update_ingest_batch


### PR DESCRIPTION
This fix was put in place on IU's production instance in May but the change never made it upstream.