### PR TITLE
Align thumbnails to the left

### DIFF
--- a/app/views/catalog/_index_media_object.html.erb
+++ b/app/views/catalog/_index_media_object.html.erb
@@ -1,0 +1,28 @@
+<%#
+Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+ University.  Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed 
+ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ specific language governing permissions and limitations under the License.
+--- END LICENSE_HEADER BLOCK  ---
+   %>
+
+<% doc_presenter = index_presenter(document) %> 
+<%# default partial to display solr document fields in catalog index view -%>
+<dl class="document-metadata dl-horizontal dl-invert col-md-9">
+  
+  <% index_fields(document).each do |field_name, field| -%>
+    <% if should_render_index_field? document, field %>
+	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
+	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
+    <% end -%>
+  <% end -%>
+
+</dl>

--- a/app/views/catalog/_thumbnail_media_object.html.erb
+++ b/app/views/catalog/_thumbnail_media_object.html.erb
@@ -1,0 +1,25 @@
+<%#
+Copyright 2011-2015, The Trustees of Indiana University and Northwestern
+ University.  Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed 
+ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ specific language governing permissions and limitations under the License.
+--- END LICENSE_HEADER BLOCK  ---
+%>
+
+<div class="col-md-3">
+  <% if image_url = image_for(document) %>
+    <%= link_to(media_object_path(document[:id]), {class: 'result-thumbnail'}) do %>
+      <%= image_tag( image_url ) %>
+    <% end %>
+  <% else %>
+    <%= image_tag 'no_icon.png', class: 'result-thumbnail' %>
+  <% end %>
+</div>


### PR DESCRIPTION
Fixes #1581 

Aligns thumbnails to the left in search results.

Takes default blacklight catalog/_index_default.html.erb and adds 'col-md-9' class to the <dl> element.
Adds custom partial for thumbnail that has 'col-md-3' class to its <div>.