### PR TITLE
Copy ENV["AVALON_XXXXX"] environment variables to ENV["XXXXX"] before…

### DIFF
--- a/ENVIRONMENT_CONFIG.md
+++ b/ENVIRONMENT_CONFIG.md
@@ -4,7 +4,7 @@ Most of Avalon's configuration settings can be replaced by environment variables
 ## Configuration Files and Equivalent Environment Variables 
 * `avalon.yml`: (*NOTE*: If `avalon.yml` exists, it will be used and the following variables ignored)
   * `APP_NAME`
-  * `AVALON_URL`: Base URL for the Avalon server
+  * `BASE_URL`: Base URL for the Avalon server
   * `DROPBOX_PATH`: Base path for Avalon dropbox
   * `DROPBOX_URI`: Base URI for Avalon dropbox
   * `FEDORA_NAMESPACE`: Fedora PID prefix

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Avalon
   class MissingUserId < Exception; end
 
   class Application < Rails::Application
+    require 'avalon/configuration'
     require 'rubyhorn/rest_client/ingest'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
@@ -73,7 +74,7 @@ module Avalon
     # of it stopping cold in production
     config.action_mailer.raise_delivery_errors = true
 
-    config.secret_key_base = ENV['AVALON_SECRET_KEY_BASE'] || ENV['SECRET_KEY_BASE'] || YAML.load(File.open("#{Rails.root}/config/secrets.yml"))[Rails.env]['secret_key_base']
+    config.secret_key_base = ENV['SECRET_KEY_BASE'] || YAML.load(File.open("#{Rails.root}/config/secrets.yml"))[Rails.env]['secret_key_base']
   end
 
   # Map config to the local namespace so we can use shorter references in

--- a/config/initializers/avalon.rb
+++ b/config/initializers/avalon.rb
@@ -5,6 +5,5 @@
 # out what is available. See lib/avalon/dropbox.rb for details on the API 
 require 'avalon/dropbox'
 require 'avalon/batch'
-require 'avalon/configuration'
 
 I18n.config.enforce_available_locales = true

--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -44,7 +44,7 @@ module Avalon
     end
     
     ENVIRONMENT_MAP = {
-      "AVALON_URL" => { key: 'domain', read_proc: ->(v){read_avalon_url(v)}, write_proc: ->(v){write_avalon_url(v)} },
+      "BASE_URL" => { key: 'domain', read_proc: ->(v){read_avalon_url(v)}, write_proc: ->(v){write_avalon_url(v)} },
       "DROPBOX_PATH" => { key: "dropbox.path" },
       "DROPBOX_URI" => { key: "dropbox.upload_uri" },
       "FEDORA_NAMESPACE" => { key: "fedora.namespace" },
@@ -78,8 +78,13 @@ module Avalon
       "Z3950_HOST" => { key: "bib_retriever.host", infer: { key: 'bib_retriever.protocol', value: 'zoom' } },
       "Z3950_PORT" => { key: "bib_retriever.port", read_proc: ->(v){coerce(v, :to_i)} },
       "Z3950_DATABASE" => { key: "bib_retriever.database" },
-      "Z3950_ATTRIBBUTE" => { key: "bib_retriever.attribute", read_proc: ->(v){coerce(v, :to_i)} }
+      "Z3950_ATTRIBUTE" => { key: "bib_retriever.attribute", read_proc: ->(v){coerce(v, :to_i)} }
     }
+
+    ENV.keys.select { |k| k =~ /^AVALON_/ }.each do |key|
+      ENV[key.split(/_/,2).last] = ENV[key]
+    end
+    
     
     def set(key, value, hash=@config_hash)
       this_key,sub_key = key.split(/\./,2)


### PR DESCRIPTION
… app initialization

This will allow you to prefix any environment variable with `AVALON_` to keep it from clashing with other processes' variables, while keeping the option to leave them unprefixed for the sake of clarity if Avalon is the only Rails service on the box.