### PR TITLE
Convert ?s in collection dropbox name

### DIFF
--- a/lib/avalon/sanitizer.rb
+++ b/lib/avalon/sanitizer.rb
@@ -14,7 +14,7 @@
 
 module Avalon
   module Sanitizer
-    def self.sanitize(name, translations=['\\/ &:.','______'])
+    def self.sanitize(name, translations=['\\/ &:.?','_______'])
       name.tr *translations
     end
   end


### PR DESCRIPTION
Fixes #1920 

Converts question marks in collection names so dropbox folder creation can succeed.