### PR TITLE
Fix layout for playlist related items

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1102,25 +1102,20 @@ h5.panel-title {
     resize: vertical;
   }
 }
-.clip_title {
-   font-weight: bold;
-   left: 0 ;
-   position: absolute;
-}
-.clip_start_time {
-  position: absolute;
-  right: 240px;
-}
-.clip_end_time {
-  position: absolute;
-  right: 130px;
-}
-.clip_position {
-  position: absolute;
-  right: 0;
-}
-.related_item {
-  position: relative;
+#related_items {
+  .clip_title {
+     font-weight: bold;
+  }
+  .clip_start_time {
+  }
+  .clip_end_time {
+  }
+  .clip_position {
+    text-align: center;
+  }
+  tr {
+    height: 2em;
+  }
 }
 
 /* Playlist edit page */

--- a/app/views/playlists/_related_items.html.erb
+++ b/app/views/playlists/_related_items.html.erb
@@ -14,21 +14,24 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <div id="related_items">
-  <ul>
-  <% @related_clips.sort_by { |hash| hash['start_time'].to_i}.each do |clip| %>
-    <% position = clip.playlist_position(@playlist.id) %>
-    <% if can? :read, clip.master_file %>
-      <li class='related_item'>
-        <%= link_to playlist_path(@playlist, position: position) do %>
-          <span class='clip_title'><%= clip.title %></span>
-          <span class='clip_start_time'>Start: <%= pretty_time(clip.start_time) %></span>
-          <span class='clip_end_time'>End: <%= pretty_time(clip.end_time) %></span>
-          <% unless position.nil? %>
-            <span class='clip_position'>Playlist Position: <%= position %></span>
-          <% end %>
-        <% end %>
-      </li>
+  <table class="table table-responsive">
+    <thead><tr><th>Title</th><th>Start</th><th>End</th><th>Position</th></tr></thead>
+    <tbody>
+      <% @related_clips.sort_by { |hash| hash['start_time'].to_i}.each do |clip| %>
+      <% if can? :read, clip.master_file %>
+        <tr>
+          <% position = clip.playlist_position(@playlist.id) %>
+          <td class='clip_title'>
+            <%= link_to playlist_path(@playlist, position: position) do %>
+              <%= clip.title %>
+            <% end %>
+          </td>
+          <td class='clip_start_time'><%= pretty_time(clip.start_time) %></td>
+          <td class='clip_end_time'><%= pretty_time(clip.end_time) %></td>
+          <td class='clip_position'><%= position %></td>
+        </tr>
+      <% end %>
     <% end %>
-  <% end %>
-  </ul>
+    </tbody>
+  </table>
 </div>


### PR DESCRIPTION
Fixes #2252 

Fixes layout of playlist related items by using a bootstrap responsive table.