### PR TITLE
Migrate Leases before Media Objects since they are referenced by...

### DIFF
--- a/app/migration/fedora_migrate/lease/object_mover.rb
+++ b/app/migration/fedora_migrate/lease/object_mover.rb
@@ -19,8 +19,8 @@ module FedoraMigrate
 
       def migrate
         #find mediaobject pid to see if it's already failed
-        media_object_pids = FedoraMigrate.source.connection.find_by_sparql("SELECT ?pid FROM <#ri> WHERE { ?pid <http://projecthydra.org/ns/relations#isGovernedBy> <#{source.uri}> }").collect(&:pid)
-        raise FedoraMigrate::Errors::MigrationError, "Parent media object(s) (#{media_object_pids}) failed to migrate" if media_object_pids.all? {|mo_pid| MigrationStatus.where(f3_pid: mo_pid).first.status == "failed" }
+#        media_object_pids = FedoraMigrate.source.connection.find_by_sparql("SELECT ?pid FROM <#ri> WHERE { ?pid <http://projecthydra.org/ns/relations#isGovernedBy> <#{source.uri}> }").collect(&:pid)
+#        raise FedoraMigrate::Errors::MigrationError, "Parent media object(s) (#{media_object_pids}) failed to migrate" if media_object_pids.all? {|mo_pid| MigrationStatus.where(f3_pid: mo_pid).first.status == "failed" }
         super
       end
 

--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -48,7 +48,7 @@ EOC
       Admin::Collection.skip_callback(:save, :around, :reindex_members)
       #::MediaObject.skip_callback(:save, :before, :update_dependent_properties!)
 
-      models = [Admin::Collection, ::MediaObject, ::MasterFile, ::Derivative, ::Lease]
+      models = [Admin::Collection, ::Lease, ::MediaObject, ::MasterFile, ::Derivative]
       migrator = FedoraMigrate::ClassOrderedRepositoryMigrator.new('avalon', class_order: models, parallel_processes: parallel_processes)
       migrator.migrate_objects(ids, overwrite)
       migrator


### PR DESCRIPTION
Media Objects and not vice versa

Without this swapping of order leases appear to migrate successfully but media objects don't know about them.