### PR TITLE
Use ruby DNS resolution

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'resolv-replace'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Fixes #1383

Use `resolv-replace` for pure ruby DNS resolution instead of `Socket.gethostbyname`

`gethostbyname` blocks the Ruby interpreter during lookup, which can bog things down, especially in multithreaded code. See [DNS, eglibc and resolv-replace on Heroku](http://blog.gregburek.com/2015/02/22/dns-eglibc-and-resolv-replace-on-heroku/).

NOTE: `resolv.rb` does have some incompatibilities, like its inability to resolve `nil` hostnames. We should keep an eye on it.