### PR TITLE
Update add to playlist form values in context of switching media play…

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -185,7 +185,7 @@ class MEJSPlayer {
     const target = e.target
     const dataset = e.target.dataset
 
-    // Did user click on Structured metadata link?// Did user click on Structured metadata link?
+    // Did user click on Structured metadata link?
     this.playRangeFlag = !!dataset.fragmentbegin
     if (this.playRangeFlag) {
       // Store temporarily range clip data

--- a/app/views/media_objects/_mejs4_add_to_playlist.html.erb
+++ b/app/views/media_objects/_mejs4_add_to_playlist.html.erb
@@ -13,6 +13,10 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+
+<%#
+This view file goes with the custom 'Add To Playlist' MediaElement 4 plugin.
+%>
 <% content_for :page_scripts do %>
   <%= javascript_include_tag 'select2.min' %>
   <%= stylesheet_link_tag 'select2.min' %>


### PR DESCRIPTION
### Description
This code will pre-populate Add To Playlist form fields with data from either a section link, or a structural metadata link.  It's also accounting for add/removing multiple instances of a MediaElement 4 player to a page without a page refresh, in switching from say audio to a video player.