### PR TITLE
Form attributes

### DIFF
--- a/app/assets/javascripts/import_button.js.coffee
+++ b/app/assets/javascripts/import_button.js.coffee
@@ -15,7 +15,7 @@
 
 $ ->
   form = $('div.import-button').closest('form').prop('id')
-  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes" form="'+form+'">Import</button></div>'
+  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes" >Import</button></div>'
   $('div.import-button').append(import_button_html)
   enable_bib_btn()
   $('#media_object_bibliographic_id').keyup -> enable_bib_btn()
@@ -30,11 +30,12 @@ $ ->
       placement: 'top'
       container: 'body'
       content: ->
-        button = '<button class="btn btn-xs btn-danger btn-confirm" type="submit" name="media_object[import_bib_record]" value="yes" data-original-title="" title="" form="'+$(this).attr('form')+'" >Import</button>'
+        button = '<button id="media_object_bibliographic_id_confirm_btn" class="btn btn-xs btn-danger btn-confirm" type="submit" name="media_object[import_bib_record]" value="yes" data-original-title="" title="" form="'+form+'" >Import</button>'
         '<p>Note: this will replace all metadata except for Other Identifiers</p> ' + button + ' <button id=\'cancel_bibimport\' class=\'btn btn-xs btn-primary\'>No, Cancel</button>'
     ).click ->
       $('.btn-confirmation').popover 'hide'
       $(this).popover 'show'
+      form_attribute_fix('#media_object_bibliographic_id_confirm_btn')
       false
 
 enable_bib_btn = ->

--- a/app/assets/javascripts/input_form_attribute_support.js.coffee
+++ b/app/assets/javascripts/input_form_attribute_support.js.coffee
@@ -15,22 +15,26 @@
 # This script will enable support for the html5 form attribute
 # This should only be needed for IE but is currently applied wholesale
 # to all disjointed submit elements as is needed in some of the workflow steps
-if not Modernizr.formattribute
-  $('input[type="submit"][form]').click (event) ->
-    event.preventDefault()
-    form = document.getElementById($(this).attr('form'))
-    newform = form.cloneNode()
-    newform.id = newform.id + "_temp"
-    $(document.body).append(newform)
-    $('*[form="' + form.id + '"]').each (index, element) ->
-      $(newform).append($(element).clone().attr('style', 'display:none'))
-    $(form).find('input[type!="submit"]').each (index, element) ->
-      $(newform).append($(element).clone().attr('style', 'display:none'))
-    $(newform).find('textarea').each (index, element) ->
-      $(elem).val($('#' + element.id).val())
-    $(newform).find('select').each (index, element) ->
-      $(elem).val($('#' + element.id).val())
-    submit_element = $(this).clone().attr('style', 'display:none')
-    $(newform).append(submit_element)
-    $(submit_element).click()
-    $(newform).remove()
+$ ->
+  form_attribute_fix()
+
+@form_attribute_fix = (selector = '*[type="submit"][form]') ->
+  if not Modernizr.formattribute
+    $(selector).click (event) ->
+      event.preventDefault()
+      form = document.getElementById($(this).attr('form'))
+      newform = form.cloneNode()
+      newform.id = newform.id + "_temp"
+      $(document.body).append(newform)
+      $('*[form="' + form.id + '"]').each (index, element) ->
+        $(newform).append($(element).clone().attr('style', 'display:none'))
+      $(form).find('input[type!="submit"]').each (index, element) ->
+        $(newform).append($(element).clone().attr('style', 'display:none'))
+      $(newform).find('textarea').each (index, element) ->
+        $(elem).val($('#' + element.id).val())
+      $(newform).find('select').each (index, element) ->
+        $(elem).val($('#' + element.id).val())
+      submit_element = $(this).clone().attr('style', 'display:none')
+      $(newform).append(submit_element)
+      $(submit_element).click()
+      $(newform).remove()


### PR DESCRIPTION
This PR takes the form attributes polyfill and makes it available throughout the app with the options of passing a jquery selector to act on.  The default selector parameter has been relaxed to all elements with type submit to include buttons instead of only inputs.

Fixes #2094.