### PR TITLE
Feature/#2167 markers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/media-element-add-to-playlist.git
-  revision: dd44f1ff31cd9e5f11eca51968af46ee68754a99
+  revision: 7232f8889530fb9ac53f372cff3028b12d25f5da
   specs:
     media_element_add_to_playlist (0.0.1)
       rails (~> 4.0)
@@ -849,4 +849,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -97,13 +97,28 @@ class AvalonPlayer
         if _this.player.options.displayMarkers
           duration = _this.stream_info.duration
           scrubber = $('.mejs-time-rail')
+          total = $('.mejs-time-total')
           scrubber.css('position', 'relative')
+          marker_rail = $('<span  class="mejs-time-marker-rail">')
           $('.row.marker').each (i,value) ->
             offset = $(this)[0].dataset['offset']
             marker_id = $(this)[0].dataset['marker']
             title = String($(this).find('.marker_title')[0].text).replace(/"/g, '&quot;') + " ["+mejs.Utility.secondsToTimeCode(offset)+"]"
             offset_percent = if isNaN(parseFloat(offset)) then 0 else Math.min(100,Math.round(100*offset / duration))
-            $('.mejs-time-total').append('<span class="fa fa-chevron-up scrubber-marker" style="left: '+offset_percent+'%" title="'+title+'" data-marker="'+marker_id+'"></span>')
+            marker = $('<span class="fa fa-chevron-up scrubber-marker" style="left: '+offset_percent+'%" data-marker="'+marker_id+'"></span>')
+            marker.click (e) ->
+              currentPlayer.setCurrentTime offset
+            marker_rail.append(marker)
+            marker_rail.append('<span class="mejs-time-float-marker" data-marker="'+marker_id+'" style="display: none; left: '+offset_percent+'%" ><span class="mejs-time-float-current-marker">'+title+'</span><span class="mejs-time-float-corner-marker"></span></span>')
+            marker_rail.width(total.width())
+          scrubber.append(marker_rail)
+          _this.player.globalBind('resize', (e) ->
+            marker_rail.width(total.width())
+          )
+          $('.scrubber-marker').bind('mouseenter', (e) ->
+            $('.mejs-time-float-marker[data-marker="'+this.dataset.marker+'"]').show()
+          ).bind 'mouseleave', (e) ->
+            $('.mejs-time-float-marker[data-marker="'+this.dataset.marker+'"]').hide()
         @player.setCurrentTime initialTime
 
       @player.options.playlistItemDefaultTitle = @stream_info.embed_title

--- a/app/assets/javascripts/marker.js.coffee
+++ b/app/assets/javascripts/marker.js.coffee
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -59,7 +59,10 @@ timeCodeToSeconds = (hh_mm_ss) ->
   row.find('button[name="marker_edit_cancel"]').remove()
   offset_percent = if isNaN(parseFloat(offset)) then 0 else Math.min(100,Math.round(100*offset / currentPlayer.media.duration))
   marker_title = String(title_val).replace(/"/g, '&quot;')+' ['+start_input.val()+']'
-  $('.scrubber-marker[data-marker="'+id+'"]').css('left',offset_percent+'%').attr('title',marker_title)
+  $('.scrubber-marker[data-marker="'+id+'"]').css('left',offset_percent+'%').unbind('click').click (e) ->
+    currentPlayer.setCurrentTime offset
+  marker = $('.mejs-time-float-marker[data-marker="'+id+'"]')
+  marker.css('left',offset_percent+'%').find('.mejs-time-float-current-marker').text(marker_title)
   return
 
 @cancelMarkerEdit = (event) ->
@@ -84,6 +87,7 @@ timeCodeToSeconds = (hh_mm_ss) ->
   if response['action'] == 'destroy'
     #respond to destroy
     $('.scrubber-marker[data-marker="'+response['id']+'"]').remove()
+    $('.mejs-time-float-marker[data-marker="'+response['id']+'"]').remove()
     $('#marker_row_' + response['id']).remove()
     if $('.row .marker').length == 0
       $('#markers_heading').remove()

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1155,7 +1155,6 @@ h5.panel-title {
 .scrubber-marker {
   color: #dedede;
   font-weight: bold;
-  top: 10px;
 }
 
 .omniauth-form {
@@ -1167,45 +1166,4 @@ h5.panel-title {
 
 .twitter-typeahead {
   z-index: auto !important;
-}
-
-.mejs-time-marker-rail {
-  margin: 5px;
-}
-
-.mejs-time-float-marker {
-	position: absolute !important;
-	background: #eee;
-	width: 66px !important;
-	height: 17px !important;
-	border: solid 1px #333;
-  top: auto;
-	bottom: 8px;
-	margin-left: -38px;
-	text-align: center;
-	color: #111;
-}
-
-.mejs-time-float-current-marker {
-	margin: 2px;
-	width: 60px !important;
-	display: block;
-	text-align: center;
-	left: 0;
-  overflow: hidden;
-}
-
-.mejs-time-float-corner-marker {
-	position: absolute !important;
-	display: block !important;
-	width: 0 !important;
-	height: 0 !important;
-	line-height: 0;
-	border: solid 5px #eee;
-	border-color: #eee transparent transparent transparent;
-	-webkit-border-radius: 0;
-	-moz-border-radius: 0;
-	border-radius: 0;
-	top: 15px;
-	left: 33px !important;
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1155,6 +1155,7 @@ h5.panel-title {
 .scrubber-marker {
   color: #dedede;
   font-weight: bold;
+  top: 10px;
 }
 
 .omniauth-form {
@@ -1166,4 +1167,45 @@ h5.panel-title {
 
 .twitter-typeahead {
   z-index: auto !important;
+}
+
+.mejs-time-marker-rail {
+  margin: 5px;
+}
+
+.mejs-time-float-marker {
+	position: absolute !important;
+	background: #eee;
+	width: 66px !important;
+	height: 17px !important;
+	border: solid 1px #333;
+  top: auto;
+	bottom: 8px;
+	margin-left: -38px;
+	text-align: center;
+	color: #111;
+}
+
+.mejs-time-float-current-marker {
+	margin: 2px;
+	width: 60px !important;
+	display: block;
+	text-align: center;
+	left: 0;
+  overflow: hidden;
+}
+
+.mejs-time-float-corner-marker {
+	position: absolute !important;
+	display: block !important;
+	width: 0 !important;
+	height: 0 !important;
+	line-height: 0;
+	border: solid 5px #eee;
+	border-color: #eee transparent transparent transparent;
+	-webkit-border-radius: 0;
+	-moz-border-radius: 0;
+	border-radius: 0;
+	top: 15px;
+	left: 33px !important;
 }


### PR DESCRIPTION
Fixes #2167 

Moves markers from the scrubber element to it's own rail element so that markers will be clickable separately from the scrubber. This enables setting handlers on the markers for mouse events. Markers are now clickable and make the player skip to correct time, and on hover popovers are displayed. This meets the immediate needs of #2167, but also lays the groundwork for future marker improvements. 