### PR TITLE
Allow 2-part fields to be updated with empty strings

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -435,18 +435,17 @@ class MediaObjectsController < ApplicationController
     bib_id_label = mo_parameters.delete(:bibliographic_id_label)
     mo_parameters[:bibliographic_id] = { id: bib_id, source: bib_id_label } if bib_id.present?
     #Related urls
-    related_item_url = mo_parameters.delete(:related_item_url)
-    related_item_label = mo_parameters.delete(:related_item_label)
-    mo_parameters[:related_item_url] = related_item_url.zip(related_item_label).map{|a|{url: a[0],label: a[1]}} if related_item_url.present? && related_item_url.reject(&:empty?).present?
+    related_item_url = mo_parameters.delete(:related_item_url) || []
+    related_item_label = mo_parameters.delete(:related_item_label) || []
+    mo_parameters[:related_item_url] = related_item_url.zip(related_item_label).map{|a|{url: a[0],label: a[1]}}
     #Other identifiers
-    other_identifier = mo_parameters.delete(:other_identifier)
-    other_identifier_type = mo_parameters.delete(:other_identifier_type)
-    mo_parameters[:other_identifier] = other_identifier.zip(other_identifier_type).map{|a|{id: a[0], source: a[1]}} if other_identifier.present? && other_identifier.reject(&:empty?).present?
+    other_identifier = mo_parameters.delete(:other_identifier) || []
+    other_identifier_type = mo_parameters.delete(:other_identifier_type) || []
+    mo_parameters[:other_identifier] = other_identifier.zip(other_identifier_type).map{|a|{id: a[0], source: a[1]}}
     #Notes
-    # FIXME: lets in empty values!
-    note = mo_parameters.delete(:note)
-    note_type = mo_parameters.delete(:note_type)
-    mo_parameters[:note] = note.zip(note_type).map{|a|{note: a[0],type: a[1]}} if note.present? && note.reject(&:empty?).present?
+    note = mo_parameters.delete(:note) || []
+    note_type = mo_parameters.delete(:note_type) || []
+    mo_parameters[:note] = note.zip(note_type).map{|a|{note: a[0],type: a[1]}}
 
 
     mo_parameters

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -327,7 +327,8 @@ describe MediaObject do
   end
 
   describe "Update datastream with empty strings" do
-    it "should handle a complex update" do
+    it "should remove pre-existing values" do
+      media_object = FactoryGirl.create( :fully_searchable_media_object )
       params = {
         'alternative_title' => [''],
         'translated_title' => [''],


### PR DESCRIPTION
Fixes #1970 

Allows 2-part fields to be updated with empty strings. The empty strings are handled lower down in the mods OM document.