### PR TITLE
try less of a bundle update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,11 +121,11 @@ group :development do
   gem 'capistrano-passenger', require: false
 end
 
-# group :profiling do
-#   gem 'rack-mini-profiler', require: false
-#   gem 'stackprof', require: false
-#   gem 'flamegraph', require: false
-# end
+group :profiling do
+  gem 'rack-mini-profiler', require: false
+  gem 'stackprof', require: false
+  gem 'flamegraph', require: false
+end
 
 group :test do
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,14 +113,14 @@ GIT
 
 GIT
   remote: https://github.com/javan/whenever.git
-  revision: 1dcb91484e6f1ee91c9272daccbe84111754102b
+  revision: 075afb22a0f681ae5d2c4289b78e71527284bfe7
   specs:
     whenever (0.9.7)
       chronic (>= 0.6.3)
 
 GIT
   remote: https://github.com/projecthydra-labs/fedora-migrate.git
-  revision: bdd8782c37d6fbfc8774c446e434645d0b1beb16
+  revision: dfbe18ec838f2574b4f2d9d9003b3e61f83326d3
   specs:
     fedora-migrate (0.5.0)
       rchardet
@@ -137,9 +137,9 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra/ldp.git
-  revision: 9b562a3e0562c61165c3059f5bf8695b36f9a697
+  revision: a988e5fa5d94eb0f3f0b3a27d1190f632048736b
   specs:
-    ldp (0.6.4)
+    ldp (0.6.2)
       deprecation
       faraday
       http_logger
@@ -172,14 +172,14 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active-fedora (11.1.5)
+    active-fedora (11.0.1)
       active-triples (~> 0.11.0)
       activemodel (>= 4.2, < 6)
       activesupport (>= 4.2.4, < 6)
       deprecation
       ldp (~> 0.6.0)
-      rsolr (>= 1.1.2, < 3)
-      solrizer (>= 3.4, < 5)
+      rsolr (~> 1.1, >= 1.1.2)
+      solrizer (~> 3.4)
     active-triples (0.11.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -195,7 +195,7 @@ GEM
       nom-xml (>= 0.5.1)
       om (~> 3.1)
       rdf-rdfxml (~> 2.0)
-    active_fedora-noid (2.0.2)
+    active_fedora-noid (2.0.0)
       active-fedora (>= 9.7, < 12)
       noid (~> 0.9)
       rails (>= 4.2.7.1, < 6)
@@ -221,27 +221,27 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.2)
+    acts_as_list (0.8.2)
       activerecord (>= 3.0)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrussh (1.1.2)
+    airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    api-pagination (4.5.2)
+    api-pagination (4.5.1)
     arel (6.0.4)
     ast (2.3.0)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    autoprefixer-rails (6.7.6)
+    autoprefixer-rails (6.5.4)
       execjs
     bcrypt (3.1.11)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    blacklight (6.8.0)
+    blacklight (6.7.2)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -257,7 +257,7 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    bootstrap_form (2.6.0)
+    bootstrap_form (2.5.2)
     browse-everything (0.10.5)
       bootstrap-sass
       dropbox-sdk (>= 1.6.2)
@@ -271,8 +271,8 @@ GEM
       skydrive
     builder (3.2.3)
     byebug (9.0.6)
-    cancancan (1.16.0)
-    capistrano (3.7.2)
+    cancancan (1.15.0)
+    capistrano (3.7.1)
       airbrussh (>= 1.0.0)
       capistrano-harrow
       i18n
@@ -284,7 +284,7 @@ GEM
     capistrano-harrow (0.5.3)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
-    capistrano-rails (1.2.3)
+    capistrano-rails (1.2.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-resque (0.2.3)
@@ -294,7 +294,7 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capybara (2.12.1)
+    capybara (2.11.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -311,7 +311,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
-    coveralls (0.8.19)
+    coveralls (0.8.17)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)
@@ -328,20 +328,20 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.3)
+    diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.0)
-    dotenv-rails (2.2.0)
-      dotenv (= 2.2.0)
-      railties (>= 3.2, < 5.1)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     dropbox-sdk (1.6.5)
       json
     ebnf (1.1.0)
       rdf (~> 2.0)
       sxp (~> 1.0)
-    edtf (3.0.1)
+    edtf (3.0.0)
       activesupport (>= 3.0, < 6.0)
     email_spec (2.1.0)
       htmlentities (~> 4.3.3)
@@ -357,13 +357,13 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    fakefs (0.10.2)
-    faker (1.7.3)
+    fakefs (0.10.1)
+    faker (1.6.6)
       i18n (~> 0.5)
     fakeweb (1.3.0)
-    faraday (0.11.0)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fcrepo_wrapper (0.8.0)
+    fcrepo_wrapper (0.7.0)
       ruby-progressbar
     flamegraph (0.9.5)
     font-awesome-rails (4.7.0.1)
@@ -398,8 +398,8 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    hashdiff (0.3.2)
-    hashie (3.5.5)
+    hashdiff (0.3.1)
+    hashie (3.4.6)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -431,32 +431,23 @@ GEM
     ims-lti (1.1.13)
       builder
       oauth (>= 0.4.5, < 0.6)
-    jbuilder (2.6.3)
-      activesupport (>= 3.0.0, < 5.2)
+    jbuilder (2.6.1)
+      activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jquery-rails (4.2.2)
+    jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (1.8.6)
-    json-ld (2.1.2)
-      multi_json (~> 1.12)
+    json-ld (2.1.0)
+      multi_json (~> 1.11)
       rdf (~> 2.1)
     jwt (1.5.6)
