### PR TITLE
Fix playlist problems with unauthenticated users

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,9 +1,9 @@
 require 'avalon/variations_playlist_importer'
 
 class PlaylistsController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: [:show, :refresh_info]
   load_and_authorize_resource
-  skip_load_and_authorize_resource only: :import_variations_playlist
+  skip_load_and_authorize_resource only: [:import_variations_playlist, :refresh_info]
   before_action :get_all_playlists, only: [:index, :edit, :update]
 
   # GET /playlists

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -64,6 +64,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if request['target_id']
       redirect_to object_path(request['target_id'])
+    elsif params[:url]
+      redirect_to params[:url]
     elsif session[:previous_url] 
       redirect_to session.delete :previous_url
     elsif auth_type == 'lti' && user_session[:virtual_groups].present?

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -55,7 +55,13 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 <% unless can? :read, @current_masterfile %>
   <span class = 'show_playlist_player_denied_title'><h2>Restricted Access</h2></span>
-  <span class = 'playlist_item_denied'>You do not have permission to playback item <%= @current_masterfile.mediaobject_id %></span>
+  <span class = 'playlist_item_denied'>
+    You do not have permission to playback item <%= @current_masterfile.mediaobject_id %>.
+    <% if !user_signed_in? %>
+      <br>Have you tried <%= link_to 'logging in', new_user_session_path %>?
+    <% end %>
+  </span>
+
 <% end %>
 <% content_for :page_scripts do %>
   <%= javascript_include_tag "mediaelement_rails/mediaelement-and-player" =%>

--- a/app/views/playlists/_playlist_item.html.erb
+++ b/app/views/playlists/_playlist_item.html.erb
@@ -20,7 +20,7 @@
          } %>
 
     <%#= link_to "#", data: data, onclick: 'reload_player(this);' do %>
-    <% if @current_masterfile.is_video? == masterfile.is_video? %>
+    <% if @current_masterfile.is_video? == masterfile.is_video? && can?(:read, @current_playlist_item.clip.master_file.mediaobject) %>
       <%= link_to playlist_refresh_info_path(@playlist, position: item.position, autostart: true), remote: true do%>
         <%= clip.title %>
       <% end %>


### PR DESCRIPTION
• If the first item is restricted and user is not logged in, it will ask user to try logging in. https://mallorn.dlib.indiana.edu/playlists/2092 
• User can now jump to other public items in the playlist regardless if there are restricted items or not.
• In-between restricted items are skipped over.
• No public items? You will be asked to log in https://mallorn.dlib.indiana.edu/playlists/2102 
