### PR TITLE
Use new section_stream route for playlist refresh …

### DIFF
--- a/app/views/playlists/_playlist_item.html.erb
+++ b/app/views/playlists/_playlist_item.html.erb
@@ -23,18 +23,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       <i class="fa fa-arrow-circle-right"></i>
     <% end %>
     <% masterfile = clip.master_file %>
-    <% clip_start = clip.start_time / 1000.0 %>
-    <% clip_end = clip.end_time / 1000.0 %>
-    <% clip_frag = "?t=#{clip_start},#{clip_end}" %>
-    <% link = id_section_media_object_path(MediaObject.find(masterfile.media_object_id), masterfile.id) + clip_frag %>
-    <% data = {
-        segment: masterfile.id,
-        is_video: masterfile.is_video?,
-        share_link: link,
-        native_url: link
-      } %>
-
-    <%#= link_to "#", data: data, onclick: 'reload_player(this);' do %>
     <% if @current_masterfile.is_video? == masterfile.is_video? && can?(:read, @current_playlist_item.clip.master_file.media_object) %>
       <%= link_to playlist_refresh_info_path(@playlist, position: item.position, autostart: true), remote: true do%>
         <%= clip.title %>

--- a/app/views/playlists/refresh_info.js.erb
+++ b/app/views/playlists/refresh_info.js.erb
@@ -21,7 +21,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% clip_start = @current_clip.start_time / 1000.0 %>
 <% clip_end = @current_clip.end_time / 1000.0 %>
 <% clip_frag = "?t=#{clip_start},#{clip_end}" %>
-<% link = id_section_media_object_path(@current_mediaobject, @current_masterfile.id) + clip_frag %>
+<% link = section_stream_media_object_path(@current_mediaobject, @current_masterfile.id) + clip_frag %>
 <% target_href = "a[href*='position=#{params[:position]}']".html_safe%>
 $('#accordion').replaceWith("<%= escape_javascript(render partial: 'info') %>");
 reload_player('<%= @current_masterfile.id %>', '<%= link %>', <%= @current_masterfile.is_video? %>);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
       get 'content/:file', :action => :deliver_content, :as => :inspect
       get 'track/:part', :action => :show, :as => :indexed_section
       get 'section/:content', :action => :show, :as => :id_section
-      get 'section/:content/stream', :action => :show_stream_details
+      get 'section/:content/stream', :action => :show_stream_details, :as => :section_stream
       get 'tree', :action => :tree, :as => :tree
       get :confirm_remove
     end


### PR DESCRIPTION
because old id_section route no longer supports .js requests

Fixes #173.

This commit removed support for .js requests to the id_section_media_object route in support of a new route which was performance optimized.  This PR updates the playlist to use this new route while naming it section_stream_media_object.  The rest of app/ has been checked to make sure none of the other calls to id_section_media_object needed to be updated.