### PR TITLE
change mediaobject and mediaobject_id to media_object and media_objec…

### DIFF
--- a/app/views/playlists/_info.html.erb
+++ b/app/views/playlists/_info.html.erb
@@ -1,7 +1,7 @@
 <%# @current_playlist_item ||= Playlist.find(params[:playlist_id]).items.where(position: params[:position].to_i).first %>
 <%# @current_clip ||= AvalonClip.find(@current_playlist_item.clip_id) %>
 <%# @current_masterfile ||= MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
-<%# @current_mediaobject ||= MediaObject.find(@current_masterfile.mediaobject_id) %>
+<%# @current_mediaobject ||= MediaObject.find(@current_masterfile.media_object_id) %>
 
 <% if can? :read, @current_masterfile %>
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -56,7 +56,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% unless can? :read, @current_masterfile %>
   <span class = 'show_playlist_player_denied_title'><h2>Restricted Access</h2></span>
   <span class = 'playlist_item_denied'>
-    You do not have permission to playback item <%= @current_masterfile.mediaobject_id %>.
+    You do not have permission to playback item <%= @current_masterfile.media_object_id %>.
     <% if !user_signed_in? %>
       <br>Have you tried <%= link_to 'logging in', new_user_session_path %>?
     <% end %>

--- a/app/views/playlists/_playlist_item.html.erb
+++ b/app/views/playlists/_playlist_item.html.erb
@@ -10,7 +10,7 @@
     <% clip_start = clip.start_time / 1000.0 %>
     <% clip_end = clip.end_time / 1000.0 %>
     <% clip_frag = "?t=#{clip_start},#{clip_end}" %>
-    <% link = pid_section_media_object_path(MediaObject.find(masterfile.mediaobject_id), masterfile.pid) + clip_frag %>
+    <% link = pid_section_media_object_path(MediaObject.find(masterfile.media_object_id), masterfile.pid) + clip_frag %>
     <% data = {
         segment: masterfile.pid,
         is_video: masterfile.is_video?,

--- a/app/views/playlists/refresh_info.js.erb
+++ b/app/views/playlists/refresh_info.js.erb
@@ -2,7 +2,7 @@
 <% @current_playlist_item = @playlist.items.where(position: params[:position].to_i).first %>
 <% @current_clip = AvalonClip.find(@current_playlist_item.clip_id) %>
 <% @current_masterfile = MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
-<% @current_mediaobject = MediaObject.find(@current_masterfile.mediaobject_id) %>
+<% @current_mediaobject = MediaObject.find(@current_masterfile.media_object_id) %>
 <% clip_start = @current_clip.start_time / 1000.0 %>
 <% clip_end = @current_clip.end_time / 1000.0 %>
 <% clip_frag = "?t=#{clip_start},#{clip_end}" %>


### PR DESCRIPTION
…t_id

Fixes #1613 

Looks like someone renamed the accessor from `masterfile.mediaobject` to `masterfile.media_object`.  I corrected in all the places I could find it.