### PR TITLE
Fix embed layout and mediaelement features

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,9 @@
 //= require modernizr
 //= require me-track-scrubber
 //= require mediaelement-qualityselector/mep-feature-qualities
+//= require mediaelement-title/mep-feature-title
+//= require mediaelement-hd-toggle/mep-feature-hdtoggle
+//= require me-logo
 //= require bootstrap-toggle
 
 // include all of our vendored js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,9 @@
  *
  *= require mediaelement-skin-avalon/mejs-skin-avalon
  *= require mediaelement-qualityselector/mep-feature-qualities
+ *= require mediaelement-title/mejs-title
+ *= require me-logo
+ *= require mediaelement-hd-toggle/mejs-hdtoggle
  *= require me-thumb-selector
  *= require me-add-to-playlist
  *= require me-track-scrubber

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -14,10 +14,6 @@
  * ---  END LICENSE_HEADER BLOCK  ---
 */
 
-#header-navbar {display: none;}
-
-footer {display: none;}
-
 body {
   background-color: #000000;
   width: 100%;

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -13,9 +13,28 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-
 <% content_for :page_styles do %>
   <%= stylesheet_link_tag 'embed' %>
 <% end %>
 
-<%= render template: "layouts/avalon" %>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title><%= render_page_title %></title>
+
+   <%= csrf_meta_tags %>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= yield :page_styles %>
+    <%= yield :additional_head_content %>
+  </head>
+
+  <body>
+    <%= yield %>
+    <%= javascript_include_tag "application" %>
+    <%= yield :page_scripts %>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #2059.  Possibly fixes other issues as this PR restores the HD quality toggle in audio embeds and the view in repository button in both audio and video players.