### PR TITLE
add in a rake task and schedule to purge sessions more than 7 days old

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,3 +5,7 @@ job_type :locking_rake, "cd :path && :environment_variable=:environment script/l
 every 1.minute do
   locking_rake "avalon:batch:ingest", :lock_name => "batch_ingest"
 end
+
+every 6.hours do
+  rake 'avalon:session_cleanup'
+end

--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -18,6 +18,13 @@ namespace :avalon do
     `rake db:migrate`
     `rails generate active_annotations:install`
   end
+
+  desc 'clean out user sessions that have not been updated for 7 days'
+  task :session_cleanup => :environment do
+    sql = 'DELETE FROM sessions WHERE updated_at < DATE_SUB(NOW(), INTERVAL 7 DAY);'
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
   namespace :services do
     services = ["jetty", "felix", "delayed_job"]
     desc "Start Avalon's dependent services"
@@ -240,7 +247,7 @@ namespace :avalon do
           mf_obj = MasterFile.where("dc_identifier_tesim:#{container}").first
           unless mf_obj.present?
             item_errors += [{username: user['username'], playlist_id: playlist_obj.id, container: container, title: title, errors: ['Masterfile not found']}]
-            next 
+            next
           end
           item_count += 1
           puts "  Importing playlist item #{title}"
@@ -301,7 +308,7 @@ namespace :avalon do
         puts [api_token.token,api_token.username].join('|')
       end
     end
-    
+
     desc "Generate an API token for a user"
     task :generate => :environment do
       user = ENV['username']
@@ -313,7 +320,7 @@ namespace :avalon do
       new_token = ApiToken.create username: user, email: email, token: token
       puts new_token.token
     end
-    
+
     desc "Revoke an API token or all of a given user's API tokens"
     task :revoke => :environment do
       user = ENV['username']


### PR DESCRIPTION
Currently the ActiveRecord Sessions are never purged (IU found 5.3 million rows representing 2 years of sessions in our production db).  I've added in a rake task that runs every 6 hours and clears any session that hasn't been updated for a week.  We should probably also consider cherry-picking this into develop for a 6.0 feature.  Also in 6.0 we might want to make it more configurable, etc.

Also note if you have a large sessions table you'll want to do the first clear via SQL, ActiveRecord will probably timeout or otherwise dislike doing millions of rows in one pass.  