### PR TITLE
Use numericality validator for all start/end time validations instead of throwing argument errors

### DIFF
--- a/app/controllers/playlist_items_controller.rb
+++ b/app/controllers/playlist_items_controller.rb
@@ -8,25 +8,22 @@ class PlaylistItemsController < ApplicationController
     comment = playlist_item_params[:comment]
     start_time = time_str_to_milliseconds playlist_item_params[:start_time]
     end_time = time_str_to_milliseconds playlist_item_params[:end_time]
-    messages = []
-    messages << 'Title is required.' if title.blank?
-    messages << "Specified start time not valid." unless numeric?(start_time)
-    messages << "Specified end time not valid." unless numeric?(end_time)
-    unless messages.empty?
-      render json: { message: messages.join(' ') }, status: 400 and return
-    end
     annotation = AvalonAnnotation.new(master_file: MasterFile.find(playlist_item_params[:master_file_id]))
     annotation.title = title
     annotation.comment = comment
     annotation.start_time = start_time
     annotation.end_time = end_time
-    unless annotation.save!
+    unless annotation.valid?
+      render json: { message: annotation.errors.full_messages }, status: 400 and return
+    end
+    unless annotation.save
       render json: { message: "Item was not created: #{annotation.errors.full_messages}" }, status: 500 and return
     end
     if PlaylistItem.create(playlist: @playlist, annotation: annotation)
       render json: { message: "Add to playlist was successful. See it: #{view_context.link_to("here", playlist_url(@playlist))}" }, status: 201 and return
     end
-    render nothing: true, status: 500 and return
+  rescue StandardError => error
+    render json: { message: "Item was not created: #{error.message}"}, status: 500 and return
   end
 
   def update
@@ -36,7 +33,7 @@ class PlaylistItemsController < ApplicationController
     annotation.comment = params[:comment]
     annotation.start_time = time_str_to_milliseconds params[:start_time]
     annotation.end_time = time_str_to_milliseconds params[:end_time]
-    if annotation.save!
+    if annotation.save
       flash[:success] = "Playlist item details saved successfully."
     else
       flash[:error] = "Playlist item details could not be saved: #{annotation.errors.full_messages}"
@@ -45,10 +42,6 @@ class PlaylistItemsController < ApplicationController
   end
 
   private
-
-  def numeric? n
-    Float(n) != nil rescue false
-  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_playlist

--- a/spec/controllers/playlist_items_controller_spec.rb
+++ b/spec/controllers/playlist_items_controller_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe PlaylistItemsController, type: :controller do
   # PlaylistItem. As you add validations to PlaylistItem, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) do
-    { title: Faker::Lorem.word, start_time: 0.0, end_time: "00:01:37", master_file_id: master_file.pid }
+    { title: Faker::Lorem.word, start_time: "00:00:00", end_time: "00:01:37", master_file_id: master_file.pid }
   end
 
   let(:invalid_attributes) do
-    { playlist_id: 'not-a-playlist-id', master_file_id: 'avalon:bad-pid', start_time: 'not-a-time', end_time: 'not-a-time' }
+    { title: "", start_time: 'not-a-time', end_time: 'not-a-time' }
   end
 
   let(:invalid_times) do
@@ -23,7 +23,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
 
   let(:user) { login_as :user }
   let(:playlist) { Playlist.create!({ title: Faker::Lorem.word, visibility: Playlist::PUBLIC, user: user }) }
-  let(:master_file) { FactoryGirl.create(:master_file) }
+  let(:master_file) { FactoryGirl.create(:master_file, duration: "100000") }
 
 
   describe 'POST #create' do
@@ -66,14 +66,10 @@ RSpec.describe PlaylistItemsController, type: :controller do
         post :create, { playlist_id: playlist.to_param, playlist_item: invalid_times }, valid_session
         expect(response).to have_http_status(:bad_request)
       end
-      it 'invalid playlist_id responds with a 400 BAD REQUEST' do
-        post :create, { playlist_id: playlist.to_param, playlist_item: invalid_attributes }, valid_session
-        expect(response).to have_http_status(:bad_request)
-      end
     end
   end
   describe 'PATCH #update' do
-    let!(:video_master_file) { FactoryGirl.create(:master_file) }
+    let!(:video_master_file) { FactoryGirl.create(:master_file, duration: "200000") }
     let!(:annotation) { AvalonAnnotation.create(master_file: video_master_file, title: Faker::Lorem.word, comment: Faker::Lorem.sentence, start_time: 1000, end_time: 2000) }
     let!(:playlist_item) { PlaylistItem.create!(playlist_id: playlist.id, annotation_id: annotation.id) }
 

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
     file_format {'Moving image'}
     percent_complete {"#{rand(100)}"}
     workflow_name 'avalon'
+    duration {'100'}
     mediaobject {FactoryGirl.create(:media_object)}
 
     factory :master_file_with_derivative do

--- a/spec/models/avalon_annonation_spec.rb
+++ b/spec/models/avalon_annonation_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 
 describe AvalonAnnotation do
-  subject(:video_master_file) { FactoryGirl.create(:master_file) }
+  subject(:video_master_file) { FactoryGirl.create(:master_file, duration: "1") }
   #subject(:sound_master_file) { FactoryGirl.create(:master_file_sound) }
   let(:annotation) { AvalonAnnotation.new(master_file: video_master_file) }
 
@@ -49,11 +49,11 @@ describe AvalonAnnotation do
 
     it 'can store start and end times' do
       annotation.start_time = 0.5
-      annotation.end_time = 2.5
+      annotation.end_time = 0.75
       annotation.save!
       annotation.reload
       expect(annotation.start_time).to eq(0.5)
-      expect(annotation.end_time).to eq(2.5)
+      expect(annotation.end_time).to eq(0.75)
     end
   end
   describe 'aliases for Avalon Annotation' do
@@ -114,23 +114,23 @@ describe AvalonAnnotation do
     describe 'negative times' do
       it 'raises an ArgumentError when start_time is negative' do
         annotation.start_time = -1
-        expect { annotation.save }.to raise_error(ArgumentError)
+        expect(annotation).not_to be_valid
       end
       it 'raises an ArgumentError when end_time is negative' do
         annotation.end_time = -1
-        expect { annotation.save }.to raise_error(ArgumentError)
+        expect(annotation).not_to be_valid
       end
     end
     describe 'start and end time spacing' do
       it 'raises an error when the end time preceeds the start time' do
         annotation.end_time = 0
         annotation.start_time = 1
-        expect { annotation.save }.to raise_error(ArgumentError)
+        expect(annotation).not_to be_valid
       end
       it 'raises an error when the end time equals the start time' do
         annotation.end_time = 0
         annotation.start_time = 0
-        expect { annotation.save }.to raise_error(ArgumentError)
+        expect(annotation).not_to be_valid
       end
     end
     describe 'duration' do
@@ -138,7 +138,7 @@ describe AvalonAnnotation do
         annotation.master_file.duration = '8'
         annotation.master_file.save!
         annotation.end_time = 60
-        expect { annotation.save }.to raise_error(ArgumentError)
+        expect(annotation).not_to be_valid
       end
     end
   end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Playlist, type: :model do
       v_two_annotation.start_time = 2
       v_two_annotation.end_time = 3
       v_two_annotation.save!
+      v_one_annotation.end_time = 1
+      v_one_annotation.save!
       expect(@playlist.related_annotations_time_contrained(PlaylistItem.first).size).to eq(0)
     end
     def setup_playlist


### PR DESCRIPTION
I believe this should also fix the failing tests in develop