### PR TITLE
Fix deleting media objects with multiple sections

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -711,7 +711,8 @@ class MasterFile < ActiveFedora::Base
   end
 
   def update_parent!
-    media_object.master_files -= [self]
+    media_object.master_files.delete(self)
+    media_object.ordered_master_files.delete(self)
     media_object.set_media_types!
     media_object.set_duration!
     media_object.save

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -711,12 +711,23 @@ describe MediaObjectsController, type: :controller do
       login_user collection.managers.first
     end
 
-    it "should remove the MediaObject and MasterFiles from the system" do
+    it "should remove a MediaObject with a single MasterFiles" do
       media_object = FactoryGirl.create(:media_object, :with_master_file, collection: collection)
       delete :destroy, id: media_object.id
       expect(flash[:notice]).to include("success")
       expect(MediaObject.exists?(media_object.id)).to be_falsey
       expect(MasterFile.exists?(media_object.master_files.first.id)).to be_falsey
+    end
+
+    it "should remove a MediaObject with multiple MasterFiles" do
+      media_object = FactoryGirl.create(:media_object, :with_master_file, collection: collection)
+      FactoryGirl.create(:master_file, media_object: media_object)
+      master_file_ids = media_object.master_files.map(&:id)
+      media_object.reload
+      delete :destroy, id: media_object.id
+      expect(flash[:notice]).to include("success")
+      expect(MediaObject.exists?(media_object.id)).to be_falsey
+      master_file_ids.each { |mf_id| expect(MasterFile.exists?(mf_id)).to be_falsey }
     end
 
     it "should fail when id doesn't exist" do

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -410,6 +410,14 @@ describe MediaObject do
     it 'destroys related master_files' do
       expect { media_object.destroy }.to change { MasterFile.exists?(master_file) }.from(true).to(false)
     end
+
+    it 'destroys multiple sections' do
+      FactoryGirl.create(:master_file, media_object: media_object)
+      media_object.reload
+      expect(media_object.master_files.size).to eq 2
+      expect { media_object.destroy }.to change { MasterFile.count }.from(2).to(0)
+      expect(MediaObject.exists?(media_object.id)).to be_falsey
+    end
   end
 
   context "dependent properties" do


### PR DESCRIPTION
Fixes #1634 

I wrote the tests first and they passed but I still got the error when testing manually through the interface.  I copied how we are removing master files from media objects in the media object controller update action.  This appears to fix things and the new tests still pass.