### PR TITLE
Forward port changes to #image_for from Avalon 5.x

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,8 +39,8 @@ module ApplicationHelper
   def image_for(document)
     master_file_id = document["section_id_ssim"].try :first
 
-    video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image') } rescue 0
-    audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording') } rescue 0
+    video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image'.titleize) } rescue 0
+    audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording'.titleize) } rescue 0
 
     if master_file_id
       if video_count > 0

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -107,15 +107,15 @@ describe ApplicationHelper do
       expect(helper.image_for(doc)).to eq(nil)
     end
     it "should return audio icon" do
-      doc = {"avalon_resource_type_ssim" => ['sound recording', 'sound recording'] }
+      doc = {"avalon_resource_type_ssim" => ['Sound Recording', 'Sound Recording'] }
       expect(helper.image_for(doc).start_with?('/assets/audio_icon')).to be_truthy
     end
     it "should return video icon" do
-      doc = {"avalon_resource_type_ssim" => ['moving image'] }
+      doc = {"avalon_resource_type_ssim" => ['Moving Image'] }
       expect(helper.image_for(doc).start_with?('/assets/video_icon')).to be_truthy
     end
     it "should return hybrid icon" do
-      doc = {"avalon_resource_type_ssim" => ['moving image', 'sound recording'] }
+      doc = {"avalon_resource_type_ssim" => ['Moving Image', 'Sound Recording'] }
       expect(helper.image_for(doc).start_with?('/assets/hybrid_icon')).to be_truthy
     end
     it "should return nil when only unprocessed video" do
@@ -123,7 +123,7 @@ describe ApplicationHelper do
       expect(helper.image_for(doc)).to eq(nil)
     end
     it "should return thumbnail" do
-      doc = {"section_id_ssim" => ['1'], "avalon_resource_type_ssim" => ['moving image'] }
+      doc = {"section_id_ssim" => ['1'], "avalon_resource_type_ssim" => ['Moving Image'] }
       expect(helper.image_for(doc)).to eq('/master_files/1/thumbnail')
     end
   end


### PR DESCRIPTION
Fixes #1355.

There was a change in avalon 5.x that missed getting pulled into develop.  This PR does that which fixes thumbnails displaying in search results.