### PR TITLE
Remove MasterFile#update_mediaobject! callback in favor of MediaObject#update_dependent_properties!

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -79,7 +79,6 @@ class MasterFile < ActiveFedora::Base
 
   has_model_version 'R3'
   before_save :update_stills_from_offset!
-  around_save :update_media_object!, if: Proc.new { |mf| mf.duration_changed? or mf.file_location_changed? or mf.file_format_changed? }
 
   define_hooks :after_processing
   
@@ -101,16 +100,6 @@ class MasterFile < ActiveFedora::Base
   
   EMBED_SIZE = {:medium => 600}
   AUDIO_HEIGHT = 50
-
-  def update_media_object!
-    yield
-    return if mediaobject.nil?
-    mediaobject.reload
-    mediaobject.set_duration!
-    mediaobject.set_media_types!
-    mediaobject.set_resource_types!
-    mediaobject.save(validate: false)
-  end
 
   def save_parent
     unless mediaobject.nil?

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -105,6 +105,7 @@ class MasterFile < ActiveFedora::Base
   def update_media_object!
     yield
     return if mediaobject.nil?
+    mediaobject.reload
     mediaobject.set_duration!
     mediaobject.set_media_types!
     mediaobject.set_resource_types!

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -414,7 +414,8 @@ describe MediaObject do
     describe '#set_media_types!' do
       let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
       it 'sets format on the model' do
-        media_object.format = nil
+        media_object.update_attribute_in_metadata(:format, nil)
+        expect(media_object.format).to be_nil
         media_object.set_media_types!
         expect(media_object.format).to eq "video/mp4"
       end
@@ -424,6 +425,7 @@ describe MediaObject do
       let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
       it 'sets resource_type on the model' do
         media_object.displayMetadata.avalon_resource_type = []
+        expect(media_object.displayMetadata.avalon_resource_type).to be_empty
         media_object.set_resource_types!
         expect(media_object.displayMetadata.avalon_resource_type).to eq ["moving image"]
       end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -403,31 +403,33 @@ describe MediaObject do
     end
   end
 
-  describe '#set_duration!' do
-    it 'sets duration on the model' do
-      media_object.set_duration!
-      expect(media_object.duration).to eq('0')
+  context "dependent properties" do
+    describe '#set_duration!' do
+      it 'sets duration on the model' do
+        media_object.set_duration!
+        expect(media_object.duration).to eq('0')
+      end
     end
-  end
 
-  describe '#set_media_types!' do
-    let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
-    it 'sets format on the model' do
-      expect(media_object.format).to be nil
-      media_object.set_media_types!
-      expect(media_object.format).to eq "video/mp4"
+    describe '#set_media_types!' do
+      let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
+      it 'sets format on the model' do
+        media_object.format = nil
+        media_object.set_media_types!
+        expect(media_object.format).to eq "video/mp4"
+      end
     end
-  end
 
-  describe '#set_resource_types!' do
-    let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
-    it 'sets resource_type on the model' do
-      expect(media_object.displayMetadata.avalon_resource_type).to eq []
-      media_object.set_resource_types!
-      expect(media_object.displayMetadata.avalon_resource_type).to eq ["moving image"]
+    describe '#set_resource_types!' do
+      let!(:master_file) { FactoryGirl.create(:master_file, mediaobject: media_object) }
+      it 'sets resource_type on the model' do
+        media_object.displayMetadata.avalon_resource_type = []
+        media_object.set_resource_types!
+        expect(media_object.displayMetadata.avalon_resource_type).to eq ["moving image"]
+      end
     end
   end
- 
+  
   describe '#publish!' do
     describe 'facet' do
       it 'publishes' do


### PR DESCRIPTION
During testing, I discovered a potential for a `409 Conflict` error in the `MasterFile#update_media_object!` callback. Reloading costs time, but it's the only way to avoid the conflict at this time. It's my hope that this is still an improvement over the old callback flow, even though it's not as fast as fully deferring the MediaObject's callback would be.