### PR TITLE
Adjust styling for add_to_playlist for mediaobjects with multiple structures

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -881,6 +881,8 @@ div.status-detail {
   background: $blue url(add_to_playlist_icon.svg) no-repeat;
   background-position: 3px 0px;
   border-color: $blue !important;
+  margin-top: -2px;
+  margin-left: 2px;
 }
 
 #mediaobject_structure {

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -21,11 +21,10 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="panel-heading" role="tab" id="heading0" style="border-bottom: 1px solid #ddd;">
       <h4 class="panel-title">
         <span id="section-label">Sections</span>
-	<button class="btn btn-primary btn-xs" id="expand_button">Expand All</button>
-	<button class="btn btn-primary btn-xs hidden" id="collapse_button">Collapse All</button>
-  <button type="button" title="Add all sections to playlist" aria-label="Add all sections to playlist" class="structure_add_to_playlist outline_on btn btn-primary" data-scope="media_object"></button>
-
-	<br class="clear"/>
+        <button type="button" title="Add all sections to playlist" aria-label="Add all sections to playlist" class="structure_add_to_playlist outline_on btn btn-primary" data-scope="media_object"></button>
+	      <button class="btn btn-primary btn-xs" id="expand_button">Expand All</button>
+	      <button class="btn btn-primary btn-xs hidden" id="collapse_button">Collapse All</button>
+        <br class="clear"/>
       </h4>
     </div>
 
@@ -49,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     $('#collapse_button').addClass('hidden');
     $('#expand_button').addClass('hidden');
   } else {
-    $('.panel-title #section-label').addClass('hidden');
+    <!-- $('.panel-title #section-label').addClass('hidden'); -->
     $('#accordion.panel-group .panel-collapse').on('shown.bs.collapse', function() {
       if($('#accordion.panel-group .panel-collapse').length == $('#accordion.panel-group .panel-collapse.in').length) {
         $('#expand_button').addClass('hidden');


### PR DESCRIPTION
Fixes layout issues when multiple sections have structural metadata.
Also, stops hiding "Sections" label in those cases.