### PR TITLE
Cancan tests should use object instead of id…

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -50,7 +50,7 @@ class MediaObjectsController < ApplicationController
   end
 
   def confirm_remove
-    raise CanCan::AccessDenied unless Array(params[:id]).any? { |id| current_ability.can? :destroy, id }
+    raise CanCan::AccessDenied unless Array(params[:id]).any? { |id| current_ability.can? :destroy, MediaObject.find(id) }
   end
 
   def new

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -757,6 +757,12 @@ describe MediaObjectsController, type: :controller do
       expect(controller.current_ability.can? :destroy, media_object2).to be_truthy
       expect(get :confirm_remove, id: [media_object1.id, media_object2.id]).to render_template(:confirm_remove)
     end
+    it "displays confirmation form for administrators" do
+      login_as :administrator
+      media_object = FactoryGirl.create(:media_object, collection: collection)
+      expect(controller.current_ability.can? :destroy, media_object).to be_truthy
+      expect(get :confirm_remove, id: media_object.id).to render_template(:confirm_remove)
+    end
   end
 
   describe "#update_status" do


### PR DESCRIPTION
…to ensure our custom permissions are applied

Fixes #1654.