### PR TITLE
Switch to webmock from fakeweb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,10 +135,10 @@ group :test do
   gem 'coveralls'
   gem 'shoulda-matchers'
   gem 'fakefs', require: 'fakefs/safe'
-  gem 'fakeweb'
   gem 'email_spec'
   gem 'capybara'
   gem 'hashdiff'
+  gem 'webmock'
 end
 
 group :mysql, optional: true do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -339,7 +341,6 @@ GEM
     fakefs (0.10.1)
     faker (1.6.6)
       i18n (~> 0.5)
-    fakeweb (1.3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.7.0)
@@ -648,6 +649,7 @@ GEM
     rubyzip (1.2.1)
     rufus-scheduler (3.3.1)
       tzinfo
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -733,6 +735,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     with_locking (1.0.2)
     xml-simple (1.1.5)
     xpath (2.0.0)
@@ -775,7 +781,6 @@ DEPENDENCIES
   factory_girl_rails
   fakefs
   faker
-  fakeweb
   fcrepo_wrapper
   fedora-migrate (~> 0.5.0)
   flamegraph
@@ -828,6 +833,7 @@ DEPENDENCIES
   stackprof
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  webmock
   whenever!
   with_locking
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -220,7 +220,7 @@ describe MediaObjectsController, type: :controller do
        end
         it "should create a new media_object with successful bib import" do
           Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db' }
-          FakeWeb.register_uri :get, sru_url, body: sru_response
+          stub_request(:get, sru_url).to_return(body: sru_response)
           fields = { bibliographic_id: bib_id }
           post 'create', format: 'json', import_bib_record: true, fields: fields, files: [master_file], collection_id: collection.id
           expect(response.status).to eq(200)
@@ -230,7 +230,7 @@ describe MediaObjectsController, type: :controller do
         end
         it "should create a new media_object with supplied fields when bib import fails" do
           Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db' }
-          FakeWeb.register_uri :get, sru_url, body: nil
+          stub_request(:get, sru_url).to_return(body: nil)
           ex_media_object = FactoryGirl.create(:media_object)
           fields = {}
           descMetadata_fields.each {|f| fields[f] = ex_media_object.send(f) }
@@ -266,7 +266,7 @@ describe MediaObjectsController, type: :controller do
         end
         it "should merge supplied other identifiers after bib import" do
           Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db' }
-          FakeWeb.register_uri :get, sru_url, body: sru_response
+          stub_request(:get, sru_url).to_return(body: sru_response)
           fields = { bibliographic_id: bib_id, other_identifier_type: ['other'], other_identifier: ['12345'] }
           post 'create', format: 'json', import_bib_record: true, fields: fields, files: [master_file], collection_id: collection.id
           expect(response.status).to eq(200)

--- a/spec/lib/avalon/batch_ingest_spec.rb
+++ b/spec/lib/avalon/batch_ingest_spec.rb
@@ -57,7 +57,7 @@ describe Avalon::Batch::Ingest do
       @dropbox_dir = collection.dropbox.base_directory
       FileUtils.cp_r 'spec/fixtures/dropbox/example_batch_ingest', @dropbox_dir
       Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db' }
-      FakeWeb.register_uri :get, sru_url, body: sru_response
+      stub_request(:get, sru_url).to_return(body: sru_response)
       manifest_file = File.join(@dropbox_dir,'example_batch_ingest','batch_manifest.xlsx')
       batch = Avalon::Batch::Package.new(manifest_file, collection)
       allow_any_instance_of(Avalon::Dropbox).to receive(:find_new_packages).and_return [batch]
@@ -67,7 +67,6 @@ describe Avalon::Batch::Ingest do
       if @dropbox_dir =~ %r{spec/fixtures/dropbox/Ut}
         FileUtils.rm_rf @dropbox_dir
       end
-      FakeWeb.clean_registry
     end
 
     it 'should send email when batch finishes processing' do

--- a/spec/lib/avalon/bib_retriever_spec.rb
+++ b/spec/lib/avalon/bib_retriever_spec.rb
@@ -44,36 +44,30 @@ describe Avalon::BibRetriever do
 
     describe 'default namespace' do
       let(:sru_response) { File.read(File.expand_path("../../../fixtures/#{bib_id}.xml",__FILE__)) }
+      let!(:request) { stub_request(:get, sru_url).to_return(body: sru_response) }
 
       before :each do
         Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db' }
-        FakeWeb.register_uri :get, sru_url, body: sru_response
-      end
-
-      after :each do
-        FakeWeb.clean_registry
       end
 
       it 'retrieves proper MODS' do
         response = Avalon::BibRetriever.instance.get_record("^%#{bib_id}")
+        expect(request).to have_been_requested
         expect(Nokogiri::XML(response)).to be_equivalent_to(mods)
       end
     end
 
     describe 'alternate namespace' do
       let(:sru_response) { File.read(File.expand_path("../../../fixtures/#{bib_id}-ns.xml",__FILE__)) }
+      let!(:request) { stub_request(:get, sru_url).to_return(body: sru_response) }
 
       before :each do
         Avalon::Configuration['bib_retriever'] = { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db', 'namespace' => 'http://example.edu/fake/sru/namespace/' }
-        FakeWeb.register_uri :get, sru_url, body: sru_response
-      end
-
-      after :each do
-        FakeWeb.clean_registry
       end
 
       it 'retrieves proper MODS' do
         response = Avalon::BibRetriever.instance.get_record("^%#{bib_id}")
+        expect(request).to have_been_requested
         expect(Nokogiri::XML(response)).to be_equivalent_to(mods)
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,7 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'database_cleaner'
 require 'active_fedora/cleaner'
+require 'webmock/rspec'
 # require 'equivalent-xml/rspec_matchers'
 # require 'fakefs/safe'
 # require 'fileutils'
@@ -66,6 +67,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
+    WebMock.disable_net_connect!(allow_localhost: true)
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
 
@@ -84,6 +86,7 @@ RSpec.configure do |config|
       Avalon::Configuration['dropbox']['path'] = Avalon::Configuration.lookup('spec.real_dropbox')
       Avalon::Configuration.delete('spec')
     end
+    WebMock.allow_net_connect!
   end
 
   config.before :each do


### PR DESCRIPTION
Fakeweb hasn't had a release since 2010 and doesn't support rspec's expectations.  Webmock's last release was days ago and has a matcher that makes expectations easy and straightforward.  This switch enables easy and clear testing for #1833.

Closes #1834.