### PR TITLE
Eliminate empty strings when updating attributes

### DIFF
--- a/app/models/concerns/media_object_mods.rb
+++ b/app/models/concerns/media_object_mods.rb
@@ -86,7 +86,7 @@ module MediaObjectMods
 
   def alternative_title=(value)
     delete_all_values(:alternative_title)
-    Array(value).each { |val| descMetadata.add_alternative_title(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_alternative_title(val) if val.present? }
   end
 
   # has_attributes :translated_title, datastream: :descMetadata, at: [:translated_title], multiple: true
@@ -96,7 +96,7 @@ module MediaObjectMods
 
   def translated_title=(value)
     delete_all_values(:translated_title)
-    Array(value).each { |val| descMetadata.add_translated_title(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_translated_title(val) if val.present? }
   end
 
   # has_attributes :uniform_title, datastream: :descMetadata, at: [:uniform_title], multiple: true
@@ -106,7 +106,7 @@ module MediaObjectMods
 
   def uniform_title=(value)
     delete_all_values(:uniform_title)
-    Array(value).each { |val| descMetadata.add_uniform_title(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_uniform_title(val) if val.present? }
   end
 
   # has_attributes :statement_of_responsibility, datastream: :descMetadata, at: [:statement_of_responsibility], multiple: false
@@ -126,7 +126,7 @@ module MediaObjectMods
 
   def creator=(value)
     delete_all_values(:creator)
-    Array(value).each { |val| descMetadata.add_creator(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_creator(val) if val.present? }
   end
 
   # has_attributes :date_created, datastream: :descMetadata, at: [:date_created], multiple: false
@@ -180,7 +180,7 @@ module MediaObjectMods
 
   def note=(value_hashes)
     delete_all_values(:note)
-    Array(value_hashes).each { |val| descMetadata.add_note(val[:note], val[:type]) } if value_hashes.present?
+    Array(value_hashes).each { |val| descMetadata.add_note(val[:note], val[:type]) if val[:note].present? and val[:type].present? }
   end
 
 
@@ -198,7 +198,7 @@ module MediaObjectMods
 
   def format=(value)
     delete_all_values(:media_type)
-    Array(value).each { |val| descMetadata.add_media_type(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_media_type(val) if val.present? }
   end
 
   # has_attributes :resource_type, datastream: :descMetadata, at: [:resource_type], multiple: true
@@ -219,7 +219,7 @@ module MediaObjectMods
 
   def contributor=(value)
     delete_all_values(:contributor)
-    Array(value).each { |val| descMetadata.add_contributor(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_contributor(val) if val.present? }
   end
 
   # has_attributes :publisher, datastream: :descMetadata, at: [:publisher], multiple: true
@@ -229,7 +229,7 @@ module MediaObjectMods
 
   def publisher=(value)
     delete_all_values(:publisher)
-    Array(value).each { |val| descMetadata.add_publisher(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_publisher(val) if val.present? }
   end
 
   # has_attributes :genre, datastream: :descMetadata, at: [:genre], multiple: true
@@ -250,7 +250,7 @@ module MediaObjectMods
 
   def subject=(value)
     delete_all_values(:topical_subject)
-    Array(value).each { |val| descMetadata.add_topical_subject(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_topical_subject(val) if val.present? }
   end
 
   # has_attributes :related_item_url, datastream: :descMetadata, at: [:related_item_url], multiple: true
@@ -261,7 +261,7 @@ module MediaObjectMods
   def related_item_url=(value_hashes)
     delete_all_values(:related_item_url)
     delete_all_values(:related_item_label)
-    Array(value_hashes).each { |val| descMetadata.add_related_item_url(val[:url], val[:label]) } if value_hashes.present?
+    Array(value_hashes).each { |val| descMetadata.add_related_item_url(val[:url], val[:label]) if val[:url].present? and val[:label].present? }
   end
 
   # has_attributes :geographic_subject, datastream: :descMetadata, at: [:geographic_subject], multiple: true
@@ -271,7 +271,7 @@ module MediaObjectMods
 
   def geographic_subject=(value)
     delete_all_values(:geographic_subject)
-    Array(value).each { |val| descMetadata.add_geographic_subject(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_geographic_subject(val) if val.present? }
   end
 
   # has_attributes :temporal_subject, datastream: :descMetadata, at: [:temporal_subject], multiple: true
@@ -281,7 +281,7 @@ module MediaObjectMods
 
   def temporal_subject=(value)
     delete_all_values(:temporal_subject)
-    Array(value).each { |val| descMetadata.add_temporal_subject(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_temporal_subject(val) if val.present? }
   end
 
   # has_attributes :topical_subject, datastream: :descMetadata, at: [:topical_subject], multiple: true
@@ -291,7 +291,7 @@ module MediaObjectMods
 
   def topical_subject=(value)
     delete_all_values(:topical_subject)
-    Array(value).each { |val| descMetadata.add_topical_subject(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_topical_subject(val) if val.present? }
   end
 
   # has_attributes :bibliographic_id, datastream: :descMetadata, at: [:bibliographic_id], multiple: false
@@ -309,7 +309,7 @@ module MediaObjectMods
   end
   def language=(value)
     delete_all_values(:language)
-    Array(value).each { |val| descMetadata.add_language(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_language(val) if val.present? }
   end
   def language_code=(value)
     delete_all_values(:language_code)
@@ -336,7 +336,7 @@ module MediaObjectMods
   end
   def table_of_contents=(value)
     delete_all_values(:table_of_contents)
-    descMetadata.table_of_contents = value if value.present?
+    descMetadata.table_of_contents = Array(value).compact if value.present?
   end
 
   # has_attributes :physical_description, datastream: :descMetadata, at: [:physical_description], multiple: true
@@ -345,7 +345,7 @@ module MediaObjectMods
   end
   def physical_description=(value)
     delete_all_values(:physical_description)
-    Array(value).each { |val| descMetadata.add_physical_description(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_physical_description(val) if val.present? }
   end
 
   # has_attributes :related_item_url, datastream: :descMetadata, at: [:related_item_url], multiple: true
@@ -356,7 +356,7 @@ module MediaObjectMods
   def related_item_url=(value_hashes)
     delete_all_values(:related_item_url)
     delete_all_values(:related_item_label)
-    Array(value_hashes).each { |val| descMetadata.add_related_item_url(val[:url], val[:label]) } if value_hashes.present?
+    Array(value_hashes).each { |val| descMetadata.add_related_item_url(val[:url], val[:label]) if val[:url].present? and val[:label].present? }
   end
 
   # has_attributes :other_identifier, datastream: :descMetadata, at: [:other_identifier], multiple: true
@@ -365,7 +365,7 @@ module MediaObjectMods
   end
   def other_identifier=(value_hashes)
     delete_all_values(:other_identifier)
-    Array(value_hashes).each { |val| descMetadata.add_other_identifier(val[:id], val[:source]) } if value_hashes.present?
+    Array(value_hashes).each { |val| descMetadata.add_other_identifier(val[:id], val[:source]) if val[:id].present? and val[:source].present? }
   end
 
   # has_attributes :record_identifier, datastream: :descMetadata, at: [:record_identifier], multiple: true
@@ -374,7 +374,7 @@ module MediaObjectMods
   end
   def record_identifier=(value)
     delete_all_values(:record_identifier)
-    Array(value).each { |val| descMetadata.add_record_identifier(val) } if value.present?
+    Array(value).each { |val| descMetadata.add_record_identifier(val) if val.present? }
   end
 
   # def find_metadata_attribute(attribute)


### PR DESCRIPTION
Fixes #1667 

Eliminate empty strings when updating attributes.

When the UI form is submitted, empty strings are submitted for those fields without values. This PR removes empty strings from multi-value fields.