### PR TITLE
Bibimport: changes for other_identifier and button confirmation

### DIFF
--- a/app/assets/javascripts/import_button.js.coffee
+++ b/app/assets/javascripts/import_button.js.coffee
@@ -14,10 +14,27 @@
 
 
 $ ->
-  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes">Import</button></div>'
+  form = $('div.import-button').closest('form').prop('id')
+  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes" form="'+form+'">Import</button></div>'
   $('div.import-button').append(import_button_html)
   enable_bib_btn()
   $('#media_object_bibliographic_id').keyup -> enable_bib_btn()
+
+  $(document).on 'click', '#cancel_bibimport', ->
+    $('#media_object_bibliographic_id_btn').popover 'hide'
+    true
+  $('#media_object_bibliographic_id_btn').popover(
+    trigger: 'manual'
+    html: true
+    placement: 'top'
+    container: 'body'
+    content: ->
+      button = '<button class="btn btn-xs btn-danger btn-confirm" type="submit" name="media_object[import_bib_record]" value="yes" data-original-title="" title="" form="'+$(this).attr('form')+'" >Import</button>'
+      '<p>Note: this will replace all metadata except for Other Identifiers</p> ' + button + ' <button id=\'cancel_bibimport\' class=\'btn btn-xs btn-primary\'>No, Cancel</button>'
+  ).click ->
+    $('.btn-confirmation').popover 'hide'
+    $(this).popover 'show'
+    false
 
 enable_bib_btn = ->
     if $('#media_object_bibliographic_id').val() == ""


### PR DESCRIPTION
Fixes #1837 

Adds a confirmation popup to the bib import button.
De-dupes languages imported.
Keeps and de-dupes old other_identifier list
Removes previously used bibliographic_id from other_identifier list
Add newly used bibliographic_id to other_identifier list