### PR TITLE
Fix bug when taking action on no selected items fixes #1079

### DIFF
--- a/app/views/bookmarks/delete.html.erb
+++ b/app/views/bookmarks/delete.html.erb
@@ -21,29 +21,28 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div class="modal-body">
     <div class="row-fluid">
       <div class="btn-options">
-	<% if @documents.empty? %>
+  <% if @documents.empty? %>
           <div class="alert alert-danger">
-	    <p><%= t('blacklight.bookmarks.no_bookmarks') %></p>
-	  </div>
-	  <%= link_to t('blacklight.messages.go_back'), :back, class: 'btn btn-default' %> 
-	<% else %>
+      <p><%= t('blacklight.bookmarks.no_bookmarks') %></p>
+    </div>
+  <% else %>
           <div class="alert alert-danger">
             <p><%= t('blacklight.delete.confirm', count: @documents.count) %></p>
-	    <ul>
-	      <% @documents.each do |doc| %>
-		<% @mediaobject = MediaObject.find(doc.id)  %>
-		<% if can? :destroy, @mediaobject  %>
-	          <li><%= @mediaobject.title %> (<%= doc.id %>)<%=hidden_field_tag "id[]", doc.id %></li>
-	        <% else %>
-	          <li><%= @mediaobject.title %> (<%= doc.id %>): <%= t('blacklight.messages.permission_denied') %></li>
-	        <% end %>
-	      <% end %>
-	    </ul>
+      <ul>
+        <% @documents.each do |doc| %>
+    <% @mediaobject = MediaObject.find(doc.id)  %>
+    <% if can? :destroy, @mediaobject  %>
+            <li><%= @mediaobject.title %> (<%= doc.id %>)<%=hidden_field_tag "id[]", doc.id %></li>
+          <% else %>
+            <li><%= @mediaobject.title %> (<%= doc.id %>): <%= t('blacklight.messages.permission_denied') %></li>
+          <% end %>
+        <% end %>
+      </ul>
           </div>
-	  <div class="modal-footer">
-	    <button type="submit" class="btn btn-primary"><%= t('blacklight.messages.yes_sure') %></button>
-	  </div>
-	<% end %>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-primary"><%= t('blacklight.messages.yes_sure') %></button>
+    </div>
+  <% end %>
       </div>
     </div>
 </div>

--- a/app/views/bookmarks/update_access_control.html.erb
+++ b/app/views/bookmarks/update_access_control.html.erb
@@ -13,113 +13,126 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% @media_objects = @documents.collect {|doc| MediaObject.find(doc.id)} %>
-<% visibility = @media_objects.first.visibility %>
-<% @visibility = visibility if @media_objects.all? {|mo| mo.visibility == visibility} %>
-<% @shown = @media_objects.all? {|doc| doc.hidden? == false} %>
-<% @hidden = @media_objects.all? {|doc| doc.hidden? == true} %>
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
   <h1><%= t('blacklight.update_access_control.form.title') %></h1>
 </div>
 
-<%= form_for "add", url: url_for(:controller => "bookmarks", :action => "update_access_control"), html: { :id => 'update_access_control_form', :class => "form-horizontal" } do |form| %>
+<% if (@documents.empty?)%>
   <div class="modal-body">
     <div class="row-fluid">
