### PR TITLE
Removed whitespace in Solr query to work with Solr cloud 4.10.x

### DIFF
--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -48,7 +48,7 @@ class StreamToken < ActiveRecord::Base
     token = self.find_by_token(value)
     if token.present? and token.expires > Time.now
       token.renew!
-      valid_streams = ActiveFedora::SolrService.query(%{is_derivation_of_ssim: "info:fedora/#{token.target}"}, fl: 'stream_path_ssi')
+      valid_streams = ActiveFedora::SolrService.query(%{is_derivation_of_ssim:"info:fedora/#{token.target}"}, fl: 'stream_path_ssi')
       return valid_streams.collect { |d| d['stream_path_ssi'] }
     else
       raise Unauthorized, "Unauthorized"


### PR DESCRIPTION
The space in the solr query will cause nothing to return from a Solr cloud built with 4.10.4 version