### PR TITLE
fix autoadvance again

### DIFF
--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -109,7 +109,7 @@ Unless required by applicable law or agreed to in writing, software distributed
             // if player's new currenttime is >= end of playlist item or equal to mf duration, advance to next playlist item
             if (t > Math.round(avalonPlayer.stream_info.t[1]*10) || t == Math.round(avalonPlayer.player.media.duration*10)) {
               // advance only if player media duration matches stream_info duration (it might not when switching sections)
-              if (Math.round(avalonPlayer.player.media.duration*10) == Math.round(avalonPlayer.stream_info.duration*10)) {
+              if (Math.round(avalonPlayer.player.media.duration) == Math.round(avalonPlayer.stream_info.duration)) {
                 avalonPlayer.player.media.stop();
                 advancePlaylist();
               }


### PR DESCRIPTION
Fixes #1508 

Fixes playlist autoadvance bug caused by masterfile duration and its derivative durations being different enough to look like different masterfiles to my test. Changing the rounding precision should fix it.