### PR TITLE
Ensure that permalink DC.identifier gets populated from hasPermalink predicate

### DIFF
--- a/app/migration/fedora_migrate/master_file/object_mover.rb
+++ b/app/migration/fedora_migrate/master_file/object_mover.rb
@@ -30,6 +30,7 @@ module FedoraMigrate
         migrate_captions
         save
         migrate_relationships
+        migrate_permalink
         target.ldp_source.save #Because save isn't persisting the isPartOf relationship
         # super
       end

--- a/app/migration/fedora_migrate/media_object/object_mover.rb
+++ b/app/migration/fedora_migrate/media_object/object_mover.rb
@@ -14,6 +14,7 @@ module FedoraMigrate
         migrate_desc_metadata #Need to do this after target is saved
         migrate_workflow
         migrate_display_metadata
+        migrate_permalink
         # migrate_dates #skip because it doesn't do anything for us
         save
         # super

--- a/app/migration/fedora_migrate/reassign_id_object_mover.rb
+++ b/app/migration/fedora_migrate/reassign_id_object_mover.rb
@@ -44,5 +44,11 @@ module FedoraMigrate
       def migrate_relationships
         report.relationships = FedoraMigrate::ReassignIdRelsExtDatastreamMover.new(source, target).migrate
       end
+
+      def migrate_permalink
+        permalink_value = target.ldp_source.graph.find{|stmt| stmt.predicate == "http://projecthydra.org/ns/relations#hasPermalink"}.object.to_s rescue nil
+        return unless permalink_value
+        target.permalink = permalink_value 
+      end
   end
 end


### PR DESCRIPTION
Fixes #1604.

The predicate we use to store a permalink changed between R5 and R6.  This change to migration ensures that the new predicate is used while the old is preserved as well.