### PR TITLE
Attempt to fix cap locking to 3.6.1

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.6.1'
+lock '>=3.6.1'
 
 set :application, 'avalon'
 set :repo_url, 'git://github.com/avalonmediasystem/avalon.git'


### PR DESCRIPTION
Bamboo currently has capistrano 3.7.1 and it's refusing our locked capfile.