### PR TITLE
Collection managers can delete their collections

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -14,7 +14,7 @@
 
 class Admin::CollectionsController < ApplicationController
   before_filter :authenticate_user!
-  load_and_authorize_resource except: [:index]
+  load_and_authorize_resource except: [:index, :remove]
   before_filter :load_and_authorize_collections, only: [:index]
   respond_to :html
 
@@ -192,6 +192,8 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1/remove
   def remove
+    @collection = Admin::Collection.find(params['id'])
+    raise CanCan::AccessDenied unless current_ability.can? :destroy, @collection
     @objects    = @collection.media_objects
     @candidates = get_user_collections.reject { |c| c == @collection }
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,4 +37,24 @@ describe ApplicationController do
       post :create
     end
   end
+
+  describe '#get_user_collections' do
+    let(:collection1) { FactoryGirl.create(:collection) }
+    let(:collection2) { FactoryGirl.create(:collection) }
+
+    it 'returns all collections for an administrator' do
+      login_as :administrator
+      expect(controller.get_user_collections).to include(collection1)
+      expect(controller.get_user_collections).to include(collection2)
+    end
+    it 'returns only relevant collections for a manager' do
+      login_user collection1.managers.first
+      expect(controller.get_user_collections).to include(collection1)
+      expect(controller.get_user_collections).not_to include(collection2)
+    end
+    it 'returns no collections for an end-user' do
+      login_as :user
+      expect(controller.get_user_collections).to be_empty
+    end
+  end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -320,4 +320,20 @@ describe Admin::CollectionsController, type: :controller do
 
     end
   end
+
+  describe "#remove" do
+    let!(:collection) { FactoryGirl.create(:collection) }
+
+    it "redirects with message when user does not have ability to delete collection" do
+      login_as :user
+      expect(controller.current_ability.can? :destroy, collection).to be_falsey
+      expect(get :remove, id: collection.id).to redirect_to(root_path)
+      expect(flash[:notice]).not_to be_empty
+    end
+    it "displays confirmation form for managers" do
+      login_user collection.managers.first
+      expect(controller.current_ability.can? :destroy, collection).to be_truthy
+      expect(get :remove, id: collection.id).to render_template(:remove)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1646.

This PR manually checks if the current ability can destroy the collection since the action name doesn't match with the standard crud action granted in ability.  This matches the approach taken here: https://github.com/avalonmediasystem/avalon/pull/1597 .   Ideally these custom actions would be changed to be :delete and then we'd alias delete to destroy in ability.

Additional tests added for get_user_collections to ensure current code working as expected.