### PR TITLE
Pass through query params using new method

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -74,7 +74,7 @@ module MasterFileBehavior
   def embed_code(width, permalink_opts = {})
     begin
       url = if self.permalink.present?
-        self.permalink(permalink_opts)
+        self.permalink_with_query(permalink_opts)
       else
         embed_master_file_url(self.id, only_path: false, protocol: '//')
       end


### PR DESCRIPTION
This fixes permalinks in embed codes not having the urlappend=/embed query which is necessary for embeds to get the embed view instead of the full view page.