### PR TITLE
fix facet count width

### DIFF
--- a/app/assets/javascripts/blacklight/facet_load.js
+++ b/app/assets/javascripts/blacklight/facet_load.js
@@ -1,0 +1,23 @@
+/*global Blacklight */
+
+(function($) {
+  'use strict';
+  
+  Blacklight.doResizeFacetLabelsAndCounts = function() {
+    // adjust width of facet columns to fit their contents
+    function longer (a,b){ return b.textContent.length - a.textContent.length; }
+
+    $('ul.facet-values, ul.pivot-facet').each(function(){
+      var longest = $(this).find('span.facet-count').sort(longer).first();
+      var clone = longest.clone()
+        .css('visibility','hidden').css('width', 'auto');
+      longest.append(clone);
+      $(this).find('.facet-count').first().width(clone.width());
+      clone.remove();
+    });
+  };
+
+  Blacklight.onLoad(function() {
+    Blacklight.doResizeFacetLabelsAndCounts();
+  });
+})(jQuery);


### PR DESCRIPTION
Fixes #1586 

Fixes width of facet counts by overriding blacklight's javascript.

Stock blacklight creates an object used to set the width for the facet count column and attaches that object to the body node. It inherits css from body that causes the width to be incorrect. This change attaches the object to the facet count itself, so it inherits the correct css.