### PR TITLE
Copying playlist fixes

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -138,7 +138,7 @@ class PlaylistsController < ApplicationController
 
       #copy items
       old_playlist.items.each do |item|
-        next if item.nil?
+        next if item.clip.master_file.nil?
         copy_item = item.duplicate!
         copy_item.playlist_id  = @playlist.id
         copy_item.save!

--- a/app/models/playlist_item.rb
+++ b/app/models/playlist_item.rb
@@ -28,6 +28,7 @@ class PlaylistItem < ActiveRecord::Base
   end
 
   def duplicate!
+    return nil if clip.master_file.nil?
     new_clip = clip.dup
     new_clip.save!
 


### PR DESCRIPTION
fixes #2222 and #2230  
This change checks to make sure a playlist item to be copied has a masterfile. If it doesn't it just skips it.
It also appends the copied items onto the end of the items list.