### PR TITLE
Do not update masterfile.workflow_id if exists

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -297,7 +297,7 @@ class MasterFile < ActiveFedora::Base
     self.status_code = encode.state.to_s.upcase
     self.duration = encode.tech_metadata[:duration] if encode.tech_metadata[:duration]
     self.file_checksum = encode.tech_metadata[:checksum] if encode.tech_metadata[:checksum]
-    self.workflow_id = encode.id
+    self.workflow_id ||= encode.id
     #self.workflow_name = encode.options[:preset] #MH can switch to an error workflow
 
     case self.status_code


### PR DESCRIPTION
Avoid edge case where Matterhorn sends a wrong workflow during ActiveEncode update jobs:
Keith Carter had a missing Matterhorn workflow from days ago, which somehow gets sent back to Avalon and updates the masterfile with wrong workflow_id, Avalon sees this workflow as "CANCELLED" and stops the ActiveEncode Update job. So even though Matterhorn processed the file, Avalon doesn't get the progress update.