### PR TITLE
Add bolding back to titles

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -330,14 +330,17 @@ header div{
 /* Sidebar */
 
 .sidenav {
-  h4 {
+  /* Browse By Header */
+  h2 {
     margin: 0px;
     background-color: $sidenavHeaderBackgroundColor;
     @include border-top-radius(6px);
     padding: 10px 0 10px 10px;
     font-weight: bold;
+    font-size: 18px;
   }
-  h5 {
+  /* Facet Group Header */
+  h3 {
     font-weight: bold;
     font-size: 1em;
   }
@@ -648,6 +651,7 @@ a[data-trigger='submit'] {
 .index_title {
   line-height: 20px;
   margin-top: 0;
+  font-weight: 700 !important;
 }
 
 .form-control {
@@ -698,10 +702,6 @@ a[data-trigger='submit'] {
     background-color: $greenBG;
     border-color: $green;
   }
-}
-
-.index_title {
-  font-weight: bold;
 }
 
 #content {

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -25,9 +25,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       <span class="icon-bar"></span>
     </button>
 
-  <h4>
+  <h2>
   	<%= groupname.blank? ? t('blacklight.search.facets.title') : t("blacklight.search.facets-#{groupname}.title", default: groupname.titleize) %>
-  </h4>
+  </h2>
     </div>
 
   <div id="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" class="collapse panel-group">


### PR DESCRIPTION
Fixes #1600

- Added bolding back to the browse titles.
- Changed the headers in the side nav to match blacklight's new header sizing.