### PR TITLE
Added support for Wowza-style M3U8 playlists.

### DIFF
--- a/lib/avalon/m3u8_reader.rb
+++ b/lib/avalon/m3u8_reader.rb
@@ -18,6 +18,8 @@ require 'uri'
 module Avalon
   class M3U8Reader
 
+    attr_reader :playlist
+
     def self.read(io)
       if io.is_a?(IO)
         self.new(io.read)
@@ -47,6 +49,9 @@ module Avalon
         elsif line =~ /^#EXTINF:(.+),(.*)$/
           tags[:duration] = $1.to_f
           tags[:title] = $2
+        elsif line =~ /\.m3u8?.*$/i
+          url = @base.is_a?(URI) ? @base.merge(line).to_s : File.expand_path(line,@base.to_s)
+          @playlist.merge!(Avalon::M3U8Reader.read(url).playlist)
         elsif line =~ /^[^#]/
           tags[:filename] = line
           @playlist[:files] << tags


### PR DESCRIPTION
Wowza playlists require multiple requests.  I've included examples below.  In order to generate thumbnails from HLS when using Wowza, the m3u8 reader needs to fetch and parse the second file.

This PR does that, and hopefully retains support for the red5-style HLS playlist files.

#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:BANDWIDTH=4526493,CODECS="avc1.77.30,mp4a.40.2",RESOLUTION=640x480
chunklist_w1068416662.m3u8

The second looks as you'd expect:
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:11
#EXT-X-MEDIA-SEQUENCE:0
#EXTINF:10.01,
media_w1068416662_0.ts
#EXTINF:10.009,
media_w1068416662_1.ts
...
#EXT-X-ENDLIST