### PR TITLE
reload page when changing media types

### DIFF
--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -84,7 +84,11 @@ Unless required by applicable law or agreed to in writing, software distributed
     function advancePlaylist() {
       nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
       if (nextUrl) {
-        nextUrl.click();
+        if ('remote' in nextUrl[0].dataset) {
+          nextUrl.click();
+        } else {
+          window.location = nextUrl[0].href;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes new bug. For some inexplicable reason, playlist autoadvance stopped working when changing between media types.