### PR TITLE
Remove form-control class so btn-primary and btn-warning styles aren't overridden

### DIFF
--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -42,8 +42,8 @@ Unless required by applicable law or agreed to in writing, software distributed
       <% end %>
       <div class="row-fluid form-inline">
 	<div class="form-group">
-	  <%= f.submit 'Yes, I am sure', class: 'btn btn-danger form-control' %>
-	  <%= link_to 'No, go back', admin_collections_path, class: 'btn btn-primary form-control' %>
+	  <%= f.submit 'Yes, I am sure', class: 'btn btn-danger' %>
+	  <%= link_to 'No, go back', admin_collections_path, class: 'btn btn-primary' %>
 	</div>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes #1682.

@bkeese can you verify that this doesn't break anything else?  I see that you added the form-control classes 2 years ago here: https://github.com/avalonmediasystem/avalon/commit/f5350652e2debb7f829c0b13e5a60544e2175eb3