### PR TITLE
add test for relevancy weighting

### DIFF
--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -54,14 +54,16 @@
        -->
         <str name="qf">
           id
-          all_text_timv
-	  section_label_tesim
+          title_tesi^10.0
+          section_label_tesim^5.0
+          all_text_timv^1.0
           active_fedora_model_ssi
           object_type_si
         </str>
         <str name="pf">
-          all_text_timv^10.0
-	  section_label_tesim^5.0
+          title_tesi^10.0
+          section_label_tesim^5.0
+          all_text_timv^1.0
         </str>
 
        <str name="author_qf">

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -186,14 +186,20 @@ describe CatalogController do
         @media_object.save!
       end
       it "should find results based upon structure" do
-        get 'index', :q => 'CD 1'
+        get 'index', q: 'CD 1'
         expect(assigns(:document_list).count).to eq 1
-        expect(assigns(:document_list).map(&:id)). to eq [@media_object.id]
+        expect(assigns(:document_list).collect(&:id)). to eq [@media_object.id]
       end
       it 'should find results based upon section labels' do
-        get 'index', :q => 'Test Label'
+        get 'index', q: 'Test Label'
         expect(assigns(:document_list).count).to eq 1
-        expect(assigns(:document_list).map(&:id)). to eq [@media_object.id]
+        expect(assigns(:document_list).collect(&:id)). to eq [@media_object.id]
+      end
+      it 'should find items in correct relevancy order' do
+        media_object_1 = FactoryGirl.create(:fully_searchable_media_object, title: 'Test Label')
+        get 'index', q: 'Test Label'
+        expect(assigns(:document_list).count).to eq 2
+        expect(assigns(:document_list).collect(&:id)).to eq [media_object_1.id, @media_object.id]
       end
     end
 


### PR DESCRIPTION
Adds boost to title field and adds boosts to fields in qf. This seems to fix the immediate weighting problem. We might want to consider adjusting weights for other fields too (like creator).