### PR TITLE
Quick-load MasterFiles and Derivatives

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -376,14 +376,7 @@ class MediaObjectsController < ApplicationController
   # return a nil value that needs to be handled appropriately by the calling code
   # block
   def set_active_file(file_pid = nil)
-    unless (@mediaobject.parts.blank? or file_pid.blank?)
-      @mediaobject.parts.each do |part|
-        return part if part.pid == file_pid
-      end
-    end
-
-    # If you haven't dropped out by this point return an empty item
-    nil
+    file_pid.nil? ? nil : @mediaobject.parts_with_order.find { |mf| mf.pid == file_pid }
   end 
   
 end

--- a/app/models/caching_simple_datastream.rb
+++ b/app/models/caching_simple_datastream.rb
@@ -1,0 +1,57 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class CachingSimpleDatastream
+  class FieldError < Exception; end
+  
+  class FieldCollector
+    attr :fields
+    def field(name, type)
+      @fields ||= {}
+      fields[name] = type
+    end
+  end
+
+  def self.create(klass)
+    cache_class = Class.new(ActiveFedora::SimpleDatastream) do
+      class_attribute :owner_class
+      
+      def self.defined_attributes(ds)
+        @defined_attributes ||= {}
+        if @defined_attributes[ds].nil?
+          fc = FieldCollector.new
+          self.owner_class.ds_specs[ds][:block].call(fc)
+          @defined_attributes[ds] = fc.fields
+        end
+        @defined_attributes[ds]
+      end
+      
+      def self.type(field)
+        field_def = self.owner_class.defined_attributes[field.to_s]
+        raise FieldError, "Unknown field `#{field}` for #{self.owner_class.name}" if field_def.nil?
+        self.defined_attributes(field_def.dsid)[field.to_sym]
+      end
+      
+      def primary_solr_name(field)
+        ActiveFedora::SolrService.solr_name(field, type: self.type(field))
+      end
+      
+      def type(field)
+        self.class.type(field)
+      end
+    end
+    cache_class.owner_class = klass
+    cache_class
+  end
+end

--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -29,7 +29,7 @@ class Derivative < ActiveFedora::Base
   # The only meaningful value at the moment is the url, which points to
   # the stream location. The other two are just stored until a migration
   # strategy is required.
-  has_metadata name: "descMetadata", :type => ActiveFedora::SimpleDatastream, autocreate: true do |d|
+  has_metadata name: "descMetadata", :type => CachingSimpleDatastream.create(self) do |d|
     d.field :location_url, :string
     d.field :hls_url, :string
     d.field :duration, :string

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -34,7 +34,7 @@ class MasterFile < ActiveFedora::Base
   belongs_to :mediaobject, :class_name=>'MediaObject', :property=>:is_part_of
   has_many :derivatives, :class_name=>'Derivative', :property=>:is_derivation_of
 
-  has_metadata name: 'descMetadata', :type => ActiveFedora::SimpleDatastream do |d|
+  has_metadata name: 'descMetadata', :type => CachingSimpleDatastream.create(self) do |d|
     d.field :file_location, :string
     d.field :file_checksum, :string
     d.field :file_size, :string
@@ -47,7 +47,7 @@ class MasterFile < ActiveFedora::Base
     d.field :date_digitized, :string
   end
 
-  has_metadata name: 'mhMetadata', :type => ActiveFedora::SimpleDatastream do |d|
+  has_metadata name: 'mhMetadata', :type => CachingSimpleDatastream.create(self) do |d|
     d.field :workflow_id, :string
     d.field :workflow_name, :string
     d.field :percent_complete, :string
@@ -220,7 +220,7 @@ class MasterFile < ActiveFedora::Base
 
   def stream_details(token,host=nil)
     flash, hls = [], []
-    derivatives.each do |d|
+    ActiveFedora::SolrService.reify_solr_results(derivatives.load_from_solr, load_from_solr: true).each do |d|
       common = { quality: d.encoding.quality.first,
                  mimetype: d.encoding.mime_type.first,
                  format: d.format } 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -448,7 +448,9 @@ describe MediaObjectsController, type: :controller do
         master_file = FactoryGirl.create(:master_file)
         master_file.mediaobject = media_object
         master_file.save
-
+        media_object.parts_with_order = media_object.parts
+        media_object.save 
+        
         mopid = media_object.pid
         media_object = MediaObject.find(mopid)
 

--- a/spec/models/caching_simple_datastream_spec.rb
+++ b/spec/models/caching_simple_datastream_spec.rb
@@ -1,0 +1,52 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'spec_helper'
+
+describe CachingSimpleDatastream do
+  
+  before do
+    class CachingModel < ActiveFedora::Base
+      has_metadata name: 'primary', :type => CachingSimpleDatastream.create(self) do |d|
+        d.field :one, :string
+        d.field :two, :integer
+      end
+      
+      has_metadata name: 'secondary', :type => CachingSimpleDatastream.create(self) do |d|
+        d.field :three, :boolean
+        d.field :four, :date
+      end
+      
+      has_attributes :one, :two, datastream: :primary
+      has_attributes :three, :four, datastream: :secondary
+    end
+  end
+  
+  after do
+    Object.send(:remove_const, :CachingModel)
+  end
+  
+  subject { CachingModel.new }
+  
+  it "should know the solr names for its attributes" do
+    expect(subject.primary.primary_solr_name(:one)).to eq(ActiveFedora::SolrService.solr_name('one', type: :string))
+    expect(subject.primary.primary_solr_name(:two)).to eq(ActiveFedora::SolrService.solr_name('two', type: :integer))
+    expect(subject.secondary.primary_solr_name(:three)).to eq(ActiveFedora::SolrService.solr_name('three', type: :boolean))
+    expect(subject.secondary.primary_solr_name(:four)).to eq(ActiveFedora::SolrService.solr_name('four', type: :date))
+  end
+  
+  it "should raise an error on an unknown field name" do
+    expect { subject.primary.primary_solr_name(:five) }.to raise_error(CachingSimpleDatastream::FieldError)
+  end
+end


### PR DESCRIPTION
This change became more involved than I expected, because `ActiveFedora::SimpleDatastream` simply doesn't provide a mechanism to determine the correct solr field name for a given attribute field. I created a `CachingSimpleDatastream` wrapper that translates attribute names to solr field names, but stays completely out of the way otherwise. It works as a drop-in with existing data, using the field definition blocks from `has_metadata`, to gather its information, and there is no reindexing needed.