-      <div class="btn-options">
-        <% if @documents.empty? %>
-          <div class="alert alert-danger">
-            <p><%= t('blacklight.bookmarks.no_bookmarks') %></p>
-          </div>
-        <% else %>
-          <div class="alert hidden">
-              <p><%= t('blacklight.update_access_control.confirm') %></p>
-    </div>
-          <fieldset class="item-discovery">
-      <legend>Discovery</legend>
-      <%= label_tag :hidden do %>
-        <%= radio_button_tag :hidden, false, @shown %>
-        Show these items in search results
-        <br>
-        <%= radio_button_tag :hidden, true, @hidden %>
-        Hide these items from search results
-      <% end %>
-    </fieldset>
-          <fieldset class="item-access">
-      <legend>Item Access</legend>
-      <%= label_tag :visibility do %>
-        <%= radio_button_tag :visibility, 'public', (@visibility == 'public') %>
-        Available to the general public
-      <% end %>
-      <%= label_tag :visibility do %>
-        <%= radio_button_tag :visibility, 'restricted', (@visibility == 'restricted') %>
-        Logged in users only
-      <% end %>
-      <%= label_tag :visibility do %>
-        <%= radio_button_tag :visibility, 'private', (@visibility == 'private') %>
-        Collection staff only
-      <% end %>
-    </fieldset>
-          <fieldset class="special-access">
-      <legend>Special Access</legend>
-      <%= label_tag "user" do %>
-        <%= render partial: "modules/tooltip", locals: { form: form, field: 'user', tooltip: t("access_control.user"), options: {display_label: t("access_control.userlabel").html_safe} } %>
-        <div style='display:inline-block;position:relative'>
-        <%= hidden_field_tag "user" %>
-        <%= text_field_tag "user_display", nil,
-      class: "typeahead from-model form-control",
-      data: { model: 'user', target: "user" } %><br>
-          <%= text_field_tag "add_user_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-          <%= text_field_tag "add_user_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
-        </div>
-        <%= button_tag "Add", name: 'submit_add_user', class:'btn btn-default', value: 'Add' %>
-        <%= button_tag "Remove", name: 'submit_remove_user', class:'btn btn-default remove_access', value: 'Remove' %>
-      <% end %>
-      <%= label_tag "group" do %>
-        <%= render partial: "modules/tooltip", locals: { form: form, field: 'group', tooltip: t("access_control.group"), options: {display_label: t("access_control.grouplabel").html_safe} } %>
-        <%  dropdown_values = [Admin::Group.non_system_groups, 'name', 'name'] %>
-        <%  dropdown_values = options_from_collection_for_select(*dropdown_values) %>
-        <%= select_tag "group",
-      dropdown_values,
-      { include_blank: true, class: "form-control"}%><br>
-          <%= text_field_tag "add_group_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-          <%= text_field_tag "add_group_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
-        <%= button_tag "Add", name: 'submit_add_group', class:'btn btn-default', value: 'Add'  %>
-        <%= button_tag "Remove", name: 'submit_remove_group', class:'btn btn-default remove_access', value: 'Remove' %>
-      <% end %>
-      <%= label_tag "class" do %>
-        <%= render partial: "modules/tooltip", locals: { form: form, field: 'class', tooltip: t("access_control.class"), options: {display_label: t("access_control.classlabel").html_safe} } %>
-        <div style='display:inline-block;position:relative;'>
-        <%= hidden_field_tag "class" %>
-        <%= text_field_tag "class_display", nil,
-      class: "typeahead from-model form-control",
-      data: { model: 'externalGroup', target: "class" } %><br>
-          <%= text_field_tag "add_class_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-          <%= text_field_tag "add_class_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
-        </div>
-        <%= button_tag "Add", name: 'submit_add_class', class:'btn btn-default', value: 'Add'  %>
-        <%= button_tag "Remove", name: 'submit_remove_class', class:'btn btn-default remove_access', value: 'Remove' %>
-	<% end %>
-      <%= label_tag "ipaddress" do %>
-        <%= render partial: "modules/tooltip", locals: { form: form, field: 'ipaddress', tooltip: t("access_control.ipaddress"), options: {display_label: t("access_control.ipaddresslabel").html_safe} } %>
-        <div style='display:inline-block;top:1px;position:relative;'>
-        <%= text_field_tag "ipaddress", nil, class: "form-control" %><br>
-          <%= text_field_tag "add_ipaddress_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-          <%= text_field_tag "add_ipaddress_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
-        </div>
-        <%= button_tag "Add", name: 'submit_add_ipaddress', class:'btn btn-default', value: 'Add'  %>
-        <%= button_tag "Remove", name: 'submit_remove_ipaddress', class:'btn btn-default remove_access', value: 'Remove' %>
-      <% end %>
-
-
-          </fieldset>
-          <div class="modal-footer">
-            <button type="submit" class="btn btn-primary"><%= t('blacklight.update_access_control.button') %></button>
-          </div>
-        <% end %>
+      <div class="alert alert-danger">
+        <p><%= t('blacklight.bookmarks.no_bookmarks') %> </p>
       </div>
     </div>
   </div>
