### PR TITLE
Managers should be able to delete sections of items within their collections

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -237,7 +237,7 @@ class MasterFilesController < ApplicationController
   # When destroying a file asset be sure to stop it first
   def destroy
     master_file = MasterFile.find(params[:id])
-    authorize! :delete, master_file, message: "You do not have sufficient privileges to delete files"
+    authorize! :destroy, master_file, message: "You do not have sufficient privileges to delete files"
     filename = File.basename(master_file.file_location) || master_file.id
     media_object = MediaObject.find(master_file.media_object_id)
     media_object.ordered_master_files.delete(master_file)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -126,7 +126,7 @@ class Ability
           is_member_of?(media_object.collection)
         end
 
-        can :edit, MasterFile do |master_file|
+        can [:edit, :destroy], MasterFile do |master_file|
           can? :edit, master_file.media_object
         end
 


### PR DESCRIPTION
Fixes #1683.

I mapped destroy master_file to edit master_file.media_object since it seemed like the best fit, but I'd be open to debating this.