### PR TITLE
Open related item URLs in new tab.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,9 +73,16 @@ module ApplicationHelper
     end
   end
 
-  def display_metadata(label, value, default=nil)
+  def display_metadata(label, value, default=nil, options = {})
     return if value.blank? and default.nil?
-    sanitized_values = Array(value).collect { |v| sanitize(v.to_s.strip) }.delete_if(&:empty?)
+    allowed_attributes = self.class.sanitized_allowed_attributes.dup
+    if options[:allow_target_attribute]
+      # If we want links to open in a separate tab, we need to add
+      # 'target' to the allowed attributes list.
+      allowed_attributes += ['target']
+    end
+    sanitized_values = Array(value).collect {
+      |v| sanitize(v.to_s.strip, attributes: allowed_attributes) }.delete_if(&:empty?)
     sanitized_values = Array(default) if sanitized_values.empty?
     label = label.pluralize(sanitized_values.size)
     result = content_tag(:dt, label) +

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -95,7 +95,8 @@ module MediaObjectsHelper
      end
 
      def display_related_item mediaobject
-       mediaobject.related_item_url.collect{ |r| link_to( r[:label], r[:url]) }
+       mediaobject.related_item_url.collect{ |r|
+         link_to( r[:label], r[:url], :target => '_blank') }
      end
 
      def current_quality stream_info

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -44,7 +44,8 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= display_metadata('Language', display_language(@mediaobject)) %>
   <%= display_metadata('Terms of Use', @mediaobject.terms_of_use) %>
   <%= display_metadata('Physical Description', @mediaobject.physical_description) %>
-  <%= display_metadata('Related Item', display_related_item(@mediaobject)) %>
+  <%= display_metadata('Related Item', display_related_item(@mediaobject), nil,
+      allow_target_attribute: true) %>
   <%= display_metadata('Notes', display_notes(@mediaobject)) %>
   <%= display_metadata('Other Identifier', display_other_identifiers(@mediaobject)) %>
 


### PR DESCRIPTION
Clicking on a related item URL can disrupt playback when that URL opens in the same tab.
This patch makes the related item link open in a new tab.

The display_metadata method needs a new keyword option (allow_target_attribute: true) for
this to work, otherwise the HTML sanitizing will scrub off the "target" attribute for an
anchor, which is what makes this work.