### PR TITLE
Removes reaction to autostart url param

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -88,7 +88,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       customError: '<%= t("media_objects.player.customError").html_safe %>',
       playlistItemDefaultTitle: '<%= @currentStream.embed_title.html_safe %>',
       displayTrackScrubber: true,
-      autostart: <%= params[:autostart] == 'true' %>,
       success: function(mediaElement, domObject, player) {
 	player.media.addEventListener('ended', function(e) {
             player.options.autostart=true;


### PR DESCRIPTION
Fixes #1702 

Autostart is no longer an accepted url param, since it is no longer needed. Autostart will be set automatically when the end of a section is reached.