### PR TITLE
Fix for playlist item creation failing with default end time

### DIFF
--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -13,7 +13,7 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
 
   validates :master_file, :title, :start_time, presence: true
   validates :start_time, numericality: { greater_than_or_equal_to: 0, message: "must be greater than or equal to 0"}
-  validates :end_time, numericality: { greater_than: Proc.new {|a| Float(a.start_time) rescue 0}, less_than_or_equal_to: Proc.new {|a| a.master_file.duration.to_f rescue -1}, message: "must be between start time and end of section"}
+  validates :end_time, numericality: { greater_than: Proc.new {|a| Float(a.start_time) rescue 0}, less_than_or_equal_to: Proc.new {|a| a.master_file.derivatives.map {|d| d.duration.to_f }.max rescue -1}, message: "must be between start time and end of section"}
 
   after_initialize do
     selector_default!

--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -12,12 +12,28 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
   alias_method :title=, :label=
 
   validates :master_file, :title, :start_time, presence: true
-  validates :start_time, numericality: { greater_than_or_equal_to: 0, message: "must be greater than or equal to 0"}
-  validates :end_time, numericality: { greater_than: Proc.new {|a| Float(a.start_time) rescue 0}, less_than_or_equal_to: Proc.new {|a| a.master_file.derivatives.map {|d| d.duration.to_f }.max rescue -1}, message: "must be between start time and end of section"}
+  validates :start_time, numericality: { greater_than_or_equal_to: 0, message: "must be greater than or equal to 0" }
+  validates :end_time, numericality: { 
+    greater_than: Proc.new { |a| Float(a.start_time) rescue 0 }, 
+    less_than_or_equal_to: Proc.new { |a| a.max_time }, 
+    message: "must be between start time and end of section"
+  }
 
   after_initialize do
     selector_default!
     title_default!
+  end
+
+  # This function determines the max time for a masterfile and its derivatives
+  # Used for determining the maximum possible end time for an annotation
+  # @return [float] the largest end time or -1 if no durations present
+  def max_time
+    max = -1
+    max = master_file.duration.to_f if master_file.duration.present?
+    master_file.derivatives.each do |derivative|
+      max = derivative.duration.to_f if derivative.duration.present? && derivative.duration.to_f > max
+    end
+    max
   end
 
   # Mixs in in Avalon specific information from the master_file to a rdf annonation prior and creates a solr document

--- a/spec/controllers/avalon_annotation_controller_spec.rb
+++ b/spec/controllers/avalon_annotation_controller_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 
 describe AvalonAnnotationController do
-  subject(:video_master_file) { FactoryGirl.create(:master_file) }
+  subject(:video_master_file) { FactoryGirl.create(:master_file_with_derivative) }
   let(:annotation) { AvalonAnnotation.new(master_file: video_master_file) }
 
   before :all do

--- a/spec/models/avalon_annonation_spec.rb
+++ b/spec/models/avalon_annonation_spec.rb
@@ -134,11 +134,16 @@ describe AvalonAnnotation do
       end
     end
     describe 'duration' do
+      subject(:video_master_file) { FactoryGirl.create(:master_file, duration: "8", derivatives: [derivative, derivative2]) }
+      let(:derivative) { FactoryGirl.create(:derivative, duration: "12") }
+      let(:derivative2) { FactoryGirl.create(:derivative, duration: "10") }
       it 'raises an error when end time exceeds the duration' do
-        annotation.master_file.duration = '8'
-        annotation.master_file.save!
         annotation.end_time = 60
         expect(annotation).not_to be_valid
+      end
+      it 'allows end times longer than master_file duration but not longer than the longest derivative' do
+        annotation.end_time = 12
+        expect(annotation).to be_valid
       end
     end
   end


### PR DESCRIPTION
Derivatives might be slightly longer than their master files so the annotation validations need to account for that.