### PR TITLE
mediaobject#set_session_quality was returning 401 always

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -19,7 +19,7 @@ class MediaObjectsController < ApplicationController
   include Avalon::Controller::ControllerBehavior
   include ConditionalPartials
 
-  before_filter :authenticate_user!, except: [:show]
+  before_filter :authenticate_user!, except: [:show, :set_session_quality]
   before_filter :authenticate_api!, only: [:show], if: proc{|c| request.format.json?}
   load_and_authorize_resource instance_name: 'mediaobject', except: [:destroy, :update_status, :set_session_quality]
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -51,7 +51,6 @@ describe MediaObjectsController, type: :controller do
           expect(get :edit, id: media_object.id).to redirect_to(new_user_session_path)
           expect(get :confirm_remove, id: media_object.id).to redirect_to(new_user_session_path)
           expect(post :create).to redirect_to(new_user_session_path)
-          expect(post :set_session_quality, quality: 'high').to redirect_to(new_user_session_path)
           expect(put :update, id: media_object.id).to redirect_to(new_user_session_path)
           expect(put :update_status, id: media_object.id).to redirect_to(new_user_session_path)
           expect(get :tree, id: media_object.id).to redirect_to(new_user_session_path)


### PR DESCRIPTION
This enables quality level switching in avalon media player, but reveals a playability problem with MEJS switchStream that had been only visible in embedded players. Play vs Pause mode gets confused when switching quality levels. 2-3 presses of play/pause sorts out the problem. Problem still needs to be fixed in mediaelement_rails.