### PR TITLE
Restore active_annotations migration

### DIFF
--- a/db/migrate/20160511155417_create_annotations.active_annotations.rb
+++ b/db/migrate/20160511155417_create_annotations.active_annotations.rb
@@ -1,0 +1,10 @@
+# This migration comes from active_annotations (originally 20160422052041)
+class CreateAnnotations < ActiveRecord::Migration
+  def change
+    create_table :annotations do |t|
+      t.string :uuid
+      t.string :source_uri
+      t.text   :annotation
+    end
+  end
+end


### PR DESCRIPTION
This reverts the commit ce6569b5a1625191625a97203c97146f037cf087.