### PR TITLE
Fix dropdown fields javascript

### DIFF
--- a/app/assets/javascripts/dropdown_text_fields.js.coffee
+++ b/app/assets/javascripts/dropdown_text_fields.js.coffee
@@ -16,7 +16,7 @@
 $ ->
   $(document).on 'click', '.dropdown-menu li a.dropdown-field', (event) ->
     event.preventDefault()
-    d = $(this)
+    d = $(this).parent()
     group = d.closest('.input-group-btn')
     group.find('.dropdown-toggle span').first().text(d.find('a').text())
     group.find('input[type="hidden"]').val(d.find('span.hidden').text())


### PR DESCRIPTION
Fixes #1642 

Fixes dropdown fields.

Something about the dropdown field html changed so that click events happen now at a different level.