### PR TITLE
Index MediaObject.ordered_master_file_ids instead of master_file_ids

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -207,7 +207,7 @@ class MediaObject < ActiveFedora::Base
       #include identifiers for parts
       solr_doc["other_identifier_sim"] +=  master_files.collect {|mf| mf.identifier.to_a }.flatten
       #include labels for parts and their structural metadata
-      solr_doc['section_id_ssim'] = master_file_ids
+      solr_doc['section_id_ssim'] = ordered_master_file_ids
       solr_doc["section_label_tesim"] = section_labels
       solr_doc['section_physical_description_ssim'] = section_physical_descriptions
       solr_doc['avalon_resource_type_ssim'] = self.avalon_resource_type.map(&:titleize)


### PR DESCRIPTION
Fixes #1580 

Uses first masterfile thumbnail based on ordered_master_file_ids instead of master_file_ids.