### PR TITLE
Allow configurable persistent flash messages

### DIFF
--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -13,6 +13,11 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+
+<% if Avalon::Configuration.has_key?('flash_message') && Avalon::Configuration.lookup('flash_message.message') %>
+  <% flash[Avalon::Configuration.lookup('flash_message.type').to_sym || :error] = Avalon::Configuration.lookup('flash_message.message').html_safe %>
+<% end %>
+
 <% if defined? flash and !flash.empty? %>
   <div class="container-fluid" id="alerts">
   <% [:success, :notice, :error, :alert].each do |type| %>

--- a/config/avalon.yml.example
+++ b/config/avalon.yml.example
@@ -75,3 +75,6 @@ test:
     protocol: sru
     url: http://zgate.example.edu:9000/exampledb
     query: rec.id='%s'
+  flash_message:
+    type: 'error'
+    message: '<p>Test flash message configured in avalon.yml. Type can be success, notice, error, or alert.</p>'


### PR DESCRIPTION
Add a configuration like this to avalon.yml:
```
  flash_message:
    type: 'error'
    message: '<p>This is a test warning message. テスト</p>'
```
type must be from list: success, notice, error, alert