+<% else %>
+  <%
+   @media_objects = @documents.collect {|doc| MediaObject.find(doc.id)}
+   visibility = @media_objects.first.visibility
+   @visibility = visibility if @media_objects.all? {|mo| mo.visibility == visibility}
+   @shown = @media_objects.all? {|doc| doc.hidden? == false}
+   @hidden = @media_objects.all? {|doc| doc.hidden? == true}
+  %>
+
+  <%= form_for "add", url: url_for(:controller => "bookmarks", :action => "update_access_control"), html: { :id => 'update_access_control_form', :class => "form-horizontal" } do |form| %>
+    <div class="modal-body">
+      <div class="row-fluid">
+        <div class="btn-options">
+          <% if @documents.empty? %>
+            <div class="alert alert-danger">
+              <p><%= t('blacklight.bookmarks.no_bookmarks') %></p>
+            </div>
+          <% else %>
+            <div class="alert hidden">
+                <p><%= t('blacklight.update_access_control.confirm') %></p>
+      </div>
+            <fieldset class="item-discovery">
+        <legend>Discovery</legend>
+        <%= label_tag :hidden do %>
+          <%= radio_button_tag :hidden, false, @shown %>
+          Show these items in search results
+          <br>
+          <%= radio_button_tag :hidden, true, @hidden %>
+          Hide these items from search results
+        <% end %>
+      </fieldset>
+            <fieldset class="item-access">
+        <legend>Item Access</legend>
+        <%= label_tag :visibility do %>
+          <%= radio_button_tag :visibility, 'public', (@visibility == 'public') %>
+          Available to the general public
+        <% end %>
+        <%= label_tag :visibility do %>
+          <%= radio_button_tag :visibility, 'restricted', (@visibility == 'restricted') %>
+          Logged in users only
+        <% end %>
+        <%= label_tag :visibility do %>
+          <%= radio_button_tag :visibility, 'private', (@visibility == 'private') %>
+          Collection staff only
+        <% end %>
+      </fieldset>
+            <fieldset class="special-access">
+        <legend>Special Access</legend>
+        <%= label_tag "user" do %>
+          <%= render partial: "modules/tooltip", locals: { form: form, field: 'user', tooltip: t("access_control.user"), options: {display_label: t("access_control.userlabel").html_safe} } %>
+          <div style='display:inline-block;position:relative'>
+          <%= hidden_field_tag "user" %>
+          <%= text_field_tag "user_display", nil,
+        class: "typeahead from-model form-control",
+        data: { model: 'user', target: "user" } %><br>
+            <%= text_field_tag "add_user_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
+            <%= text_field_tag "add_user_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+          </div>
+          <%= button_tag "Add", name: 'submit_add_user', class:'btn btn-default', value: 'Add' %>
+          <%= button_tag "Remove", name: 'submit_remove_user', class:'btn btn-default remove_access', value: 'Remove' %>
+        <% end %>
+        <%= label_tag "group" do %>
+          <%= render partial: "modules/tooltip", locals: { form: form, field: 'group', tooltip: t("access_control.group"), options: {display_label: t("access_control.grouplabel").html_safe} } %>
+          <%  dropdown_values = [Admin::Group.non_system_groups, 'name', 'name'] %>
+          <%  dropdown_values = options_from_collection_for_select(*dropdown_values) %>
+          <%= select_tag "group",
+        dropdown_values,
+        { include_blank: true, class: "form-control"}%><br>
+            <%= text_field_tag "add_group_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
+            <%= text_field_tag "add_group_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+          <%= button_tag "Add", name: 'submit_add_group', class:'btn btn-default', value: 'Add'  %>
+          <%= button_tag "Remove", name: 'submit_remove_group', class:'btn btn-default remove_access', value: 'Remove' %>
+        <% end %>
+        <%= label_tag "class" do %>
+          <%= render partial: "modules/tooltip", locals: { form: form, field: 'class', tooltip: t("access_control.class"), options: {display_label: t("access_control.classlabel").html_safe} } %>
+          <div style='display:inline-block;position:relative;'>
+          <%= hidden_field_tag "class" %>
+          <%= text_field_tag "class_display", nil,
+        class: "typeahead from-model form-control",
+        data: { model: 'externalGroup', target: "class" } %><br>
+            <%= text_field_tag "add_class_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
+            <%= text_field_tag "add_class_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+          </div>
+          <%= button_tag "Add", name: 'submit_add_class', class:'btn btn-default', value: 'Add'  %>
+          <%= button_tag "Remove", name: 'submit_remove_class', class:'btn btn-default remove_access', value: 'Remove' %>
+    <% end %>
+        <%= label_tag "ipaddress" do %>
+          <%= render partial: "modules/tooltip", locals: { form: form, field: 'ipaddress', tooltip: t("access_control.ipaddress"), options: {display_label: t("access_control.ipaddresslabel").html_safe} } %>
+          <div style='display:inline-block;top:1px;position:relative;'>
+          <%= text_field_tag "ipaddress", nil, class: "form-control" %><br>
+            <%= text_field_tag "add_ipaddress_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
+            <%= text_field_tag "add_ipaddress_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+          </div>
+          <%= button_tag "Add", name: 'submit_add_ipaddress', class:'btn btn-default', value: 'Add'  %>
+          <%= button_tag "Remove", name: 'submit_remove_ipaddress', class:'btn btn-default remove_access', value: 'Remove' %>
+        <% end %>
+
+
+            </fieldset>
+            <div class="modal-footer">
+              <button type="submit" class="btn btn-primary"><%= t('blacklight.update_access_control.button') %></button>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
 <% end %>
 
 <script>


### PR DESCRIPTION
You now get consistent error messages when you try to perform an action on the selected items page when you uncheck every item manually.
I copied what was being done for the move operation, which pops up with a modal saying that you have no elements selected.
I also removed the back button on the delete error message modal. It was inconvenient that it refreshes the page instead of just going back to what you were doing.