### PR TITLE
Add mime types from avalon 5.1 mime types initializer

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -5,3 +5,23 @@
 Mime::Type.register "application/n-triples", :nt
 Mime::Type.register "application/ld+json", :jsonld
 Mime::Type.register "text/turtle", :ttl
+
+#Copied from avalon 5.1
+# Mime::Type.register "text/html", :html
+# Mime::Type.register "application/pdf", :pdf
+# Mime::Type.register "image/jpeg2000", :jp2
+Mime::Type.register_alias "text/html", :textile
+Mime::Type.register_alias "text/html", :inline
+
+Mime::Type.register_alias "text/plain", :refworks_marc_txt
+Mime::Type.register_alias "text/plain", :openurl_kev
+Mime::Type.register "application/x-endnote-refer", :endnote
+Mime::Type.register "application/marc", :marc
+Mime::Type.register "application/marcxml+xml", :marcxml, 
+      ["application/x-marc+xml", "application/x-marcxml+xml", 
+       "application/marc+xml"]
+Mime::Type.register "application/x-www-urlform-encoded", :urlencoded
+
+# Add new mime types for use in respond_to blocks:
+# Mime::Type.register "text/richtext", :rtf
+# Mime::Type.register_alias "text/html", :iphone


### PR DESCRIPTION
This keeps the authorize route from bombing with a 500 NoMethodError.