### PR TITLE
Make cookie secure and httponly

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 #Avalon::Application.config.session_store :cookie_store, :key => '_avalon_session'
-Avalon::Application.config.session_store :active_record_store
+Avalon::Application.config.session_store :active_record_store, secure: Rails.env.production?, httponly: true
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
This was a local change we made to production to fix redirection after SSO login.