### PR TITLE
Refactor embed assets

### DIFF
--- a/app/assets/javascripts/embed_player.js
+++ b/app/assets/javascripts/embed_player.js
@@ -1,4 +1,9 @@
 //= require jquery
+//= require mediaelement_rails/mediaelement-and-player
+//= require mediaelement-qualityselector/mep-feature-qualities
+//= require mediaelement-skin-avalon/mep-feature-responsive
+//= require keyboard_access
+//= require android_pre_play
 //= require avalon_player
 //= require mediaelement-title/mep-feature-title
 //= require me-logo

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -15,6 +15,12 @@
 */
 
 @import "bootstrap";
+@import "mediaelement-qualityselector/mep-feature-qualities";
+@import "mediaelement-skin-avalon/mejs-skin-avalon";
+@import "mediaelement-title/mejs-title";
+@import "me-logo";
+@import "font-awesome";
+@import "mediaelement-hd-toggle/mejs-hdtoggle";
 
 body {
     background-color: #000000;

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -43,7 +43,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     </section>
 
 <% content_for :page_scripts do %>
-
+  <%= javascript_include_tag 'embed_player' =%>
   <% features = ['playpause','current','progress','duration','tracks','volume','responsive', 'title'] %>
 
   <% if @master_file.is_video? %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( embed.css )
+Rails.application.config.assets.precompile += %w( embed_player.js )


### PR DESCRIPTION
Fixes #1206 
It is not desirable for embedded player to load full application assets, so pull them in as needed.
Still need to deal with configuration on Spruce for missing protocol in embed code.