### PR TITLE
Pass along and use player reference in success callback to avoid…

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -39,7 +39,7 @@ class AvalonPlayer
       success: (mediaElement, domObject, player) =>
         @boundPrePlay = => if mejs.MediaFeatures.isAndroid then AndroidShim.androidPrePlay(this, player)
         @boundPrePlay()
-        if success_callback then success_callback()
+        if success_callback then success_callback(mediaElement, domObject, player)
 
     player_options[key] = val for key, val of opts
     @player = new MediaElementPlayer element, player_options

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -104,8 +104,8 @@ Unless required by applicable law or agreed to in writing, software distributed
       customError: '<%= t("media_objects.player.customError").html_safe %>',
       playlistItemDefaultTitle: '<%= @currentStream.embed_title.html_safe %>',
       autostart: <%= params[:autostart] == 'true' ? 'true' : 'false' %>,
-      success: function(mediaElement, domObject) {
-	avalonPlayer.player.media.addEventListener('ended', function(e) {
+      success: function(mediaElement, domObject, player) {
+	player.media.addEventListener('ended', function(e) {
 	    advancePlaylist();
 	}, false);
       }

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -90,8 +90,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 	customError: '<%= t("media_objects.player.customError").html_safe %>',
 	displayMediaFragment: true,
         autostart: <%= params[:autostart] == 'true' ? 'true' : 'false' %>,
-	success: function(mediaElement, domObject) {
-	  avalonPlayer.player.media.addEventListener('timeupdate', function(e) {
+	success: function(mediaElement, domObject, player) {
+	  player.media.addEventListener('timeupdate', function(e) {
 	    if (avalonPlayer.player.getCurrentTime() > avalonPlayer.stream_info.t.split(',')[1]) {
 	      avalonPlayer.player.media.stop();
 	      advancePlaylist();


### PR DESCRIPTION
…race condition where success callback is fired before AvalonPlayer constructor returns

Fixes #890