### PR TITLE
Add about_page and avalon-about gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem 'activerecord-session_store'
 gem 'whenever', git: "https://github.com/javan/whenever.git", require: false
 gem 'with_locking'
 gem 'parallel'
+gem 'avalon-about', git: "https://github.com/avalonmediasystem/avalon-about.git"
+gem 'about_page', git: "https://github.com/avalonmediasystem/about_page.git", tag: "avalon-r6"
 
 #MediaElement.js related
 gem 'mediaelement_rails', git: 'https://github.com/avalonmediasystem/mediaelement_rails.git', branch: 'captions'

--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'activerecord-session_store'
 gem 'whenever', git: "https://github.com/javan/whenever.git", require: false
 gem 'with_locking'
 gem 'parallel'
-gem 'avalon-about', git: "https://github.com/avalonmediasystem/avalon-about.git"
+gem 'avalon-about', git: "https://github.com/avalonmediasystem/avalon-about.git", tag: "avalon-r6"
 gem 'about_page', git: "https://github.com/avalonmediasystem/about_page.git", tag: "avalon-r6"
 
 #MediaElement.js related

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/avalonmediasystem/about_page.git
+  revision: e4a87a7aec112b1ccdfa8f4cc71e0ee7ccdf66a6
+  tag: avalon-r6
+  specs:
+    about_page (0.3.1)
+      rails (>= 3.2)
+
+GIT
+  remote: https://github.com/avalonmediasystem/avalon-about.git
+  revision: 4bb6dda8426bfdad0969bbadb8f921c633d1cda0
+  specs:
+    avalon-about (0.1.0)
+      about_page
+      mediainfo
+
+GIT
   remote: https://github.com/avalonmediasystem/avalon-workflow.git
   revision: 1dd1f63b8110809c42141952890934b9f0f8041e
   branch: hydra10
@@ -688,6 +704,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  about_page!
   active-fedora (~> 11.0)
   active_annotations (~> 0.2.0)
   active_encode!
@@ -695,6 +712,7 @@ DEPENDENCIES
   activerecord-session_store
   acts_as_list
   api-pagination
+  avalon-about!
   avalon-workflow!
   blacklight (~> 6.6)
   bootstrap_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/avalon-about.git
-  revision: 4bb6dda8426bfdad0969bbadb8f921c633d1cda0
+  revision: 93cd70f348e04ee0affeb4543e57d630c976efe1
+  tag: avalon-r6
   specs:
     avalon-about (0.1.0)
       about_page

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,7 +52,7 @@
 @import "blacklight_folders/folders";
 @import "blacklight_folders/nestable";
 
-
+@import "about_page";
 @import "admin";
 @import "blacklight";
 @import "branding";

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,6 +38,7 @@ class Ability
         can :inspect, MediaObject
         can :manage, Admin::Group
         can :manage, Admin::Collection
+        can :read, :about_page
       end
 
       if @user_groups.include? "group_manager"

--- a/config/initializers/about_page.rb
+++ b/config/initializers/about_page.rb
@@ -1,0 +1,17 @@
+AboutPage.configure do |config|
+  config.app          = { :name => Avalon.name, :version => Avalon::VERSION }
+  config.environment  = AboutPage::Environment.new({
+    'Ruby/Rails' => /^(RUBY|RAILS|RACK|GEM_|rvm)/
+  })
+  config.request = AboutPage::RequestEnvironment.new({
+    'HTTP Server' => /^(SERVER_|POW_)/
+  })
+  config.fedora           = AboutPage::Fedora.new(ActiveFedora.fedora.connection)
+  config.solr             = AboutPage::Solr.new(ActiveFedora.solr.conn, :numDocs => 1)
+  config.database         = Avalon::About::Database.new(User)
+  config.matterhorn       = Avalon::About::Matterhorn.new(Rubyhorn)
+  config.mediainfo        = Avalon::About::MediaInfo.new(:version => '>=0.7.59')
+  config.streaming_server = Avalon::About::RTMPServer.new(URI.parse(Avalon::Configuration.lookup('streaming.rtmp_base')).host)
+  config.git_log          = AboutPage::GitLog.new(limit: 15) if Rails.env.development?
+  config.dependencies     = AboutPage::Dependencies.new
+end

--- a/config/initializers/about_page.rb
+++ b/config/initializers/about_page.rb
@@ -12,6 +12,8 @@ AboutPage.configure do |config|
   config.matterhorn       = Avalon::About::Matterhorn.new(Rubyhorn)
   config.mediainfo        = Avalon::About::MediaInfo.new(:version => '>=0.7.59')
   config.streaming_server = Avalon::About::RTMPServer.new(URI.parse(Avalon::Configuration.lookup('streaming.rtmp_base')).host)
