### PR TITLE
migrated_from should index and be used correctly

### DIFF
--- a/app/migration/fedora_migrate/class_ordered_repository_migrator.rb
+++ b/app/migration/fedora_migrate/class_ordered_repository_migrator.rb
@@ -21,8 +21,9 @@ module FedoraMigrate
       class_order.each do |klass|
         @klass = klass
         klass.class_eval do
-          property :migrated_from, predicate: RDF::URI("http://www.w3.org/ns/prov#wasDerivedFrom"), multiple: false do |index|
-            index.as :stored_searchable
+          # We don't really need multiple true but there is a bug with indexing single valued URI objects
+          property :migrated_from, predicate: RDF::URI("http://www.w3.org/ns/prov#wasDerivedFrom"), multiple: true do |index|
+            index.as :symbol
           end
         end
         @source_objects = nil
@@ -71,7 +72,7 @@ module FedoraMigrate
         unless (status_record.status == 'failed') && (method == :second_pass)
           begin
             status_record.update_attributes status: method.to_s, log: nil
-            target = klass.where(migrated_from_tesim: construct_migrate_from_uri(source).to_s).first
+            target = klass.where(migrated_from_ssim: construct_migrate_from_uri(source).to_s).first
             options[:report] = report.reload[source.pid]
             result.object = object_mover.new(source, target, options).send(method)
             status_record.reload

--- a/app/migration/fedora_migrate/media_object/master_file_aggregation_mover.rb
+++ b/app/migration/fedora_migrate/media_object/master_file_aggregation_mover.rb
@@ -22,7 +22,7 @@ module FedoraMigrate
           sections_md = Nokogiri::XML(source.datastreams['sectionsMetadata'].content)
           old_pid_order = sections_md.xpath('fields/section_pid').collect(&:text)
           target.ordered_master_files = master_files.sort do |a,b|
-            old_pid_order.index(a.migrated_from.to_s) <=> old_pid_order.index(b.migrated_from.to_s)
+            old_pid_order.index(pid_from_obj(a)) <=> old_pid_order.index(pid_from_obj(b))
           end
         else
           target.ordered_master_files = master_files
@@ -30,6 +30,11 @@ module FedoraMigrate
         target.save
         master_files.collect(&:id)
       end
+
+      private
+        def pid_from_obj(obj)
+          obj.migrated_from.first.rdf_subject.to_s.split('/').last
+        end
     end
   end
 end

--- a/app/migration/fedora_migrate/reassign_id_object_mover.rb
+++ b/app/migration/fedora_migrate/reassign_id_object_mover.rb
@@ -25,7 +25,7 @@ module FedoraMigrate
 
     def complete_target
       after_object_migration
-      target.migrated_from = construct_migrate_from_uri(source)
+      target.migrated_from = [construct_migrate_from_uri(source)]
       save
       complete_report
     end


### PR DESCRIPTION
Fixes #1877.  This works around the URI indexing issue by setting the property to multiple: true.