### PR TITLE
[WIP] Always resize player and controls in case they got missed during init

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -120,6 +120,12 @@ class AvalonPlayer
           ).bind 'mouseleave', (e) ->
             $('.mejs-time-float-marker[data-marker="'+this.dataset.marker+'"]').hide()
         @player.setCurrentTime initialTime
+        #Workaround for Firefox rendering issue
+        #TODO figure out how to scope this to Firefox and/or misrendered players
+        #Might also want to try moving it to another place in the initialization code to minimize impact
+        #as it causes some flashing while resizing things
+        @player.setPlayerSize()
+        @player.setControlsSize()
 
       @player.options.playlistItemDefaultTitle = @stream_info.embed_title
 


### PR DESCRIPTION
This is a workaround that needs review and possible reworking.  The player has some extra flashing during initialization due to this workaround so it would be good if it could be scoped to only the cases where it is needed.

Fixes #2167.