### PR TITLE
Fix autoadvance when switching streams timing is bad

### DIFF
--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -103,12 +103,18 @@ Unless required by applicable law or agreed to in writing, software distributed
         displayTrackScrubber: true,
         autostart: <%= params[:autostart] == 'true' ? 'true' : 'false' %>,
 	success: function(mediaElement, domObject, player) {
-	  player.media.addEventListener('timeupdate', function(e) {
-	    if (avalonPlayer.player.getCurrentTime() > avalonPlayer.stream_info.t[1]) {
-	      avalonPlayer.player.media.stop();
-	      advancePlaylist();
-	    }
-	  }, false);
+          player.media.addEventListener('timeupdate', function(e) {
+            // round times to nearest .1 second for derivative duration discrepancies
+            t = Math.round(avalonPlayer.player.getCurrentTime()*10)
+            // if player's new currenttime is >= end of playlist item or equal to mf duration, advance to next playlist item
+            if (t > Math.round(avalonPlayer.stream_info.t[1]*10) || t == Math.round(avalonPlayer.player.media.duration*10)) {
+              // advance only if player media duration matches stream_info duration (it might not when switching sections)
+              if (Math.round(avalonPlayer.player.media.duration*10) == Math.round(avalonPlayer.stream_info.duration*10)) {
+                avalonPlayer.player.media.stop();
+                advancePlaylist();
+              }
+            }
+          }, false);
         }
       });
       currentPlayer = avalonPlayer.player;


### PR DESCRIPTION
Fixes #1500 
Fixes #1478

Prevents playlist autoadvance from skipping items when player is switching streams

If the playlist has advanced to the next track before the player has finished switching streams, a lingering player timeupdate event can trigger a second autoadvance.

Autoadvance is triggered by a media timeupdate event and compares player media currenttime to stream info mediafragment endtime. If the timeupdate event occurs while streams are switching, player media and stream_info can be for different tracks. This PR adds a check that ensures player media is the same as the stream info before autoadvancing the playlist. It compares their durations, since that is the only datapoint easily available. 