### PR TITLE
Reject file upload with non-ascii characters in filename

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -173,7 +173,7 @@ class MasterFilesController < ApplicationController
           return redirect_to :back
         end
 
-        unless file.path.valid_encoding? && file.path.ascii_only?
+        unless file.original_filename.valid_encoding? && file.original_filename.ascii_only?
           flash[:error] = 'The file you have uploaded has non-ASCII characters in its name.'
           return redirect_to :back
         end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -58,6 +58,19 @@ describe MasterFilesController do
       end
     end
 
+    context "cannot upload a file with a non-ascii character in the filename" do
+      it "should provide a warning about the invalid filename" do
+        request.env["HTTP_REFERER"] = "/"
+
+        file = fixture_file_upload('/videoshort.mp4', 'video/mp4')
+        allow(file).to receive(:original_filename).and_return("videoshort_é.mp4")
+
+        expect { post :create, Filedata: [file], original: 'any', container_id: media_object.id}.not_to change { MasterFile.count }
+
+        expect(flash[:error]).not_to be_nil
+      end
+    end
+
     context "must be a valid MIME type" do
       it "should recognize a video format" do
         file = fixture_file_upload('/videoshort.mp4', 'video/mp4')


### PR DESCRIPTION
Fixes #1335 

If user tries to upload a file with a non-ascii character in the filename, reject the upload and present error message to user.

