### PR TITLE
5.x toggle autoadvance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@
     gem 'handlebars_assets'
     #gem 'twitter-typeahead-rails', '~>0.11.1'
     gem 'twitter-typeahead-rails', '= 0.11.1.pre.corejavascript'
+    gem 'bootstrap-toggle-rails'
   end
 
   group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
     bootstrap-sass (3.3.3)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    bootstrap-toggle-rails (2.2.1.0)
     bootstrap_form (2.3.0)
     browse-everything (0.6.3)
       bootstrap-sass
@@ -782,6 +783,7 @@ DEPENDENCIES
   binding_of_caller
   blacklight (~> 5.10)
   bootstrap-sass (= 3.3.3)
+  bootstrap-toggle-rails
   bootstrap_form
   browse-everything (= 0.6.3)
   builder (~> 3.1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,6 +42,7 @@
 //= require jquery.ui.nestedSortable
 
 //= require bootstrap-sprockets
+//= require bootstrap-toggle
 
 //= require browse_everything
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "branding";
 @import "font-awesome";
 @import "bootstrap-sprockets";
+@import "bootstrap-toggle";
 @import "browse_everything";
 @import "bootstrap";
 @import "blacklight_themes/avalon";

--- a/app/assets/stylesheets/avalon.css.scss
+++ b/app/assets/stylesheets/avalon.css.scss
@@ -1049,14 +1049,16 @@ h5.panel-title {
     text-align:right;
   }
 }
-.playlist-title {
-  margin:0;padding:0;
-  font-size:1.5em;
-}
 #section-label {
   float:left;
 }
