### PR TITLE
Convert Comment to a hash before passing to mailer, and then to an OpenStruct for processing

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -31,16 +31,16 @@ class CommentsController < ApplicationController
 
     if (@comment.valid?)
       begin
-	CommentsMailer.contact_email(@comment).deliver_later
+        CommentsMailer.contact_email(@comment.to_h).deliver_later
       rescue Errno::ECONNRESET => e
-	logger.warn "The mail server does not appear to be responding \n #{e}"
+        logger.warn "The mail server does not appear to be responding \n #{e}"
 
-	flash[:notice] = "The message could not be sent in a timely fashion. Contact us at #{Avalon::Configuration.lookup('email.support')} to report the problem."
-	render action: "index"
+        flash[:notice] = "The message could not be sent in a timely fashion. Contact us at #{Avalon::Configuration.lookup('email.support')} to report the problem."
+        render action: "index"
       end
     else
-     flash[:error] = "There were problems submitting your comment. Please correct the errors and try again."
-     render action: "index"
+      flash[:error] = "There were problems submitting your comment. Please correct the errors and try again."
+      render action: "index"
     end
   end
 

--- a/app/mailers/comments_mailer.rb
+++ b/app/mailers/comments_mailer.rb
@@ -16,7 +16,7 @@ class CommentsMailer < ActionMailer::Base
   default :to => Avalon::Configuration.lookup('email.comments')
   
   def contact_email(comment)
-    @comment = comment
-    mail(:from => comment.email, :subject => comment.subject)
+    @comment = OpenStruct.new(comment)
+    mail(:from => @comment.email, :subject => @comment.subject)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -65,4 +65,13 @@ class Comment
     false
   end
 
+  def to_h
+    {
+      name: name,
+      subject: subject,
+      email: email,
+      nickname: nickname,
+      comment: comment
+    }
+  end
 end


### PR DESCRIPTION
Fixes #1789 

ActiveJob can't serialize a `Comment`, but it can serialize a `Hash`. By leveraging `OpenStruct`, we can convert the `Comment` to a `Hash` for serializing, and then back to something that quacks like a `Comment` for rendering.