### PR TITLE
drop Ruby 2.1 of the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ notifications:
   irc: "chat.freenode.net#projectvov-updates"
 language: ruby
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
 addons:


### PR DESCRIPTION
fixes #823 by removing Ruby 2.1 from the Travis Build