### PR TITLE
Override twitter-typeahead z-index setting

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1165,3 +1165,7 @@ h5.panel-title {
   margin: 0px auto;
   padding: 8px;
 }
+
+.twitter-typeahead {
+  z-index: auto !important;
+}


### PR DESCRIPTION
Fixes #1653 

Overrides twitter-typeahead z-index settings so dropdowns aren't hidden by text inputs.