### PR TITLE
Asset manifests for ME.js 2 and 4 players

### DIFF
--- a/app/assets/javascripts/mejs2_player.js
+++ b/app/assets/javascripts/mejs2_player.js
@@ -1,0 +1,8 @@
+//= require mediaelement_rails
+//= require me-thumb-selector
+//= require me-add-to-playlist
+//= require me-track-scrubber
+//= require mediaelement-qualityselector/mep-feature-qualities
+//= require mediaelement-title/mep-feature-title
+//= require mediaelement-hd-toggle/mep-feature-hdtoggle
+//= require me-logo

--- a/app/assets/javascripts/mejs4_player.js
+++ b/app/assets/javascripts/mejs4_player.js
@@ -1,0 +1,4 @@
+//= require mediaelement/mediaelement-and-player
+//= require mediaelement/plugins/markers
+//= require mediaelement/plugins/quality
+//= require mediaelement/plugins/quality-i18n

--- a/app/assets/stylesheets/mejs2_player.scss
+++ b/app/assets/stylesheets/mejs2_player.scss
@@ -1,0 +1,13 @@
+/*
+ *= require mediaelement_rails
+ *= require mediaelement_rails/mejs-skins
+ *
+ *= require mediaelement-skin-avalon/mejs-skin-avalon
+ *= require mediaelement-qualityselector/mep-feature-qualities
+ *= require mediaelement-title/mejs-title
+ *= require me-logo
+ *= require mediaelement-hd-toggle/mejs-hdtoggle
+ *= require me-thumb-selector
+ *= require me-add-to-playlist
+ *= require me-track-scrubber
+ */

--- a/app/assets/stylesheets/mejs4_player.scss
+++ b/app/assets/stylesheets/mejs4_player.scss
@@ -1,0 +1,4 @@
+/*
+ *= require mediaelement/mediaelementplayer.css
+ *= require mediaelement/plugins/quality.css
+ */

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -13,6 +13,13 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+<% content_for :page_styles do %>
+  <%= stylesheet_link_tag 'mejs2_player' %>
+<% end %>
+<% content_for :page_scripts do %>
+  <%= javascript_include_tag "mejs2_player" %>
+<% end %>
+
     <section id="content" class="avalon-player" style="width: 100%" tabIndex="-1">
       <% if @master_file.present? and @master_file.succeeded? %>
 

--- a/app/views/media_objects/_mejs2_section.html.erb
+++ b/app/views/media_objects/_mejs2_section.html.erb
@@ -1,16 +1,8 @@
 <% content_for :page_styles do %>
-  <% stylesheet_link_tag 'mediaelement_rails', 'mediaelement_rails/mejs-skins', 'mediaelement-skin-avalon/mejs-skin-avalon', 'mediaelement-qualityselector/mep-feature-qualities', 'mediaelement-title/mejs-title', 'me-logo', 'mediaelement-hd-toggle/mejs-hdtoggle', 'me-thumb-selector', 'me-add-to-playlist', 'me-track-scrubber' %>
+  <% stylesheet_link_tag 'mejs2_player' %>
 <% end %>
 <% content_for :page_scripts do %>
-  <%= javascript_include_tag 'jquery',
-    'mediaelement_rails',
-    'me-thumb-selector',
-    'me-add-to-playlist',
-    'me-track-scrubber',
-    'mediaelement-qualityselector/mep-feature-qualities',
-    'mediaelement-title/mep-feature-title',
-    'mediaelement-hd-toggle/mep-feature-hdtoggle',
-    'me-logo'  %>
+  <%= javascript_include_tag 'mejs2_player' %>
 <% end %>
 
 <section id="content" class="avalon-player" style="width: 100%; visibility: hidden;" tabIndex="-1">

--- a/app/views/media_objects/_mejs4_section.html.erb
+++ b/app/views/media_objects/_mejs4_section.html.erb
@@ -1,11 +1,8 @@
 <% content_for :page_styles do %>
