### PR TITLE
reset the create collection button after a failure

### DIFF
--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -48,10 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       if (xhr.responseJSON.hasOwnProperty('errors')){
         $(this).closest('.modal').modal('hide')
         inject_alert(xhr.responseJSON['errors'].join('<br/>'));
-        button = document.getElementsByName('commit')[0]
-        button.value = 'Create Collection'
-        button.disabled = false;
-        button.classList.remove('disabled');
+        $('.btn-stateful-loading').button('reset')
       }
       else window.location = '/admin/collections/' + encodeURIComponent(xhr.responseJSON['id']);
     });

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -48,6 +48,10 @@ Unless required by applicable law or agreed to in writing, software distributed
       if (xhr.responseJSON.hasOwnProperty('errors')){
         $(this).closest('.modal').modal('hide')
         inject_alert(xhr.responseJSON['errors'].join('<br/>'));
+        button = document.getElementsByName('commit')[0]
+        button.value = 'Create Collection'
+        button.disabled = false;
+        button.classList.remove('disabled');
       }
       else window.location = '/admin/collections/' + encodeURIComponent(xhr.responseJSON['id']);
     });


### PR DESCRIPTION
Fixes #1643 

I'm hoping Brian or Chris S might know a more elegant way to do this (reseting the whole form didn't do it), but if not, this works well enough for just enabling one button.