### PR TITLE
Fix playthrough for changing media types

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -212,5 +212,8 @@ class AvalonPlayer
           $.getJSON uri, params.join('&'), (data) =>
             @player.options.autostart = autostart
             @setStreamInfo(data)
+      else
+        @click()
+      return
 
 (exports ? this).AvalonPlayer = AvalonPlayer


### PR DESCRIPTION
Fixes #1838 

Fixes playthrough for changing media types.

Section click default action was not occurring even though e.isDefaultPrevented() was false.