### PR TITLE
fix mejs button jumping out of correct location on window resize

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1164,3 +1164,7 @@ h5.panel-title {
   margin: 0px auto;
   padding: 8px;
 }
+
+div.mejs-button:last {
+  width: 25px;
+}


### PR DESCRIPTION
Fixes #1155 
This should be backported to 5 and pushed to production also.