### PR TITLE
Feature/#1943 add mediaobject to playlist

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -875,6 +875,13 @@ div.status-detail {
 }
 
 /* MediaObject structure page */
+.structure_add_to_playlist {
+  float: right;
+  height: 1.5em;
+  background: #2a4d59 url(/assets/add_to_playlist_icon-233fc168dd0a0fb5cc59665bf7004c7cfe0f89b642ae81cc614e0ea754693131.svg) no-repeat;
+  background-position: 3px 0px;
+  border-color: #2a4d59 !important;
+}
 
 #mediaobject_structure {
   a.structure_toggle, a.captions_toggle {

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -878,9 +878,9 @@ div.status-detail {
 .structure_add_to_playlist {
   float: right;
   height: 1.5em;
-  background: #2a4d59 url(/assets/add_to_playlist_icon-233fc168dd0a0fb5cc59665bf7004c7cfe0f89b642ae81cc614e0ea754693131.svg) no-repeat;
+  background: $blue url(add_to_playlist_icon.svg) no-repeat;
   background-position: 3px 0px;
-  border-color: #2a4d59 !important;
+  border-color: $blue !important;
 }
 
 #mediaobject_structure {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -78,6 +78,26 @@ class ApplicationController < ActionController::Base
     end
   end
   helper_method :get_user_collections
+
+  # Returns milliseconds from a time string of format h:m:s.s or m:s.s or s.s
+  # @param [String] The time string
+  # @return [float] the time string converted to milliseconds
+  def time_str_to_milliseconds(value)
+    if value.is_a?(Numeric)
+      value.floor
+    elsif value.is_a?(String)
+      result = 0
+      segments = value.split(/:/).reverse
+      begin
+        segments.each_with_index { |v, i| result += i > 0 ? Float(v) * (60**i) * 1000 : (Float(v) * 1000) }
+        result.to_i
+      rescue
+        return value
+      end
+    else
+      value
+    end
+  end
 
   def current_ability
     session_opts ||= user_session

--- a/app/controllers/avalon_marker_controller.rb
+++ b/app/controllers/avalon_marker_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -102,23 +102,4 @@ class AvalonMarkerController < ApplicationController
     @marker_params
   end
 
-  # Returns milliseconds from a time string of format h:m:s.s or m:s.s or s.s
-  # @param [String] The time string
-  # @return [float] the time string converted to milliseconds
-  def time_str_to_milliseconds(value)
-    if value.is_a?(Numeric)
-      value.floor
-    elsif value.is_a?(String)
-      result = 0
-      segments = value.split(/:/).reverse
-      begin
-        segments.each_with_index { |v, i| result += i > 0 ? Float(v) * (60**i) * 1000 : (Float(v) * 1000) }
-        result.to_i
-      rescue
-        return value
-      end
-    else
-      value
-    end
-  end
 end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -107,8 +107,8 @@ class MediaObjectsController < ApplicationController
         playlist.items += [PlaylistItem.new(clip: clip, playlist: playlist)]
       end
     end
-
-    render json: {message: 'Playlist item creating has started and will be finished soon.'}, status: 200
+    link = view_context.link_to('View Playlist', playlist_path(playlist), class: "btn btn-primary btn-xs")
+    render json: {message: "<p>Playlist items created successfully.</p> #{link}", status: 200}
   end
 
   # POST /media_objects

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -135,6 +135,7 @@ module MediaObjectsHelper
        headeropen = <<EOF
     <div class="panel-heading" role="tab" id="heading#{index}">
       <h4 class="panel-title #{ 'progress-indented' if progress_div.present? }">
+      <button type="button" title="Add section to playlist" aria-label="Add section to playlist" class="structure_add_to_playlist outline_on btn btn-primary" data-scope="master_file" data-masterfile-id="#{section.id}"></button>
 EOF
        headerclose = <<EOF
       #{progress_div}

--- a/app/views/media_objects/_add_to_playlist_form.html.erb
+++ b/app/views/media_objects/_add_to_playlist_form.html.erb
@@ -47,7 +47,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <div class="row">
             <div class="col-sm-offset-2 col-sm-10">
               <div>
-                <input type="submit" name="commit" value="Add to Playlist" class="btn btn-primary btn-xs">
+                <input type="submit" name="commit" data-loading-text="Working..." value="Add to Playlist" class="btn btn-primary btn-xs" id="playlistitem_submit">
               </div>
             </div>
           </div>

--- a/app/views/media_objects/_add_to_playlist_form.html.erb
+++ b/app/views/media_objects/_add_to_playlist_form.html.erb
@@ -1,0 +1,57 @@
+<%#
+Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+<!-- contents for add_to_playlist modal form ---->
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Add <%= scope=='master_file'? 'Section' : 'Media Object'%> to Playlist</h4>
+      </div>
+      <div class="modal-body">
+        <form id="add_to_playlist_form" class="form-horizontal" action="<%= add_to_playlist_media_object_path(@media_object) %>" accept-charset="UTF-8" data-remote="true" method="post" >
+          <input type="hidden" name="post[masterfile_id]" value="<%= masterfile_id %>" />
+          <div class="row form-group">
+            <label class="col-sm-2 control-label" for="playlist">Playlist</label>
+            <div class="col-sm-10">
+              <% @add_playlist_item_playlists = Playlist.where(user: current_user).sort_by(&:title) %>
+              <%= collection_select(:post, :playlist_id, @add_playlist_item_playlists, :id, :title, {}, {class: "form-control form-model", style: 'width:100%;'}) %>
+            </div>
+          </div>
+          <div class="row form-group">
+            <label class="col-sm-2 control-label">Playlist Item Scope</label>
+            <div class="col-sm-10">
+              <label class="radio-inline">
+                <input type="radio" value="section" name="post[playlistitem_scope]" id="playlistitem_scope_section">
+                Create single item for <%= scope=='master_file'? '' : 'each '%>section
+              </label>
+              <br>
+              <label class="radio-inline">
+                <input type="radio" value="structure" name="post[playlistitem_scope]" id="playlistitem_scope_structure">
+                Create multiple items from subsections, if available
+              </label>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-offset-2 col-sm-10">
+              <div>
+                <input type="submit" name="commit" value="Add to Playlist" class="btn btn-primary btn-xs">
+              </div>
+            </div>
+          </div>
+          </form>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -23,6 +23,8 @@ Unless required by applicable law or agreed to in writing, software distributed
         <span id="section-label">Sections</span>
 	<button class="btn btn-primary btn-xs" id="expand_button">Expand All</button>
 	<button class="btn btn-primary btn-xs hidden" id="collapse_button">Collapse All</button>
+  <button type="button" title="Add all sections to playlist" aria-label="Add all sections to playlist" class="structure_add_to_playlist outline_on btn btn-primary" data-scope="media_object"></button>
+
 	<br class="clear"/>
       </h4>
     </div>
@@ -37,6 +39,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   </div>
 </div>
+
+<!-- add_to_playlist modal form ---->
+<div class="modal fade" id="add-to-playlist-modal" tabindex="-1" role="dialog"></div>
 
 <% content_for :page_scripts do %>
 <script>
@@ -79,6 +84,30 @@ Unless required by applicable law or agreed to in writing, software distributed
     var sectiondiv = $(panelheader.find('.fa-plus-square').data('target'));
     if (!sectiondiv.hasClass('in')) panelheader.find('.fa-plus-square').click();
   });
