### PR TITLE
Only save master file if permalink was updated

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -560,8 +560,8 @@ class MediaObject < ActiveFedora::Base
         ensure_permalink!
         self.parts.each do |master_file| 
           begin
-            master_file.ensure_permalink!
-            master_file.save( validate: false )
+            updated = master_file.ensure_permalink!
+            master_file.save( validate: false ) if updated
           rescue
           	# no-op
           	# Save is called (uncharacteristically) during a destroy.

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -118,6 +118,23 @@ describe MasterFilesController do
 
         expect(flash[:errors]).to be_nil
       end
+      it "should not fail when associating with a published mediaobject" do
+        media_object = FactoryGirl.create(:published_media_object)
+        login_user media_object.collection.managers.first
+        @file = fixture_file_upload('/videoshort.mp4', 'video/mp4')
+        #Work-around for a Rails bug
+        class << @file
+          attr_reader :tempfile
+        end
+   
+        post :create, Filedata: [@file], original: 'any', container_id: media_object.pid
+
+        master_file = MasterFile.all.last
+        expect(media_object.reload.parts).to include master_file
+        expect(master_file.mediaobject.pid).to eq(media_object.pid)
+         
+        expect(flash[:errors]).to be_nil
+      end
     end
   end
   


### PR DESCRIPTION
This keeps things from spiraling out of control when trying to add a file to a published media object.  The added test passes but also wasn't failing for me before the change.