### PR TITLE
Use MasterFileBehavior to detect actual MasterFiles and also SolrPres…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
     else
       case obj
       when MediaObject then media_object_url(obj)
-      when MasterFile  then id_section_media_object_url(obj.media_object.id, obj.id)
+      when MasterFileBehavior then id_section_media_object_url(obj.media_object.id, obj.id)
       end
     end
   end


### PR DESCRIPTION
…enter proxies for MasterFiles

Fixes #1699 

Fixes playthough of MediaObjects from one section to the next.

Share links drive playthrough of item sections. They were being miscalculated due to MasterFiles being newly respresented by SolrPresenter proxies instead of actual MasterFiles. 