+  config.resque           = Avalon::About::Resque.new(::Resque)
+  config.resque_scheduler = Avalon::About::ResqueScheduler.new(::Resque::Scheduler)
   config.git_log          = AboutPage::GitLog.new(limit: 15) if Rails.env.development?
   config.dependencies     = AboutPage::Dependencies.new
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     mount AboutPage::Engine => '/about(.:format)', as: 'about_page'
   end
   get '/about(.:format)', to: redirect('/')
+  get '/about/health(.:format)', to: redirect('/')
 
   require 'resque/server'
   mount Resque::Server, at: '/jobs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,14 +136,14 @@ Rails.application.routes.draw do
 
   match "/oembed", to: 'master_files#oembed', via: [:get]
 
-  def can_see?(thing, scope=nil)
+  def route_can?(action, thing, scope=nil)
     lambda do |request|
       warden = request.env['warden']
-      warden.authenticate? && Ability.new(warden.user(scope), warden.session(scope)).can?(:manage, thing)
+      warden.authenticate? && Ability.new(warden.user(scope), warden.session(scope)).can?(action, thing)
     end
   end
 
-  constraints(can_see?(Admin::Collection)) do
+  constraints(route_can?(:manage, Admin::Collection)) do
     mount AboutPage::Engine => '/about(.:format)', as: 'about_page'
   end
   get '/about(.:format)', to: redirect('/')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@
   end
 
   mount BrowseEverything::Engine => '/browse'
+  mount AboutPage::Engine => '/about(.:format)', :as => 'about_page'
 
   # Avalon routes
   match "/authorize", to: 'derivatives#authorize', via: [:get, :post]
@@ -135,7 +136,7 @@
   end
 
   match "/oembed", to: 'master_files#oembed', via: [:get]
-  
+
   require 'resque/server'
   mount Resque::Server, at: '/jobs'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,7 +143,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints(route_can?(:manage, Admin::Collection)) do
+  constraints(route_can?(:read, :about_page)) do
     mount AboutPage::Engine => '/about(.:format)', as: 'about_page'
   end
   get '/about(.:format)', to: redirect('/')

--- a/spec/features/secure_routes_spec.rb
+++ b/spec/features/secure_routes_spec.rb
@@ -16,10 +16,10 @@ require 'rails_helper'
 
 describe "Secure Routes" do
   after { Warden.test_reset! }
+  let!(:admin) { FactoryGirl.create(:administrator) }
+  let!(:user)  { FactoryGirl.create(:user) }
+
   describe "/about" do
-    let!(:admin) { FactoryGirl.create(:administrator) }
-    let!(:user)  { FactoryGirl.create(:user) }
-    
     it "should provide access to admins" do
       login_as admin, scope: :user
       visit '/about'
@@ -35,6 +35,26 @@ describe "Secure Routes" do
     it "should not provide access to anonymous users" do
       login_as user, scope: :user
       visit '/about'
+      page.should have_content('Sample Content')
+    end
+  end
+
+  describe "/about/health" do  
+    it "should provide access to admins" do
+      login_as admin, scope: :user
+      visit '/about/health'
+      page.should have_content('Service Health')
+    end
+
+    it "should not provide access to regular users" do
+      login_as user, scope: :user
+      visit '/about/health'
+      page.should have_content('Sample Content')
+    end
+
+    it "should not provide access to anonymous users" do
+      login_as user, scope: :user
+      visit '/about/health'
       page.should have_content('Sample Content')
     end
   end

--- a/spec/features/secure_routes_spec.rb
+++ b/spec/features/secure_routes_spec.rb
@@ -1,0 +1,41 @@
+# Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe "Secure Routes" do
+  after { Warden.test_reset! }
+  describe "/about" do
+    let!(:admin) { FactoryGirl.create(:administrator) }
+    let!(:user)  { FactoryGirl.create(:user) }
+    
+    it "should provide access to admins" do
+      login_as admin, scope: :user
+      visit '/about'
+      page.should have_content('Environment')
+    end
+
+    it "should not provide access to regular users" do
+      login_as user, scope: :user
+      visit '/about'
+      page.should have_content('Sample Content')
+    end
+
+    it "should not provide access to anonymous users" do
+      login_as user, scope: :user
+      visit '/about'
+      page.should have_content('Sample Content')
+    end
+  end
+end


### PR DESCRIPTION
Installs and configures the about_page and avalon-about gems with new support for Fedora 4. Test by running `bundle install` and navigating to `/about` and `/about/health`