### PR TITLE
Fix issue with marker_rail resizing

### DIFF
--- a/app/assets/javascripts/avalon_player.js.coffee
+++ b/app/assets/javascripts/avalon_player.js.coffee
@@ -110,11 +110,11 @@ class AvalonPlayer
               currentPlayer.setCurrentTime offset
             marker_rail.append(marker)
             marker_rail.append('<span class="mejs-time-float-marker" data-marker="'+marker_id+'" style="display: none; left: '+offset_percent+'%" ><span class="mejs-time-float-current-marker">'+title+'</span><span class="mejs-time-float-corner-marker"></span></span>')
-            marker_rail.width(total.width())
           scrubber.append(marker_rail)
           _this.player.globalBind('resize', (e) ->
             marker_rail.width(total.width())
           )
+          marker_rail.width(total.width())
           $('.scrubber-marker').bind('mouseenter', (e) ->
             $('.mejs-time-float-marker[data-marker="'+this.dataset.marker+'"]').show()
           ).bind 'mouseleave', (e) ->


### PR DESCRIPTION
Fixes #2221 

Fixes occasional issue with marker offsets appearing incorrectly. Resizing of the marker rail depended on the order in which a browser's javascript engine would add elements to the DOM or process events on those elements. This removes that dependency on order.