### PR TITLE
add in no wrap for just the facet-value.  This will work up to five i…

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -582,6 +582,7 @@ a[data-trigger='submit'] {
 
 .facet-values {
   display: table;
+  //white-space: nowrap; I don't think we want values to no wrap because collection names can be long
   table-layout: fixed;
   //set hyphen definitions at this (display:block) level
   -ms-word-break: keep-all;
@@ -618,6 +619,7 @@ a[data-trigger='submit'] {
 .facet-count {
   text-align: right;
   width: 5em;
+  white-space: nowrap;
 }
 
 .facets .panel-group .panel {


### PR DESCRIPTION
After speaking with POs, since this is a time boxed fix the best move was to set facet-count to no-wrap.  I believe we do not need to expand max-width for the sidebar style, but if desired for look we can.  

Fixes #1586 
Fixes #1025 (titles wrap relatively cleanly)
Fixes #1054 

This is an example of what we end up with:
<img width="230" alt="screen shot 2017-02-10 at 3 23 27 pm" src="https://cloud.githubusercontent.com/assets/5350060/22842968/6aa1b322-efa5-11e6-8b8a-a3183948037e.png">
 