### PR TITLE
Fix autoadvance

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -91,7 +91,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if @currentStream.present? and @currentStream.derivatives.present? %>
   <script>
     function advancePlaylist() {
-      nextUrl = $('div.panel-heading').has('a.current-stream').next().find('a.playable').attr('href');
+      nextUrl = $('div.panel-heading').has('a.current-section').nextAll('div[role="tab"]:first').find('a.playable').attr('href');
       if (nextUrl) {
         window.location = nextUrl + "?autostart=true";
       }


### PR DESCRIPTION
Fixes VOV-5296.

This resolves a timing issue where the 'ended' event fires after the 'timeupdate' so the current-stream is set to the current-section and not the currently ending leaf node.  This screwed things up even for items with only one section.  This PR doesn't rely on current-stream and should fix the autoadvance.