+#edit-playlist-button {
+  margin-left: 5px;
+  margin-top: 1px;
+}
 .playlist-title {
+  margin:0;padding:0;
+  font-size:1.5em;
   width:100%;
   border-bottom:1px solid $gray;
   line-height:2em;

--- a/app/views/playlists/_item_list.html.erb
+++ b/app/views/playlists/_item_list.html.erb
@@ -25,7 +25,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% end %>
   <div>
     <span>Autoplay</span>
-    <input type="checkbox" checked data-toggle="toggle" data-size="mini">
+    <input type="checkbox" checked data-toggle="toggle" data-size="mini" name="autoadvance">
   </div>
 </div>
 <h3 class="playlist-title">

--- a/app/views/playlists/_item_list.html.erb
+++ b/app/views/playlists/_item_list.html.erb
@@ -13,15 +13,21 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% if current_ability.can? :edit, @playlist %>
- <div class="btn-group pull-right">
-  <%= link_to edit_playlist_path(@playlist) do %>
-    <button type="button" class="btn btn-default" style="display:block;" >
-      <span class="fa fa-edit"> Edit Playlist</span>
-    </button>
+<div class="text-right">
+  <% if current_ability.can? :edit, @playlist %>
+    <div class="btn-group pull-right" id="edit-playlist-button">
+      <%= link_to edit_playlist_path(@playlist) do %>
+      <button type="button" class="btn btn-default btn-xs" style="display:block;" >
+        <span class="fa fa-edit"> Edit Playlist</span>
+      </button>
+      <% end %>
+    </div>
   <% end %>
- </div>
-<% end %>
+  <div>
+    <span>Autoplay</span>
+    <input type="checkbox" checked data-toggle="toggle" data-size="mini">
+  </div>
+</div>
 <h3 class="playlist-title">
   <% if @playlist.visibility==Playlist::PRIVATE %>
     <span class="fa fa-lock" alt="<%= t('playlist.lockAltText') %>" title="<%= t('playlist.lockAltText') %>"></span>

--- a/app/views/playlists/_item_list.html.erb
+++ b/app/views/playlists/_item_list.html.erb
@@ -25,7 +25,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% end %>
   <div>
     <span>Autoplay</span>
-    <input type="checkbox" checked data-toggle="toggle" data-size="mini" name="autoadvance">
+    <input type="checkbox" <%= 'checked' if params['autoadvance'].nil? or params['autoadvance']=='true' %> data-toggle="toggle" data-size="mini" name="autoadvance">
   </div>
 </div>
 <h3 class="playlist-title">

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -82,12 +82,15 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if @currentStream.present? and @currentStream.derivatives.present? %>
   <script>
     function advancePlaylist() {
-      nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
-      if (nextUrl) {
-        if ('remote' in nextUrl[0].dataset) {
-          nextUrl.click();
-        } else {
-          window.location = nextUrl[0].href;
+      if ($('input[name="autoadvance"]')[0].checked) {
+        nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
+        if (nextUrl) {
+          if ('remote' in nextUrl[0].dataset) {
+            currentPlayer.options['autostart']='true'
+            nextUrl.click();
+          } else {
+            window.location = nextUrl[0].href;
+          }
         }
       }
     }
@@ -112,11 +115,8 @@ Unless required by applicable law or agreed to in writing, software distributed
             t = Math.round(avalonPlayer.player.getCurrentTime()*10)
             // if player's new currenttime is >= end of playlist item or equal to mf duration, advance to next playlist item
             if (t > Math.round(avalonPlayer.stream_info.t[1]*10) || t == Math.round(avalonPlayer.player.media.duration*10)) {
-              // advance only if player media duration matches stream_info duration (it might not when switching sections)
-              if (Math.round(avalonPlayer.player.media.duration) == Math.round(avalonPlayer.stream_info.duration)) {
-                avalonPlayer.player.media.stop();
-                advancePlaylist();
-              }
+              avalonPlayer.player.media.stop();
+              advancePlaylist();
             }
           }, false);
         }

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -83,16 +83,18 @@ Unless required by applicable law or agreed to in writing, software distributed
   <script>
     function advancePlaylist() {
       nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
-      if (nextUrl.length && $('input[name="autoadvance"]')[0].checked) {
-        if ('remote' in nextUrl[0].dataset) {
-          currentPlayer.options['autostart']='true'
-          nextUrl.click();
+      if ($('input[name="autoadvance"]')[0].checked) {
+        if (nextUrl.length) {
+          if ('remote' in nextUrl[0].dataset) {
+            currentPlayer.options['autostart']='true'
+            nextUrl.click();
+          } else {
+            window.location = nextUrl[0].href.replace('autoadvance=false','autoadvance=true');
+          }
         } else {
-          window.location = nextUrl[0].href;
+          currentPlayer.pause()
+          currentPlayer.setCurrentTime(avalonPlayer.stream_info.t[0] || 0)
         }
-      } else {
-        currentPlayer.pause()
-        currentPlayer.setCurrentTime(avalonPlayer.stream_info.t[0] || 0)
       }
     }
 
@@ -111,10 +113,17 @@ Unless required by applicable law or agreed to in writing, software distributed
         displayTrackScrubber: true,
         autostart: <%= params[:autostart] == 'true' ? 'true' : 'false' %>,
 	success: function(mediaElement, domObject, player) {
-          player.media.addEventListener('timeupdate', function(e) {
-            // round times to nearest .1 second for derivative duration discrepancies
+            <%# turn off autoadvance if scrubber is clicked %>
+            var scrubber =  $('.mejs-time-total')[0];
+            var oldclick = scrubber.onclick;
+            scrubber.onclick = function(){
+              $('input[name="autoadvance"]').prop('checked',false).change();
+              if(oldclick){oldclick();}
+            }
+            player.media.addEventListener('timeupdate', function(e) {
+            <%# round times to nearest .1 second for derivative duration discrepancies %>
             t = Math.round(avalonPlayer.player.getCurrentTime()*10)
-            // if player's new currenttime is >= masterfile duration or end of playlist item advance to next playlist item
+            <%# if players new currenttime is >= masterfile duration or end of playlist item advance to next playlist item %>
             if (t >= Math.round(avalonPlayer.player.media.duration*10) || t > Math.round(avalonPlayer.stream_info.t[1]*10)) {
               advancePlaylist();
             }

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -82,16 +82,17 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if @currentStream.present? and @currentStream.derivatives.present? %>
   <script>
     function advancePlaylist() {
-      if ($('input[name="autoadvance"]')[0].checked) {
-        nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
-        if (nextUrl) {
-          if ('remote' in nextUrl[0].dataset) {
-            currentPlayer.options['autostart']='true'
-            nextUrl.click();
-          } else {
-            window.location = nextUrl[0].href;
-          }
+      nextUrl = $('.side-playlist li.now_playing').nextAll('li.queue:first').find('a');
+      if (nextUrl.length && $('input[name="autoadvance"]')[0].checked) {
+        if ('remote' in nextUrl[0].dataset) {
+          currentPlayer.options['autostart']='true'
+          nextUrl.click();
+        } else {
+          window.location = nextUrl[0].href;
         }
+      } else {
+        currentPlayer.pause()
+        currentPlayer.setCurrentTime(avalonPlayer.stream_info.t[0] || 0)
       }
     }
 
@@ -113,9 +114,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           player.media.addEventListener('timeupdate', function(e) {
             // round times to nearest .1 second for derivative duration discrepancies
             t = Math.round(avalonPlayer.player.getCurrentTime()*10)
-            // if player's new currenttime is >= end of playlist item or equal to mf duration, advance to next playlist item
-            if (t > Math.round(avalonPlayer.stream_info.t[1]*10) || t == Math.round(avalonPlayer.player.media.duration*10)) {
-              avalonPlayer.player.media.stop();
+            // if player's new currenttime is >= masterfile duration or end of playlist item advance to next playlist item
+            if (t >= Math.round(avalonPlayer.player.media.duration*10) || t > Math.round(avalonPlayer.stream_info.t[1]*10)) {
               advancePlaylist();
             }
           }, false);

--- a/app/views/playlists/_playlist_item.html.erb
+++ b/app/views/playlists/_playlist_item.html.erb
@@ -25,7 +25,7 @@
         <%= clip.title %>
       <% end %>
     <% else %>
-      <%= link_to playlist_path(@playlist, position: item.position, autostart: true) do %>
+      <%= link_to playlist_path(@playlist, position: item.position, autostart: true, autoadvance: false) do %>
         <%= clip.title %>
       <% end %>
     <% end %>


### PR DESCRIPTION
Fixes #1504 

Improves playlist autoadvance

Fixes handling of playlist items that end at the end of a masterfile.
Fixes handling of end of final playlist item
Add toggle to turn off autoadvance
Turns off autoadvance when scrubber is clicked to allow users to jump to point beyond end of item
Turns off autoadvance when different playlist item is manually clicked to prevent lingering timeupdate events from forcing the playlist to occasionally skip items.