### PR TITLE
Exclude Fedora ids from Other Identifiers in UI

### DIFF
--- a/app/models/mods_document.rb
+++ b/app/models/mods_document.rb
@@ -163,7 +163,7 @@ class ModsDocument < ActiveFedora::OmDatastream
       t.creation_date(:path => 'recordCreationDate')
       t.change_date(:path => 'recordChangeDate')
       t.identifier(:path => "recordIdentifier[@source='Fedora']") { t.source_(:path => '@source', :namespace_prefix => nil) }
-      t.bibliographic_id(:path => "recordIdentifier[@source!='Fedora']") { t.source_(:path => '@source', :namespace_prefix => nil) }
+      t.bibliographic_id(:path => "recordIdentifier[@source!='Fedora' and @source!='Fedora4']") { t.source_(:path => '@source', :namespace_prefix => nil) }
       t.language_of_cataloging(:path => 'languageOfCataloging') { t.language_term(:path => 'languageTerm') }
       t.language(:proxy => [:language_of_cataloging, :language_term])
     end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -372,7 +372,6 @@ describe MediaObject do
 
   describe "Update datastream directly" do
     it "should reflect datastream changes on media object" do
-      newtitle = Faker::Lorem.sentence
       media_object.descMetadata.add_bibliographic_id('ABC123','local')
       media_object.save
       media_object.reload
@@ -388,6 +387,17 @@ describe MediaObject do
     it "should include actual strings" do
       media_object.update_attributes({'table_of_contents' => ['Test']})
       expect(media_object.table_of_contents).to eq(['Test'])
+    end
+  end
+
+  describe "Bibliographic Identifiers" do
+    it "should exclude recordIdentifier[@source = Fedora or Fedora4]" do
+      media_object.descMetadata.add_bibliographic_id('ABC123','local')
+      media_object.descMetadata.add_bibliographic_id('DEF456','Fedora')
+      media_object.descMetadata.add_bibliographic_id('GHI789','Fedora4')
+      media_object.save
+      media_object.reload
+      expect(media_object.bibliographic_id).to eq({source: "local", id: 'ABC123'})
     end
   end
 


### PR DESCRIPTION
Fixes #1938 

Excludes Fedora identifiers from Other Identifiers in UI

Other Identifiers in the UI shows other identifiers and bibliographic ids. The xpath for selecting these was excluding those with source="Fedora", but not the new ones with source="Fedora4". This PR also excludes those with source="Fedora4"