+  $('.structure_add_to_playlist').on('click',function(){
+    $.ajax({
+        type: "POST",
+        url: "<%= add_to_playlist_form_media_object_path(@media_object) %>",
+        data: {
+          masterfile_id: $(this).data('masterfileId'),
+          scope: $(this).data('scope')
+         },
+        success: function(result) {
+          modal = $('#add-to-playlist-modal')
+          modal.html(result);
+          modal.find('#add_to_playlist_form').on('ajax:success', function(e, data, status, xhr){
+            $('#add-to-playlist-modal .modal-body').html(data["message"]);
+          }).on('ajax:error',function(e, xhr, status, error){
+            $('#add-to-playlist-modal .modal-body').html(error);
+          });
+          modal.modal('show');
+        },
+        error: function(result) {
+            alert('error');
+        }
+    });
+  });
+
 </script>
 <% end %>
 <% end %>

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -86,7 +86,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   });
   $('.structure_add_to_playlist').on('click',function(){
     $.ajax({
-        type: "POST",
+        type: "GET",
         url: "<%= add_to_playlist_form_media_object_path(@media_object) %>",
         data: {
           masterfile_id: $(this).data('masterfileId'),
@@ -95,6 +95,9 @@ Unless required by applicable law or agreed to in writing, software distributed
         success: function(result) {
           modal = $('#add-to-playlist-modal')
           modal.html(result);
+          modal.find('#playlistitem_submit').on('click', function(){
+              $(this).button('loading')
+          })
           modal.find('#add_to_playlist_form').on('ajax:success', function(e, data, status, xhr){
             $('#add-to-playlist-modal .modal-body').html(data["message"]);
           }).on('ajax:error',function(e, xhr, status, error){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
       get 'section/:content/stream', :action => :show_stream_details, :as => :section_stream
       get 'tree', :action => :tree, :as => :tree
       get :confirm_remove
-      post :add_to_playlist_form
+      get :add_to_playlist_form
       post :add_to_playlist
     end
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
       get 'section/:content/stream', :action => :show_stream_details, :as => :section_stream
       get 'tree', :action => :tree, :as => :tree
       get :confirm_remove
+      post :add_to_playlist_form
+      post :add_to_playlist
     end
     collection do
       post :create, action: :create, constraints: { format: 'json' }

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1042,29 +1042,27 @@ describe MediaObjectsController, type: :controller do
       login_as 'administrator'
     end
     it "should render add_to_playlist_form with correct masterfile_id" do
-      post :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
+      get :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
       expect(response).to render_template(:_add_to_playlist_form)
       expect(response.body).to include(media_object.master_file_ids[0])
     end
     it "should render the correct label for scope=master_file" do
-      post :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
+      get :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
       expect(response.body).to include('Add Section to Playlist')
     end
-    it "should render the correct label for scope=master_file" do
-      post :add_to_playlist_form, id: media_object.id, scope: 'media_object', masterfile_id: media_object.master_file_ids[0]
+    it "should render the correct label for scope=media_object" do
+      get :add_to_playlist_form, id: media_object.id, scope: 'media_object', masterfile_id: media_object.master_file_ids[0]
       expect(response.body).to include('Add Media Object to Playlist')
     end
   end
 
   describe "#add_to_playlist" do
-    let(:media_object) { FactoryGirl.create(:media_object, :with_master_file, title: 'Test Item') }
+    let(:media_object) { FactoryGirl.create(:media_object, ordered_master_files: [FactoryGirl.create(:master_file), master_file_with_structure], title: 'Test Item') }
     let(:master_file_with_structure) { FactoryGirl.create(:master_file, :with_structure) }
     let(:playlist) { FactoryGirl.create(:playlist) }
 
     before do
       login_as 'administrator'
-      media_object.ordered_master_files += [master_file_with_structure]
-      media_object.save!
     end
 
     it "should create a single playlist_item for a single master_file" do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -1034,4 +1034,67 @@ describe MediaObjectsController, type: :controller do
       expect(@request.session[:quality]).to eq('crazy_high')
     end
   end
+
+  describe "#add_to_playlist_form" do
+    let(:media_object) { FactoryGirl.create(:media_object, :with_master_file) }
+
+    before do
+      login_as 'administrator'
+    end
+    it "should render add_to_playlist_form with correct masterfile_id" do
+      post :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
+      expect(response).to render_template(:_add_to_playlist_form)
+      expect(response.body).to include(media_object.master_file_ids[0])
+    end
+    it "should render the correct label for scope=master_file" do
+      post :add_to_playlist_form, id: media_object.id, scope: 'master_file', masterfile_id: media_object.master_file_ids[0]
+      expect(response.body).to include('Add Section to Playlist')
+    end
+    it "should render the correct label for scope=master_file" do
+      post :add_to_playlist_form, id: media_object.id, scope: 'media_object', masterfile_id: media_object.master_file_ids[0]
+      expect(response.body).to include('Add Media Object to Playlist')
+    end
+  end
+
+  describe "#add_to_playlist" do
+    let(:media_object) { FactoryGirl.create(:media_object, :with_master_file, title: 'Test Item') }
+    let(:master_file_with_structure) { FactoryGirl.create(:master_file, :with_structure) }
+    let(:playlist) { FactoryGirl.create(:playlist) }
+
+    before do
+      login_as 'administrator'
+      media_object.ordered_master_files += [master_file_with_structure]
+      media_object.save!
+    end
+
+    it "should create a single playlist_item for a single master_file" do
+      expect {
+        post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, masterfile_id: media_object.master_file_ids[0], playlistitem_scope: 'section' }
+      }.to change { playlist.items.count }.from(0).to(1)
+      expect(playlist.items[0].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[0].title}")
+    end
+    it "should create playlist_items for each span in a single master_file's structure" do
+      expect {
+        post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, masterfile_id: media_object.master_file_ids[1], playlistitem_scope: 'structure' }
+      }.to change { playlist.items.count }.from(0).to(13)
+      expect(playlist.items[0].title).to eq("Test Item - CD 1 - Copland, Three Piano Excerpts from Our Town - Track 1. Story of Our Town")
+      expect(playlist.items[12].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
+    end
+    it "should create a single playlist_item for each master_file in a media_object" do
+      expect {
+        post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, playlistitem_scope: 'section' }
+      }.to change { playlist.items.count }.from(0).to(2)
+      expect(playlist.items[0].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[0].title}")
+      expect(playlist.items[1].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[1].title}")
+    end
+    it "should create playlist_items for each span in a master_file structures in a media_object" do
+      expect {
+        post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, playlistitem_scope: 'structure' }
+      }.to change { playlist.items.count }.from(0).to(14)
+      expect(response.response_code).to eq(200)
+      expect(playlist.items[0].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[0].title}")
+      expect(playlist.items[13].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
+    end
+  end
+
 end

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2017, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -18,7 +18,7 @@ FactoryGirl.define do
     file_format {'Moving image'}
     percent_complete {"#{rand(100)}"}
     workflow_name 'avalon'
-    duration {'100'}
+    duration {'200000'}
 
     trait :with_media_object do
       association :media_object #, factory: :media_object


### PR DESCRIPTION
Fixes #1943 

Adds new ability to easily add one or all sections of a media object to a playlist. Entire sections may be added as single playlist items, or if structural metadata is available, sections may be added as multiple playlist items based on that structure.