### PR TITLE
Use active_fedora-noid for minting ids for collections, media objects, and master files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'hydra-head', '~> 10.1'
 gem 'active-fedora', '~> 11.0'
 gem 'active_fedora-datastreams'
+gem 'active_fedora-noid'
 gem 'blacklight', '~> 6.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,10 @@ GEM
       nom-xml (>= 0.5.1)
       om (~> 3.1)
       rdf-rdfxml (~> 2.0)
+    active_fedora-noid (2.0.0.beta3)
+      active-fedora (>= 9.7, < 12)
+      noid (~> 0.9)
+      rails (>= 4.2.6, < 6)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -421,6 +425,7 @@ GEM
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     netrc (0.11.0)
+    noid (0.9.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     nom-xml (0.5.4)
@@ -647,6 +652,7 @@ DEPENDENCIES
   active_annotations (~> 0.2.0)
   active_encode!
   active_fedora-datastreams
+  active_fedora-noid
   activerecord-session_store
   acts_as_list
   api-pagination

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -20,6 +20,7 @@ class Admin::Collection < ActiveFedora::Base
   include Hydra::AccessControls::Permissions
   include Hydra::AdminPolicyBehavior
   include ActiveFedora::Associations
+  include Identifier
 
   has_many :media_objects, class_name: 'MediaObject', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection
 

--- a/app/models/concerns/identifier.rb
+++ b/app/models/concerns/identifier.rb
@@ -1,0 +1,15 @@
+require 'active_fedora/noid'
+
+module Identifier
+  extend ActiveSupport::Concern
+
+  def assign_id
+    noid_service.mint
+  end
+
+  private
+
+  def noid_service
+    @noid_service ||= ActiveFedora::Noid::Service.new
+  end
+end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -26,6 +26,7 @@ class MasterFile < ActiveFedora::Base
   include Rails.application.routes.url_helpers
   include Permalink
   include FrameSize
+  include Identifier
 
   belongs_to :media_object, class_name: 'MediaObject', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
   has_many :derivatives, class_name: 'Derivative', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isDerivationOf, dependent: :destroy

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -19,6 +19,7 @@ class MediaObject < ActiveFedora::Base
   include MediaObjectMods
   include Avalon::Workflow::WorkflowModelMixin
   include Permalink
+  include Identifier
   require 'avalon/controlled_vocabulary'
 
   include Kaminari::ActiveFedoraModelExtension

--- a/config/initializers/active_fedora.rb
+++ b/config/initializers/active_fedora.rb
@@ -1,0 +1,2 @@
+ActiveFedora::Base.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
+ActiveFedora::Base.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri


### PR DESCRIPTION
Don't merge this yet!

Possible solution for #1291.  Related to #836.

Fixes http forwarding to https and embed in http context.  Allows for removing apache and passenger directives allowing escaped slashes.
