### PR TITLE
Speed up stream switching by only loading the currently selected masterfile

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -199,7 +199,7 @@ class AvalonPlayer
         else
           $('.mejs-overlay-loading').show().closest('.mejs-layer').show()
           splitUrl = (target_stream.nativeUrl || target.attr('href')).split('?')
-          uri = "#{splitUrl[0]}.js"
+          uri = "#{splitUrl[0]}/stream"
           params = ["content=#{segment}"]
           params.push(splitUrl[1]) if splitUrl[1]?
           $.getJSON uri, params.join('&'), (data) => @setStreamInfo(data)

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -27,8 +27,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       </h4>
     </div>
 
+<% show_all_sections = can? :edit, @media_object %>
 <% sections.each_with_index do |section,i| %>
-<%   unless can? :edit, @media_object %>
+<%   unless show_all_sections %>
 <%     next if section.derivatives.empty? %>
 <%   end %>
 <%=  structure_html(section,i,show_progress).html_safe %>
@@ -81,4 +82,3 @@ Unless required by applicable law or agreed to in writing, software distributed
 </script>
 <% end %>
 <% end %>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       get 'content/:file', :action => :deliver_content, :as => :inspect
       get 'track/:part', :action => :show, :as => :indexed_section
       get 'section/:content', :action => :show, :as => :id_section
+      get 'section/:content/stream', :action => :show_stream_details
       get 'tree', :action => :tree, :as => :tree
       get :confirm_remove
     end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -498,15 +498,9 @@ describe MediaObjectsController, type: :controller do
       end
 
       it "should provide a JSON stream description to the client" do
-        master_file = FactoryGirl.create(:master_file)
-        master_file.media_object = media_object
-        master_file.save
-
-        moid = media_object.id
-        media_object = MediaObject.find(moid)
-
+        FactoryGirl.create(:master_file, media_object: media_object)
         media_object.master_files.each { |part|
-          xhr :get, :show, id: media_object.id, format: :js, content: part.id
+          xhr :get, :show_stream_details, id: media_object.id, content: part.id
           json_obj = JSON.parse(response.body)
           expect(json_obj['is_video']).to eq(part.is_video?)
         }
@@ -617,7 +611,6 @@ describe MediaObjectsController, type: :controller do
     context "correctly handle unfound streams/sections" do
       subject(:mo){FactoryGirl.create(:media_object, :with_master_file)}
       before do
-        mo.save
         login_user mo.collection.managers.first
       end
       it "redirects to first stream when currentStream is nil" do


### PR DESCRIPTION
refs #1407 

Changes proposed in this pull request:
* Reduces redundancy on initial player load
* Eliminates unnecessary MasterFile retrieval on AJAX stream switching