### PR TITLE
Cwant/dev reload fix for avalon upstream

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,6 +23,22 @@ class CatalogController < ApplicationController
 
   before_filter :save_sticky_settings
 
+  if Rails.env.development?
+    # Hot-reload of rails confuses which Blacklight helpers it wants to use,
+    # we beat it into submission so that it uses ours ...
+    include ActionView::Helpers::TagHelper
+    include ActionView::Context
+    include ActionView::Helpers::NumberHelper
+    include ActionView::Helpers::TextHelper
+    include Blacklight::FacetsHelperBehavior
+    include Blacklight::ConfigurationHelperBehavior
+    include Blacklight::LocalBlacklightHelper
+
+    Blacklight::LocalBlacklightHelper.instance_methods.each do |method|
+      helper_method method
+    end
+  end
+
   #Override taken from Hydra::Controller::ControllerBehavior and reapplied here to be in scope
   def search_builder processor_chain = search_params_logic
     super.tap { |builder| builder.current_ability = current_ability }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,23 +21,9 @@ class CatalogController < ApplicationController
   include Hydra::Controller::ControllerBehavior
   include Hydra::MultiplePolicyAwareAccessControlsEnforcement
 
+  include BlacklightHelperReloadFix
+
   before_filter :save_sticky_settings
-
-  if Rails.env.development?
-    # Hot-reload of rails confuses which Blacklight helpers it wants to use,
-    # we beat it into submission so that it uses ours ...
-    include ActionView::Helpers::TagHelper
-    include ActionView::Context
-    include ActionView::Helpers::NumberHelper
-    include ActionView::Helpers::TextHelper
-    include Blacklight::FacetsHelperBehavior
-    include Blacklight::ConfigurationHelperBehavior
-    include Blacklight::LocalBlacklightHelper
-
-    Blacklight::LocalBlacklightHelper.instance_methods.each do |method|
-      helper_method method
-    end
-  end
 
   #Override taken from Hydra::Controller::ControllerBehavior and reapplied here to be in scope
   def search_builder processor_chain = search_params_logic

--- a/app/controllers/concerns/blacklight_helper_reload_fix.rb
+++ b/app/controllers/concerns/blacklight_helper_reload_fix.rb
@@ -1,0 +1,21 @@
+module BlacklightHelperReloadFix
+  extend ActiveSupport::Concern
+
+  included do
+    if Rails.env.development?
+      # Hot-reload of rails confuses which Blacklight helpers it wants to use,
+      # we beat it into submission so that it uses ours ...
+      include ActionView::Helpers::TagHelper
+      include ActionView::Context
+      include ActionView::Helpers::NumberHelper
+      include ActionView::Helpers::TextHelper
+      include Blacklight::FacetsHelperBehavior
+      include Blacklight::ConfigurationHelperBehavior
+      include Blacklight::LocalBlacklightHelper
+
+      Blacklight::LocalBlacklightHelper.instance_methods.each do |method|
+        helper_method method
+      end
+    end
+  end
+end


### PR DESCRIPTION
Third time's a charm, see previous PRs, particularly: https://github.com/avalonmediasystem/avalon/pull/1717

After code changes, the development environment reloads in a
way that it uses the wrong Blacklight helper definitions.
This change ensures it always uses our Blacklight helpers.