### PR TITLE
add in rb-readline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'resque-scheduler', '~> 4.3.0'
 group :development, :test do
   gem 'equivalent-xml'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'rb-readline'
   gem 'byebug'
   gem 'pry-rails'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,6 +538,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.3.0)
+    rb-readline (0.5.3)
     rdf (2.1.0)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -774,6 +775,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   rails (= 4.2.7.1)
+  rb-readline
   resque (~> 1.26.0)
   resque-scheduler (~> 4.3.0)
   rest-client


### PR DESCRIPTION
This fixes an issue that emerged on some OS X systems in Oct 2016 where homebrew was not assigning readline to ruby.  Developers would see an error when bringing up the test or dev environments.  Devs either have the option to recompile ruby or else just add the rb-readline gem.  I propose just making rb-readline a dependency for all dev and test environments.  