-  <% stylesheet_link_tag 'mediaelement/mediaelementplayer', 'mediaelement/plugins/quality' %>
+  <% stylesheet_link_tag 'mejs4_player' %>
 <% end %>
 <% content_for :page_scripts do %>
-  <%= javascript_include_tag 'mediaelement/mediaelement-and-player',
-      'mediaelement/plugins/quality',
-      'mediaelement/plugins/quality-i18n',
-      'mediaelement/plugins/markers' %>
+  <%= javascript_include_tag 'mejs4_player' %>
 <% end %>
 
 <section id="content" style="width: 100%;" tabIndex="-1">

--- a/app/views/playlists/_player.html.erb
+++ b/app/views/playlists/_player.html.erb
@@ -13,6 +13,12 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+<% content_for :page_styles do %>
+  <% stylesheet_link_tag 'mejs2_player' %>
+<% end %>
+<% content_for :page_scripts do %>
+  <%= javascript_include_tag "mejs2_player" %>
+<% end %>
 
 <% f_start = @current_clip.start_time / 1000.0 %>
 <% f_end = @current_clip.end_time / 1000.0 %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,32 +13,9 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.precompile += %w( embed.css )
 
 # MediaElement 4 files
-Rails.application.config.assets.precompile += %w( mediaelement/mediaelement-and-player.js )
-Rails.application.config.assets.precompile += %w( mediaelement/plugins/quality.js )
-Rails.application.config.assets.precompile += %w( mediaelement/plugins/quality-i18n.js )
-Rails.application.config.assets.precompile += %w( mediaelement/plugins/markers.js )
-
-Rails.application.config.assets.precompile += %w( mediaelement/mediaelementplayer.css )
-Rails.application.config.assets.precompile += %w( mediaelement/plugins/quality.css )
+Rails.application.config.assets.precompile += %w( mejs4_player.js )
+Rails.application.config.assets.precompile += %w( mejs4_player.scss )
 
 # MediaElement 2 files
-Rails.application.config.assets.precompile += %w( jquery.js )
-Rails.application.config.assets.precompile += %w( mediaelement_rails/index.js )
-Rails.application.config.assets.precompile += %w( me-thumb-selector.js )
-Rails.application.config.assets.precompile += %w( me-add-to-playlist.js )
-Rails.application.config.assets.precompile += %w( me-track-scrubber.js )
-Rails.application.config.assets.precompile += %w( mediaelement-qualityselector/mep-feature-qualities.js )
-Rails.application.config.assets.precompile += %w( mediaelement-title/mep-feature-title.js )
-Rails.application.config.assets.precompile += %w( mediaelement-hd-toggle/mep-feature-hdtoggle.js )
-Rails.application.config.assets.precompile += %w( me-logo.js )
-
-Rails.application.config.assets.precompile += %w( mediaelement_rails/index.css )
-Rails.application.config.assets.precompile += %w( mediaelement_rails/mejs-skins.css )
-Rails.application.config.assets.precompile += %w( mediaelement-skin-avalon/mejs-skin-avalon.css )
-Rails.application.config.assets.precompile += %w( mediaelement-qualityselector/mep-feature-qualities.css )
-Rails.application.config.assets.precompile += %w( mediaelement-title/mejs-title.css )
-Rails.application.config.assets.precompile += %w( me-logo.css )
-Rails.application.config.assets.precompile += %w( mediaelement-hd-toggle/mejs-hdtoggle.css )
-Rails.application.config.assets.precompile += %w( me-thumb-selector.css )
-Rails.application.config.assets.precompile += %w( me-add-to-playlist.css )
-Rails.application.config.assets.precompile += %w( me-track-scrubber.css )
+Rails.application.config.assets.precompile += %w( mejs2_player.js )
+Rails.application.config.assets.precompile += %w( mejs2_player.scss )


### PR DESCRIPTION
This PR restores the JS and CSS for the MediaElement 2 playlist and embed player while fixing a bug in the media object player where jquery was included twice.  A subsequent PR will be needed for exposing the MediaElement 4 player in playlist and embed contexts.