### PR TITLE
Disable bib import if there's no value

### DIFF
--- a/app/assets/javascripts/import_button.js.coffee
+++ b/app/assets/javascripts/import_button.js.coffee
@@ -1,18 +1,27 @@
 # Copyright 2011-2015, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
-# Unless required by applicable law or agreed to in writing, software distributed 
+#
+# Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
 
 $ ->
-  import_button_html = '<div class="input-group-btn"><button type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes">Import</button></div>'
+  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes">Import</button></div>'
   $('div.import-button').append(import_button_html)
+  enable_bib_btn()
+  $('#media_object_bibliographic_id').keyup -> enable_bib_btn()
+
+enable_bib_btn = ->
+    if $('#media_object_bibliographic_id').val() == ""
+      $('#media_object_bibliographic_id_btn').prop('disabled', true)
+    else
+      $('#media_object_bibliographic_id_btn').prop('disabled', false)
+    return


### PR DESCRIPTION
fixes #1195 

I added some coffeescript that disables the import button if there isn't anything in the bib import field.
If there is an invalid import id, it will act like it used to, warning that there are missing fields.