### PR TITLE
Fix BrowseEverything without breaking web upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'rest-client'
 gem 'active_annotations', '~> 0.2.0'
 gem 'acts_as_list'
 gem 'api-pagination'
-gem 'browse-everything'
+gem 'browse-everything', '~> 0.10.5'
 gem 'bootstrap_form'
 gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
 gem 'roo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     bootstrap_form (2.5.0)
-    browse-everything (0.10.4)
+    browse-everything (0.10.5)
       bootstrap-sass
       dropbox-sdk (>= 1.6.2)
       font-awesome-rails
@@ -368,7 +368,7 @@ GEM
     json-ld (2.1.0)
       multi_json (~> 1.11)
       rdf (~> 2.1)
-    jwt (1.5.4)
+    jwt (1.5.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -655,7 +655,7 @@ DEPENDENCIES
   avalon-workflow!
   blacklight (~> 6.6)
   bootstrap_form
-  browse-everything
+  browse-everything (~> 0.10.5)
   byebug
   capistrano (~> 2.12.0)
   capybara
@@ -716,4 +716,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.0
+   1.13.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,9 +16,9 @@
 //= require turbolinks//
 
 // Required by Blacklight
-//= require blacklight/blacklight
-//= require browse_everything
 //= require jquery-ui
 //= require jquery.ui.nestedSortable
+//= require blacklight/blacklight
+//= require browse_everything
 
 //= require_tree .

--- a/app/assets/javascripts/file_browse.js.coffee
+++ b/app/assets/javascripts/file_browse.js.coffee
@@ -5,10 +5,11 @@ $ ->
   initialized = false
   $('#browse-btn').browseEverything()
     .show ->
-      skip_box = $('#web_upload input[name=workflow]').closest('span')
-        .clone().removeClass().css('margin-right','10px')
-      
-      $('.ev-cancel').before skip_box
+      unless $('#browse-everything input[name=workflow]').length > 0
+        skip_box = $('#web_upload input[name=workflow]').closest('span')
+          .clone().removeClass().css('margin-right','10px')
+        $('.ev-cancel').before skip_box
+
       $('.ev-providers .ev-container a').click()
       initialized = true
     .done (data) -> 

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -207,10 +207,10 @@ class MasterFilesController < ApplicationController
       params[:selected_files].each_value do |entry|
         file_path = URI.parse(entry[:url]).path.gsub(/\+/,' ')
         master_file = MasterFile.new
-        master_file.save( validate: false )
-        master_file.media_object = media_object
         master_file.setContent(File.open(file_path, 'rb'))
         master_file.set_workflow(params[:workflow])
+        master_file.save( validate: false )
+        master_file.media_object = media_object
 
         unless master_file.save
           flash[:error] = "There was a problem storing the file"

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -142,7 +142,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           </span>
           <a href="#" class="input-group-addon btn btn-default fileinput-exists" data-dismiss="fileinput">Remove</a>
           <span class="input-group-addon fileinput-exists" style="background-color: white; padding-top: 8px; padding-bottom: 2px; border: none;">
-            <%= check_box_tag(:workflow, 'skip_transcoding', false)%>
+            <%= check_box_tag(:workflow, 'skip_transcoding', false, id: nil)%>
             <%= label_tag(:skip_transcoding) do %>
               <div style="font-size: inherit;" class="tooltip-help" data-title="Skip Transcoding" data-tooltip="#skip-transcoding-tooltip">
                 Skip transcoding

--- a/config/initializers/dropbox_context.rb
+++ b/config/initializers/dropbox_context.rb
@@ -1,0 +1,6 @@
+BrowseEverythingController.before_filter do
+  if params[:context]
+    collection = Admin::Collection.find(params[:context])
+    browser.providers['file_system'].config[:home] = collection.dropbox_absolute_path
+  end
+end

--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -49,6 +49,7 @@ module Avalon
       "DROPBOX_URI" => { key: "dropbox.upload_uri" },
       "FEDORA_NAMESPACE" => { key: "fedora.namespace" },
       "FFMPEG_PATH" => { key: "ffmpeg.path" },
+      "MEDIA_PATH" => { key: "matterhorn.media_path" },
       "MEDIAINFO_PATH" => { key: "mediainfo.path" },
       "EMAIL_COMMENTS" => { key: "email.comments" },
       "EMAIL_NOTIFICATION" => { key: "email.notification" },

--- a/lib/avalon/dropbox.rb
+++ b/lib/avalon/dropbox.rb
@@ -84,8 +84,7 @@ module Avalon
 
   #  protected
     def find_open_files(files)
-      # TODO: uncomment next line
-      # Avalon::Batch.find_open_files(files, @base_directory)
+      Avalon::Batch.find_open_files(files, @base_directory)
     end
   end
 end


### PR DESCRIPTION
There were a few issues going on:

- A bug in `browse-everything` (fixed in 0.10.5)
- Load order that was causing `jquery-ui` to stomp on `bootstrap`
- Missing initializer that lets BE virtually chroot to collection directories
- Weirdness with the Skip Transcoding checkbox getting displayed twice
- Back-end workflow validation issue