### PR TITLE
Only display icon for visibility on playlist view page

### DIFF
--- a/app/helpers/playlists_helper.rb
+++ b/app/helpers/playlists_helper.rb
@@ -15,9 +15,17 @@
 module PlaylistsHelper
   def human_friendly_visibility(visibility)
     if (visibility == Playlist::PUBLIC)
-      safe_join([content_tag(:span, '', class:"fa fa-globe fa-lg", title: t("playlist.unlockAltText")),t("playlist.unlockText")], ' ')
+      safe_join([icon_only_visibility(visibility),t("playlist.unlockText")], ' ')
     else
-      safe_join([content_tag(:span, '', class:"fa fa-lock fa-lg", title: t("playlist.lockAltText")),t("playlist.lockText")], ' ')
+      safe_join([icon_only_visibility(visibility),t("playlist.lockText")], ' ')
+    end
+  end
+
+  def icon_only_visibility(visibility)
+    if (visibility == Playlist::PUBLIC)
+      content_tag(:span, '', class:"fa fa-globe fa-lg", title: t("playlist.unlockAltText"))
+    else
+      content_tag(:span, '', class:"fa fa-lock fa-lg", title: t("playlist.lockAltText"))
     end
   end
 end

--- a/app/views/playlists/_item_list.html.erb
+++ b/app/views/playlists/_item_list.html.erb
@@ -37,11 +37,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= render 'share' if will_partial_list_render? :share %>
 </div>
 <h3 class="playlist-title">
-  <% if @playlist.visibility==Playlist::PUBLIC %>
-    <%= human_friendly_visibility Playlist::PUBLIC %>
-  <% else %>
-    <%= human_friendly_visibility Playlist::PRIVATE %>
-  <% end %>
+  <%= icon_only_visibility @playlist.visibility %>
   <%= @playlist.title %>
 </h3>
 <% if @playlist.comment.present? %>


### PR DESCRIPTION
Fixes #2237.

This reverts and cleans up a change to the display of the visibility on the playlist view page which brings it in line with Avalon 6.1.