### PR TITLE
Make AvalonAnnotation behave more like an ActiveRecord::Base

### DIFF
--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -13,28 +13,24 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
   alias_method :title, :label
   alias_method :title=, :label=
 
-  # Intialize an annotation with the start and end time set to the lengths of the master_file by default
-  # @param [MasterFile] :source the master file referenced by the annotation
-  def initialize(master_file: master_file)
-    super
-    @master_file = master_file
-    self.source = @master_file
+  after_initialize do
+    unless master_file.nil?
+      self.source = master_file
+    end
     selector_default!
     title_default!
-    self
   end
 
   # Mixs in in Avalon specific information from the master_file to a rdf annonation prior and creates a solr document
   # @return [Hash] a hash capable of submission to solr
   def to_solr
-    init_masterfile if @master_file.nil?
     solr_hash = {}
     # TODO: User Key via parsing of User URI
     #byebug
     solr_hash[:id] = solr_id
     solr_hash[:title_ssi] = title
-    solr_hash[:master_file_uri_ssi] = @master_file.rdf_uri
-    solr_hash[:master_file_rdf_type_ssi] = @master_file.rdf_type
+    solr_hash[:master_file_uri_ssi] = master_file.rdf_uri
+    solr_hash[:master_file_rdf_type_ssi] = master_file.rdf_type
     solr_hash[:start_time_fsi] = start_time
     solr_hash[:end_time_fsi] = end_time
     solr_hash[:mediafragment_uri_ssi] = mediafragment_uri
@@ -63,24 +59,28 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
   # Sets the default selector to a start time of 0 and an end time of the master file length
   def selector_default!
     self.start_time = 0
-    self.end_time = @master_file.duration || 1
+    self.end_time = master_file.duration || 1
   end
 
   # Set the default title to be the label of the master_file
   def title_default!
-    self.title = @master_file.label
+    self.title = master_file.label
   end
 
   # Sets the class variable @master_file by finding the master referenced in the source uri
-  def init_masterfile
-    @master_file = MasterFile.find(source.split('/').last)
+  def master_file
+    @master_file ||= MasterFile.find(source.split('/').last)
   end
 
+  def master_file=(value)
+    @master_file = value
+  end
+  
   # Calcuates the mediafragment_uri based on either the internal fragment value or start and end times
   # @return [String] the uri with time bounding
   def mediafragment_uri
-    @master_file.rdf_uri + "?#{internal.fragment_value.object}"
+    master_file.rdf_uri + "?#{internal.fragment_value.object}"
   rescue
-    @master_file.rdf_uri + "?t=#{start_time},#{end_time}"
+    master_file.rdf_uri + "?t=#{start_time},#{end_time}"
   end
 end

--- a/db/migrate/20160511155417_create_annotations.active_annotations.rb
+++ b/db/migrate/20160511155417_create_annotations.active_annotations.rb
@@ -1,0 +1,10 @@
+# This migration comes from active_annotations (originally 20160422052041)
+class CreateAnnotations < ActiveRecord::Migration
+  def change
+    create_table :annotations do |t|
+      t.string :uuid
+      t.string :source_uri
+      t.text   :annotation
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,30 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160428133859) do
+ActiveRecord::Schema.define(version: 20160511155417) do
 
-  create_table "blacklight_folders_folder_items", force: true do |t|
-    t.integer  "folder_id",   null: false
-    t.integer  "bookmark_id", null: false
-    t.integer  "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "annotations", force: true do |t|
+    t.string "uuid"
+    t.string "source_uri"
+    t.text   "annotation"
   end
-
-  add_index "blacklight_folders_folder_items", ["bookmark_id"], name: "index_blacklight_folders_folder_items_on_bookmark_id"
-  add_index "blacklight_folders_folder_items", ["folder_id"], name: "index_blacklight_folders_folder_items_on_folder_id"
-
-  create_table "blacklight_folders_folders", force: true do |t|
-    t.string   "name"
-    t.integer  "user_id",                       null: false
-    t.string   "user_type",                     null: false
-    t.string   "visibility"
-    t.integer  "number_of_members", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "blacklight_folders_folders", ["user_id", "user_type"], name: "index_blacklight_folders_folders_on_user_id_and_user_type"
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",       null: false

--- a/spec/models/avalon_annonation_spec.rb
+++ b/spec/models/avalon_annonation_spec.rb
@@ -20,11 +20,8 @@ describe AvalonAnnotation do
   let(:annotation) { AvalonAnnotation.new(master_file: video_master_file) }
 
   describe 'creating an annotation' do
-    before :each do
-      annotation = AvalonAnnotation.new(master_file: video_master_file)
-    end
     it 'sets the master file when creating the object' do
-      expect(annotation.master_file.id).to eq(video_master_file.id)
+      expect(annotation.master_file.pid).to eq(video_master_file.pid)
     end
     it 'sets the source uri' do
       expect(annotation.source).not_to be_nil
@@ -42,6 +39,12 @@ describe AvalonAnnotation do
     end
     it 'sets the title to the master_file label by default' do
       expect(annotation.title).to match(video_master_file.label)
+    end
+    
+    it 'loads the master_file' do
+      annotation.save
+      new_instance = AvalonAnnotation.find_by(id: annotation.id)
+      expect(new_instance.master_file.pid).to eq(video_master_file.pid)
     end
   end
   describe 'aliases for Avalon Annotation' do
@@ -71,8 +74,8 @@ describe AvalonAnnotation do
     end
   end
   it 'can load the master_file based on the uri' do
-    mf = annotation.init_masterfile
-    expect(mf.id).to eq(video_master_file.id)
+    mf = annotation.master_file
+    expect(mf.pid).to eq(video_master_file.pid)
   end
   describe 'selector' do
     it 'can create the selector using the start and end time' do
@@ -94,5 +97,4 @@ describe AvalonAnnotation do
       expect { annotation.destroy }.not_to raise_error
     end
   end
-
 end


### PR DESCRIPTION
Don't override `#initialize` on an ActiveRecord model; use `after_initialize` callback instead. Treat `#master_file` like any a regular, non-persisted attribute.