### PR TITLE
Allow override of pid namespace on the migration rake task

### DIFF
--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -43,6 +43,7 @@ EOC
       ids = Array(ids) | File.readlines(ENV['pidfile']).map(&:strip) unless ENV['pidfile'].nil?
       parallel_processes = ENV['parallel_processes']
       overwrite = !!ENV['overwrite']
+      namespace = ENV['namespace'] || 'avalon'
 
       #disable callbacks
       Admin::Collection.skip_callback(:save, :around, :reindex_members)
@@ -51,7 +52,7 @@ EOC
       #::MediaObject.skip_callback(:save, :before, :update_dependent_properties!)
 
       models = [Admin::Collection, ::Lease, ::MediaObject, ::MasterFile, ::Derivative]
-      migrator = FedoraMigrate::ClassOrderedRepositoryMigrator.new('avalon', class_order: models, parallel_processes: parallel_processes)
+      migrator = FedoraMigrate::ClassOrderedRepositoryMigrator.new(namespace, class_order: models, parallel_processes: parallel_processes)
       migrator.migrate_objects(ids, overwrite)
       migrator
     end


### PR DESCRIPTION
@mbklein I noticed this same thing while writing the documentation today.  Too late for 6.1 but it could go into 6.1.1/6.2.