### PR TITLE
Fix UTF8 conversion issue

### DIFF
--- a/app/migration/fedora_migrate/master_file/object_mover.rb
+++ b/app/migration/fedora_migrate/master_file/object_mover.rb
@@ -77,7 +77,7 @@ module FedoraMigrate
 
       def migrate_file_location
         return unless source.datastreams.keys.include?(MASTERFILE_DATASTREAM)
-        target.masterFile = source.datastreams[MASTERFILE_DATASTREAM].content
+        target.masterFile = source.datastreams[MASTERFILE_DATASTREAM].content.to_s.force_encoding(Encoding.default_external)
       end
 
       def migrate_title


### PR DESCRIPTION
This fixes a corner case bug where content being copied from the masterFile datastream into the new RDF property threw an error dealing with converting between ASCII-UTF8 and UTF8.