### PR TITLE
Make batch ingest less verbose when no new packages found

### DIFF
--- a/lib/avalon/batch/ingest.rb
+++ b/lib/avalon/batch/ingest.rb
@@ -30,7 +30,7 @@ module Avalon
       def ingest
         # Scans dropbox for new batch packages
         new_packages = collection.dropbox.find_new_packages
-        logger.info "<< Found #{new_packages.count} new packages for collection #{collection.name} >>"
+        logger.info "<< Found #{new_packages.count} new packages for collection #{collection.name} >>" if new_packages.count > 0 
         # Extract package and process
         new_packages.each do |package|
           begin

--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -60,6 +60,7 @@ namespace :avalon do
       require 'avalon/batch/ingest'
 
       WithLocking.run(name: 'batch_ingest') do
+        logger.info "<< Scanning for new batch packages in existing collections >>"
         Admin::Collection.all.each do |collection|
           Avalon::Batch::Ingest.new(collection).ingest
         end


### PR DESCRIPTION
Batch is too verbose, especially in production where there are hundred of collections.