### PR TITLE
Use DB-backed noid minter by default

### DIFF
--- a/config/initializers/active_fedora-noid.rb
+++ b/config/initializers/active_fedora-noid.rb
@@ -1,0 +1,5 @@
+require 'active_fedora/noid'
+
+ActiveFedora::Noid.configure do |config|
+  config.minter_class = ActiveFedora::Noid::Minter::Db
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523195146) do
+ActiveRecord::Schema.define(version: 20170530173242) do
 
   create_table "annotations", force: :cascade do |t|
     t.string  "uuid"
@@ -86,6 +86,18 @@ ActiveRecord::Schema.define(version: 20170523195146) do
   end
 
   add_index "migration_statuses", ["source_class", "f3_pid", "datastream"], name: "index_migration_statuses"
+
+  create_table "minter_states", force: :cascade do |t|
+    t.string   "namespace",            default: "default", null: false
+    t.string   "template",                                 null: false
+    t.text     "counters"
+    t.integer  "seq",        limit: 8, default: 0
+    t.binary   "rand"
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+  end
+
+  add_index "minter_states", ["namespace"], name: "index_minter_states_on_namespace", unique: true
 
   create_table "playlist_items", force: :cascade do |t|
     t.integer  "playlist_id", null: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ require 'capybara/rails'
 require 'database_cleaner'
 require 'active_fedora/cleaner'
 require 'webmock/rspec'
+require 'active_fedora/noid/rspec'
 # require 'equivalent-xml/rspec_matchers'
 # require 'fakefs/safe'
 # require 'fileutils'
@@ -58,6 +59,8 @@ Shoulda::Matchers.configure do |config|
 end
 
 RSpec.configure do |config|
+  include ActiveFedora::Noid::RSpec
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -70,6 +73,7 @@ RSpec.configure do |config|
     WebMock.disable_net_connect!(allow_localhost: true)
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
+    disable_production_minter!
 
     # Stub the entire dropbox
     Avalon::Configuration['spec'] = {
@@ -86,6 +90,7 @@ RSpec.configure do |config|
       Avalon::Configuration['dropbox']['path'] = Avalon::Configuration.lookup('spec.real_dropbox')
       Avalon::Configuration.delete('spec')
     end
+    enable_production_minter!
     WebMock.allow_net_connect!
   end
 


### PR DESCRIPTION
This is a change to use the recommended database backed minter for noids instead of the minter state yaml file.  There is a rake task to copy the state from the file into the database: `rake active_fedora:noid:migrate:file_to_database`.  This should hopefully clear up errors we are seeing running our migration with multiple processes where we get Ldp::Conflict about every 1000 objects.