### PR TITLE
Add quality selector back in. Fixes #1611

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,7 @@
 //= require me-add-to-playlist
 //= require modernizr
 //= require me-track-scrubber
+//= require mediaelement-qualityselector/mep-feature-qualities
 
 // include all of our vendored js
 //= require_tree ../../../vendor/assets/javascripts/.


### PR DESCRIPTION
Fixes #1611 

Inclusion of `mediaelement-qualityselector/mep-feature-qualities` was missing from `application.js`. I'm not sure when or how it was removed.