### PR TITLE
Fix player load timing issue for autostart

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -132,6 +132,10 @@ class AvalonPlayer
           )
         $(@player.media).one 'loadedmetadata', initialize_view
         $(@player.media).one 'loadeddata', initialize_view
+        # in case media is not playable yet, also listen for canplay
+        $(@player.media).one 'canplay', =>
+          if @player.options.autostart
+            @player.media.play()
         keyboardAccess()
         @boundPrePlay()
         if @player.options.autostart


### PR DESCRIPTION
Refs #1702 

Fixes autostart (Pulled in from 5.x-stable)

Player load timing in some cases could cause the autoplay code to executed before player is ready. This tries again after player is ready.