### PR TITLE
Position swf outside only if audio

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git'
 gem 'about_page', git: 'https://github.com/avalonmediasystem/about_page.git', tag: 'avalon-r6'
 
 #MediaElement.js related
-gem 'mediaelement_rails', git: 'https://github.com/avalonmediasystem/mediaelement_rails.git', tag: 'avalon-r6_embed-fix'
+gem 'mediaelement_rails', git: 'https://github.com/avalonmediasystem/mediaelement_rails.git', tag: 'avalon-r6_flash-fix'
 gem 'mediaelement-qualityselector', git:'https://github.com/avalonmediasystem/mediaelement-qualityselector.git', tag: 'avalon-r4'
 gem 'media_element_thumbnail_selector', git: 'https://github.com/avalonmediasystem/media-element-thumbnail-selector', tag: 'avalon-r4'
 gem 'mediaelement-skin-avalon', git:'https://github.com/avalonmediasystem/mediaelement-skin-avalon.git', tag: 'avalon-r5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,8 +76,8 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/mediaelement_rails.git
-  revision: 273c6dab083afba8e1737f99ee87794d175d0e3a
-  tag: avalon-r6_embed-fix
+  revision: 8ce0042124460f1c3893372afcee34a93d25f8fd
+  tag: avalon-r6_flash-fix
   specs:
     mediaelement_rails (0.5.1)
       jquery-rails (>= 1.0)
@@ -838,4 +838,4 @@ DEPENDENCIES
   with_locking
 
 BUNDLED WITH
-   1.14.3
+   1.14.6


### PR DESCRIPTION
We can't have our embed fix for audio messing with the video container, so I added a condition to changing the style to move offscreen: it has to be audio.