### PR TITLE
Wrap omniauth-identity forms in the app layout and add bootstrap classes

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1157,3 +1157,10 @@ h5.panel-title {
   bottom: 6pt;
   width: 1em !important;
 }
+
+.omniauth-form {
+  width: 320px;
+  border: 2px solid #eee;
+  margin: 0px auto;
+  padding: 8px;
+}

--- a/app/controllers/auth_forms_controller.rb
+++ b/app/controllers/auth_forms_controller.rb
@@ -1,0 +1,31 @@
+class AuthFormsController < ApplicationController
+  def self.dispatcher(provider, phase)
+    klass = Class.new(ActionDispatch::Request) do
+      class_attribute :provider
+      class_attribute :phase
+    end
+    klass.provider = provider
+    klass.phase = phase
+    klass
+  end
+  
+  def render_form
+    render html: omniauth_form(request.class.provider, request.class.phase).html_safe, layout: true
+  end
+  
+  private
+  def omniauth_form(strategy_name, phase=:request_phase)
+    opts = Devise.omniauth_configs[strategy_name].options
+    strategy_class = Devise.omniauth_configs[strategy_name].strategy_class
+    strategy = strategy_class.new(opts)
+    html = strategy.send(phase).last.body.first.strip
+    doc = Nokogiri::HTML(html)
+    form = doc.at_xpath('//form')
+    form.xpath('label|input').to_a.in_groups_of(2).each do |label, input|
+      input['class'] = 'form-control'
+      label.replace('<div class="form-group"/>').first.add_child(label).add_next_sibling(input)
+    end
+    form.xpath('button').each { |btn| btn['class'] = 'btn btn-primary' }
+    %{<div class="omniauth-form container">#{form.to_html}</div>}
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,7 +15,7 @@
 class Users::SessionsController < Devise::SessionsController
   def new
     if Avalon::Authentication::VisibleProviders.length == 1
-      redirect_to user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider], params)
+      redirect_to user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider])
     else
       super
     end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -253,6 +253,14 @@ Devise.setup do |config|
     if provider[:provider] == :lti
       provider[:params].merge!({consumers: Avalon::Lti::Configuration})
     end
+    
+    if provider[:provider] == :identity
+      provider[:params].merge!({
+        on_login: AuthFormsController.action(:render_form, AuthFormsController.dispatcher(:identity, :request_phase)),
+        on_registration: AuthFormsController.action(:render_form, AuthFormsController.dispatcher(:identity, :registration_form))
+      })
+    end
+    
     config.omniauth provider[:provider], provider[:params]
   end
   if ENV['LTI_AUTH_KEY']

--- a/config/initializers/omniauth-identity.rb
+++ b/config/initializers/omniauth-identity.rb
@@ -1,1 +1,0 @@
-OmniAuth.config.form_css = OmniAuth::Form::DEFAULT_CSS + " h1 { width: 340px; } form { width: 320px; }"

--- a/spec/integration/auth_forms_spec.rb
+++ b/spec/integration/auth_forms_spec.rb
@@ -1,0 +1,27 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe AuthFormsController, type: :feature do
+  scenario "User reaches the login screen" do
+    visit "/users/auth/identity"
+    expect(page).to have_text('Avalon Media System')
+  end
+  
+  scenario "User reaches the registration screen" do
+    visit "/users/auth/identity/register"
+    expect(page).to have_text('Avalon Media System')
+  end
+end


### PR DESCRIPTION
This takes the auto-generated login and registration forms from `OmniAuth::Identity` and renders them within the Avalon layout with bootstrap controls. The result is a more integrated look and feel, and login error flash messages render properly. This is potentially extensible to other login mechanisms that rely on app-driven forms (like LDAP, but not OAuth or CAS), but right now it only works for Identity.