### PR TITLE
Use the filename instead of whole path when testing if pid prefix is …

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -468,6 +468,15 @@ class MasterFile < ActiveFedora::Base
     is_video? ? 'dctypes:MovingImage' : 'dctypes:Sound'
   end
 
+  def self.post_processing_move_filename(oldpath, options = {})
+    prefix = options[:pid].tr(':', '_')
+    if File.basename(oldpath).start_with?(prefix)
+      File.basename(oldpath)
+    else
+      "#{prefix}-#{File.basename(oldpath)}"
+    end
+  end
+
   protected
 
   def mediainfo
@@ -642,19 +651,10 @@ class MasterFile < ActiveFedora::Base
     when 'move'
       move_path = Avalon::Configuration.lookup('master_file_management.path')
       raise '"path" configuration missing for master_file_management strategy "move"' if move_path.blank?
-      newpath = File.join(move_path, post_processing_move_filename(file_location, pid: self.pid))
+      newpath = File.join(move_path, MasterFile.post_processing_move_filename(file_location, pid: pid))
       AvalonJobs.move_masterfile self.pid, newpath
     else
       # Do nothing
-    end
-  end
-
-  def post_processing_move_filename(oldpath, options={})
-    prefix = options[:pid].gsub(":","_")
-    if oldpath.start_with?(prefix)
-      oldpath
-    else
-      "#{prefix}-#{File.basename(oldpath)}"
     end
   end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -458,4 +458,20 @@ describe MasterFile do
       end
     end
   end
+
+  describe '#post_processing_move_filename' do
+    let(:pid) { 'avalon:12345' }
+    let(:pid_prefix) { 'avalon_12345' }
+    let(:path) { '/path/to/video.mp4' }
+    it 'prepends the pid' do
+      expect(MasterFile.post_processing_move_filename(path, pid: pid).starts_with?(pid_prefix)).to be_truthy
+    end
+    it 'returns a filename' do
+      expect(File.dirname(MasterFile.post_processing_move_filename(path, pid: pid))).to eq('.')
+    end
+    it 'does not prepend the pid if already present' do
+      path = '/path/to/avalon_12345-video.mp4'
+      expect(MasterFile.post_processing_move_filename(path, pid: pid).include?(pid_prefix + '-' + pid_prefix)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
…prepended to the filename

This caused us problems at IU when the move background job failed after prepending the pid and storing that in the master file's file_location.  Thus when delayed job reran the job, the pid got prepended.  This kept repeating until the pid was prepended 10+ times.