### PR TITLE
Resolve derivative resolution to width/height

### DIFF
--- a/app/migration/fedora_migrate/derivative/encoding_datastream_mover.rb
+++ b/app/migration/fedora_migrate/derivative/encoding_datastream_mover.rb
@@ -28,9 +28,15 @@ module FedoraMigrate
         target.audio_codec = present_or_nil(encodingProfile.xpath('//audio/codec').text)
         target.video_bitrate = present_or_nil(encodingProfile.xpath('//video/bitrate').text)
         target.video_codec = present_or_nil(encodingProfile.xpath('//video/codec').text)
-        target.width = width = present_or_nil(encodingProfile.xpath('//video/resolution/width').text)
-        target.height = height = present_or_nil(encodingProfile.xpath('//video/resolution/height').text)
-        target.resolution = "#{width}x#{height}" if width.present? && height.present?
+        resolution = present_or_nil(encodingProfile.xpath('//video/resolution').text)
+        res_width,res_height = resolution.present? resolution.split('x') : [nil,nil]
+        width = present_or_nil(encodingProfile.xpath('//video/resolution/width').text)
+        height = present_or_nil(encodingProfile.xpath('//video/resolution/height').text)
+        if (res_width.present? and width.present? and res_width!=width) or (res_height.present? and height.present? and res_height!=height)
+          raise FedoraMigrate::Errors::MigrationError, "Derivative resolution and height/width do not match" 
+        end
+        target.width = width || res_width
+        target.height = height || res_height
         super
       end
 


### PR DESCRIPTION
Fixes #1992 

Checks derivatives resolution and height/width for migration. Raise error if they both exist but do not match.