### PR TITLE
Use bookmark count as solr :rows parameter instead of default

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -93,11 +93,17 @@ class BookmarksController < CatalogController
   #   end
   # end
 
-  # def action_documents
+  # def action_documents (R5)
   #   bookmarks = token_or_current_or_guest_user.bookmarks
   #   bookmark_ids = bookmarks.collect { |b| b.document_id.to_s }
   #   get_solr_response_for_document_ids(bookmark_ids, rows: bookmark_ids.count, defType: 'edismax')
   # end
+
+  def action_documents
+    bookmarks = token_or_current_or_guest_user.bookmarks
+    bookmark_ids = bookmarks.collect { |b| b.document_id.to_s }
+    fetch(bookmark_ids, rows: bookmark_ids.count)
+  end
 
   def access_control_action documents
     errors = []

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -35,6 +35,15 @@ describe BookmarksController, type: :controller do
       expect(flash[:success]).to eq(I18n.t("blacklight.delete.success", count: 3))
       media_objects.each {|mo| expect(MediaObject.exists?(mo.id)).to be_falsey }
     end
+    it "should remove more than the blacklight default number of items (>10)" do
+      8.times do
+        media_objects << mo = FactoryGirl.create(:media_object, collection: collection)
+        post :create, id: mo.id
+      end
+      post :delete
+      expect(flash[:success]).to eq(I18n.t("blacklight.delete.success", count: 11))
+      media_objects.each {|mo| expect(MediaObject.exists?(mo.id)).to be_falsey }
+    end
   end
 
   describe "#update_status" do


### PR DESCRIPTION
Fixes #1927 

Overrides blacklight default for bulk action bookmark count. 