### PR TITLE
Add xray to dev mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,9 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
 
+  # ctrl+shift+x to see erb files rendered on page
+  gem 'xray-rails'
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   #gem 'spring'
   gem 'rubocop', '~> 0.40.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -738,6 +738,8 @@ GEM
     xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    xray-rails (0.3.1)
+      rails (>= 3.1.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
I think adding [xray-rails](https://github.com/brentd/xray-rails) to the dev environment would be handy to have. When you press crtl+shft+x, it shows how the page html.erb files it's using and where. 
![image](https://user-images.githubusercontent.com/5091130/28035266-11f62250-6582-11e7-9fa6-cdd1d4d5fce1.png)
****