### PR TITLE
Fix bug with playlist comment field

### DIFF
--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -214,8 +214,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 
     // Handle playlist edit cancel
     $('#playlist_edit_cancel').click(function(event) {
-      $('#playlist_form #playlist_title').val('<%= @playlist.title %>');
-      $('#playlist_form #playlist_comment').val('<%= @playlist.comment %>');
+      $('#playlist_form #playlist_title').val('<%= j @playlist.title %>');
+      $('#playlist_form #playlist_comment').val('<%= j @playlist.comment %>');
       <% if @playlist.visibility==Playlist::PRIVATE %>
         $('#playlist_form #playlist_visibility_private').prop('checked', true);
       <% else %>


### PR DESCRIPTION
Comments with newlines would break the JavaScript. We get out of that by using string literals.