### PR TITLE
Sort administrative date facets by date descending from current date

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -80,8 +80,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'workflow_published_sim', label: 'Published', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow"
     config.add_facet_field 'created_by_sim', label: 'Created by', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow"
     config.add_facet_field 'read_access_virtual_group_ssim', label: 'External Group', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow", helper_method: :vgroup_display
-    config.add_facet_field 'date_digitized_sim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow"#, partial: 'blacklight/hierarchy/facet_hierarchy'
-    config.add_facet_field 'date_ingested_sim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow"
+    config.add_facet_field 'date_digitized_sim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow", sort: 'index', reverse: true
+    config.add_facet_field 'date_ingested_sim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| Ability.new(context.current_user, context.user_session).can? :create, MediaObject}, group: "workflow", sort: 'index', reverse: true
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,0 +1,36 @@
+Blacklight::Facet.module_eval do
+    def facet_paginator field_config, display_facet
+      Blacklight::Solr::FacetPaginator.new(display_facet.items,
+        sort: display_facet.sort,
+        offset: display_facet.offset,
+        limit: facet_limit_for(field_config.key),
+        reverse: field_config.reverse)
+    end
+end
+
+Blacklight::Solr::FacetPaginator.class_eval do
+    # all_facet_values is a list of facet value objects returned by solr,
+    # asking solr for n+1 facet values.
+    # options:
+    # :limit =>  number to display per page, or (default) nil. Nil means
+    #            display all with no previous or next. 
+    # :offset => current item offset, default 0
+    # :sort => 'count' or 'index', solr tokens for facet value sorting, default 'count'. 
+    # :reverse => true = descending, false = ascending
+    def initialize(all_facet_values, arguments)
+      # to_s.to_i will conveniently default to 0 if nil
+      @offset = arguments[:offset].to_s.to_i
+      @limit = arguments[:limit]
+      # count is solr's default
+      @sort = arguments[:sort] || "count"
+
+      @all = all_facet_values
+
+      @reverse = arguments[:reverse] || false
+    end
+
+    def items
+      sorted_items = @reverse ? @all.reverse : @all
+      items_for_limit(sorted_items)
+    end
+end


### PR DESCRIPTION
Required monkey patching blacklight in order to apply descending

This is currently wanted for MDPI but I think this could be useful for Avalon proper.  I'll check with POs so please wait before merging.