### PR TITLE
Test Avalon project link without visiting the Avalon website.

### DIFF
--- a/spec/features/capybara_homepage_spec.rb
+++ b/spec/features/capybara_homepage_spec.rb
@@ -48,9 +48,8 @@ end
 describe 'checks navigation to external links' do
   it 'checks navigation to Avalon Website' do
     visit '/'
-    click_link('Avalon Media System Project Website')
-    expect(page.status_code).to eq(200)
-    expect(page.current_url).to eq('http://www.avalonmediasystem.org/')
+    page.should have_link('Avalon Media System Project Website',
+                          href: 'http://www.avalonmediasystem.org')
   end
   it 'checks navigation to Contact us page' do
     visit '/'


### PR DESCRIPTION
One of the tests currently checks a link to the Avalon website by visiting the Avalon website.
Tests should not require the user being connected to the internet to pass.
The modified test just checks the href of the Avalon link.