### PR TITLE
Preserve other identifiers across bib import and ensure that supplied…

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -84,6 +84,8 @@ class MediaObjectsController < ApplicationController
     populate_from_catalog = !!params[:import_bib_record]
     if populate_from_catalog and Avalon::BibRetriever.configured?
       begin
+        # Set other identifiers
+        @mediaobject.update_datastream(:descMetadata, params[:fields].slice(:other_identifier_type, :other_identifier))
         # Try to use Bib Import
         @mediaobject.descMetadata.populate_from_catalog!(Array(params[:fields][:bibliographic_id]).first, 
                                                          Array(params[:fields][:bibliographic_id_label]).first)

--- a/app/models/mods_document.rb
+++ b/app/models/mods_document.rb
@@ -226,7 +226,9 @@ class ModsDocument < ActiveFedora::OmDatastream
         languages = self.language.collect &:strip
         self.language = nil
         languages.each { |lang| self.add_language(lang) }
-        old_other_identifier.each do |id_pair|
+        new_other_identifier = self.other_identifier.type.zip(self.other_identifier)
+        self.other_identifier = nil
+        (old_other_identifier | new_other_identifier).each do |id_pair|
           self.add_other_identifier(id_pair[1], id_pair[0])
         end
       end

--- a/app/models/mods_document.rb
+++ b/app/models/mods_document.rb
@@ -212,6 +212,7 @@ class ModsDocument < ActiveFedora::OmDatastream
       if new_record.present?
         old_resource_type = self.resource_type.dup
         old_media_type = self.media_type.dup
+        old_other_identifier = self.other_identifier.type.zip(self.other_identifier)
         self.ng_xml = Nokogiri::XML(new_record)
         [:genre, :topical_subject, :geographic_subject, :temporal_subject, 
          :occupation_subject, :person_subject, :corporate_subject, :family_subject, 
@@ -225,6 +226,9 @@ class ModsDocument < ActiveFedora::OmDatastream
         languages = self.language.collect &:strip
         self.language = nil
         languages.each { |lang| self.add_language(lang) }
+        old_other_identifier.each do |id_pair|
+          self.add_other_identifier(id_pair[1], id_pair[0])
+        end
       end
     end
     self.bibliographic_id = nil


### PR DESCRIPTION
… other identifiers are persisted with API calls

This might create duplicates in the case when bib import fails.