### PR TITLE
Move mediaelement swf off screen

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/mediaelement_rails.git
-  revision: 02cb23fb807bf2992c7ee06cfa65e51feaeae641
+  revision: 273c6dab083afba8e1737f99ee87794d175d0e3a
   tag: avalon-r6_embed-fix
   specs:
     mediaelement_rails (0.5.1)


### PR DESCRIPTION
When we made the swf slightly bigger, it started to show up in the corner when playing the audio. I moved it off to the side.