-    kaminari (1.0.1)
-      activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.0.1)
-      kaminari-activerecord (= 1.0.1)
-      kaminari-core (= 1.0.1)
-    kaminari-actionview (1.0.1)
-      actionview
-      kaminari-core (= 1.0.1)
-    kaminari-activerecord (1.0.1)
-      activerecord
-      kaminari-core (= 1.0.1)
-    kaminari-core (1.0.1)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
@@ -488,11 +479,11 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.4.5)
-    net-http-digest_auth (1.4.1)
-    net-ldap (0.16.0)
+    net-http-digest_auth (1.4)
+    net-ldap (0.15.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (3.2.0)
     netrc (0.11.0)
     noid (0.9.0)
     nokogiri (1.7.0.1)
@@ -502,8 +493,8 @@ GEM
       i18n
       nokogiri
     oauth (0.5.1)
-    oauth2 (1.3.1)
-      faraday (>= 0.8, < 0.12)
+    oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -513,16 +504,16 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
-    omniauth (1.6.1)
-      hashie (>= 3.4.6, < 3.6.0)
-      rack (>= 1.6.2, < 3)
+    omniauth (1.3.1)
+      hashie (>= 1.2, < 4)
+      rack (>= 1.0, < 3)
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
     orm_adapter (0.5.0)
     os (0.9.6)
     parallel (1.10.0)
-    parser (2.4.0.0)
+    parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
     powerpack (0.1.1)
@@ -533,9 +524,9 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    pry-rails (0.3.5)
+    pry-rails (0.3.4)
       pry (>= 0.9.10)
-    public_suffix (2.0.5)
+    public_suffix (2.0.4)
     rack (1.6.5)
     rack-mini-profiler (0.10.2)
       rack (>= 1.2.0)
@@ -567,18 +558,18 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
+    rainbow (2.1.0)
     rake (12.0.0)
-    rb-readline (0.5.4)
+    rb-readline (0.5.3)
     rchardet (1.6.1)
     rdf (2.1.1)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
-    rdf-aggregate-repo (2.1.0)
+    rdf-aggregate-repo (2.0.0)
       rdf (~> 2.0)
     rdf-isomorphic (2.0.0)
       rdf (~> 2.0)
-    rdf-rdfa (2.1.1)
+    rdf-rdfa (2.0.1)
       haml (~> 4.0)
       htmlentities (~> 4.3)
       rdf (~> 2.0)
@@ -592,13 +583,13 @@ GEM
     rdf-turtle (2.0.0)
       ebnf (~> 1.0, >= 1.0.1)
       rdf (~> 2.0)
-    rdf-vocab (2.1.1)
+    rdf-vocab (2.1.0)
       rdf (~> 2.1)
-    rdf-xsd (2.1.0)
-      rdf (~> 2.1)
+    rdf-xsd (2.0.0)
+      rdf (~> 2.0)
     rdoc (4.3.0)
-    redis (3.3.3)
-    redis-namespace (1.5.3)
+    redis (3.3.2)
+    redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
@@ -613,12 +604,12 @@ GEM
       redis (~> 3.3)
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
-    rest-client (2.0.1)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (1.4.1)
-    roo (2.7.1)
+    roo (2.5.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.1.2)
@@ -662,9 +653,9 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.2.1)
-    rufus-scheduler (3.3.4)
+    rufus-scheduler (3.3.1)
       tzinfo
-    sass (3.4.23)
+    sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -686,7 +677,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sinatra (1.4.8)
+    sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
@@ -696,11 +687,11 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.21.0)
+    solr_wrapper (0.19.0)
       faraday
       ruby-progressbar
       rubyzip
-    solrizer (3.4.1)
+    solrizer (3.4.0)
       activesupport
       daemons
       nokogiri
@@ -713,8 +704,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
-    sshkit (1.12.0)
+    sqlite3 (1.3.12)
+    sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stackprof (0.2.10)
@@ -725,8 +716,8 @@ GEM
       tins (~> 1.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.6)
-    tins (1.13.2)
+    tilt (2.0.5)
+    tins (1.13.0)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -734,15 +725,15 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
-    uglifier (3.1.4)
+    uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.1.2)
     vegas (0.1.11)
       rack (>= 1.0.0)
-    warden (1.2.7)
+    warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
       activemodel (>= 4.0)
@@ -848,4 +839,4 @@ DEPENDENCIES
   with_locking
 
 BUNDLED WITH
-   1.13.7
+   1.14.3


### PR DESCRIPTION
@mbklein This fixes all your tests related to the log_level issue.  I recall back during a Rails upgrade @csyversen ran into either this exact bug or something very similar.  I also ran into it when trying to update a few gems.  Basically one of our gems really can't be updated past its current point release without breaking changes.  It might be kanimari as that is going from 0.17 to 1.00, but really with the way Ruby gems work any point release could be a breaking change.

In the interests of speed rather than going through all your changes one by one, I pulled develop's Gemfile.lock and then did `bundle install` to grab speedy-af and your annotations update.  All other gems remain pegged to what they are currently in the develop branch.  This should green up your tests.

If you have any gems you want updated let me know and I can try to update just that gem and go through them one at a time.

Tagging @davidschober @joncameron for reference.  