### PR TITLE
Make master file destroy callbacks safe

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -191,7 +191,6 @@ class MasterFilesController < ApplicationController
           error << file.original_filename
           error << " (" << file.content_type << ")"
           flash[:error].push error
-          master_file.destroy
           next
         else
           flash[:notice] = create_upload_notice(master_file.file_format)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -670,11 +670,12 @@ class MasterFile < ActiveFedora::Base
   def stop_processing!
     # Stops all processing
     if workflow_id.present? && !finished_processing?
-      encoder_class.find(workflow_id).cancel!
+      encoder_class.find(workflow_id).try(:cancel!)
     end
   end
 
   def update_parent!
+    return unless media_object.present?
     media_object.master_files.delete(self)
     media_object.ordered_master_files.delete(self)
     media_object.set_media_types!

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -15,15 +15,6 @@
 require 'rails_helper'
 
 describe MasterFilesController do
-  before do
-    MasterFile.skip_callback(:destroy, :before, :stop_processing!)
-    MasterFile.skip_callback(:destroy, :before, :update_parent!)
-  end
-  after do
-    MasterFile.set_callback(:destroy, :before, :stop_processing!)
-    MasterFile.set_callback(:destroy, :before, :update_parent!)
-  end
-
   describe "#create" do
     let(:media_object) { FactoryGirl.create(:media_object) }
     # TODO: fill in the lets below with a legitimate values from mediainfo

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -494,4 +494,19 @@ describe MasterFile do
       expect(master_file.structuralMetadata.original_name).to eq 'structuralMetadata.xml'
     end
   end
+
+  describe 'update_parent!' do
+    it 'does not error if the master file has no parent' do
+      expect { MasterFile.new.send(:update_parent!) }.not_to raise_error
+    end
+  end
+
+  describe 'stop_processing!' do
+    before do
+      allow(ActiveEncode::Base).to receive(:find).and_return(nil)
+    end
+    it 'does not error if the master file has no encode' do
+      expect { MasterFile.new(workflow_id: '1', status_code: 'RUNNING').send(:stop_processing!) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Also remove unnecessary destroy in controller.  Fixes #1769.

The issue in #1769 was that the master file was getting `.destroy` called on it even though it hadn't been persisted yet.  This triggered callbacks which tried to access `media_object` which was nil and an exception was thrown.  This PR ensures those callbacks are safe even when values are missing and removes the `.destroy` call since it was unnecessary.  The issue was masked because we had turned off those callbacks in the controller tests so this PR reenables them now that they are safe.