### PR TITLE
Prevent autocompleted ID values from being overwritten by display values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@
     gem 'font-awesome-rails', '~> 4.3'
     gem 'bootstrap_form'
     gem 'handlebars_assets'
-    gem 'twitter-typeahead-rails', '=0.10.5'
+    gem 'twitter-typeahead-rails', '~>0.11.1'
   end
 
   group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,11 +689,11 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     tins (1.6.0)
-    twitter-typeahead-rails (0.10.5)
+    twitter-typeahead-rails (0.11.1)
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (0.3.45)
+    tzinfo (0.3.46)
     uber (0.0.13)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
@@ -815,12 +815,9 @@ DEPENDENCIES
   sqlite3
   therubyracer (>= 0.12.0)
   therubyrhino
-  twitter-typeahead-rails (= 0.10.5)
+  twitter-typeahead-rails (~> 0.11.1)
   uglifier (>= 1.0.3)
   validates_email_format_of
   whenever
   with_locking
   xray-rails
-
-BUNDLED WITH
-   1.10.5

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,16 +42,15 @@
 
 //= require bootstrap-sprockets
 
+//= require browse_everything
+
+/* bootstrap 3 eliminated typeahead. use twitter-typeahead-rails instead */
+//= require twitter/typeahead
 
 /* requirements for handling modals with modal logic gem */
 //= require modal_logic
 //= require handlebars.runtime
 //= require templates/modal/crud
-
-//= require browse_everything
-
-/* bootstrap 3 eliminated typeahead. use twitter-typeahead-rails instead */
-//= require twitter/typeahead
 
 /*
  * Place any local overrides in avalon.js (for Blacklight, Hydra, jQuery,

--- a/app/assets/stylesheets/typeahead.css
+++ b/app/assets/stylesheets/typeahead.css
@@ -127,7 +127,7 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   cursor: not-allowed;
   background-color: #eeeeee !important;
 }
-.tt-dropdown-menu {
+.tt-menu {
   position: absolute;
   top: 100%;
   left: 0;
@@ -148,7 +148,7 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   *border-right-width: 2px;
   *border-bottom-width: 2px;
 }
-.tt-dropdown-menu .tt-suggestion {
+.tt-menu .tt-suggestion {
   display: block;
   padding: 3px 20px;
   clear: both;
@@ -157,16 +157,16 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   color: #333333;
   white-space: nowrap;
 }
-.tt-dropdown-menu .tt-suggestion.tt-cursor {
+.tt-menu .tt-suggestion.tt-cursor {
   text-decoration: none;
   outline: 0;
   background-color: #f5f5f5;
   color: #262626;
 }
-.tt-dropdown-menu .tt-suggestion.tt-cursor a {
+.tt-menu .tt-suggestion.tt-cursor a {
   color: #262626;
 }
-.tt-dropdown-menu .tt-suggestion p {
+.tt-menu .tt-suggestion p {
   margin: 0;
 }
 .input-group .twitter-typeahead .tt-hint,


### PR DESCRIPTION
There were two issues:

* `modal_logic` overrides the `exports` global, which prevents `Bloodhound` from loading correctly.
* Our validation logic was relying on a cache of values that doesn't get reliably initialized, causing the ID to be overwritten by the display value in cases where they are different.