### PR TITLE
Exclude top level in structure for default playlistitem title

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/media-element-add-to-playlist.git
-  revision: 90c07c0c8403d88c4c5c091af4468a9656ea4e2b
+  revision: 129f6bb1d05bd9cea5b359d25ccd2288f2336632
   specs:
     media_element_add_to_playlist (0.0.1)
       rails (~> 4.0)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -87,8 +87,8 @@ class MediaObjectsController < ApplicationController
       if playlistitem_scope=='structure' && mf.has_structuralMetadata? && mf.structuralMetadata.xpath('//Span').present?
         #create individual items for spans within structure
         mf.structuralMetadata.xpath('//Span').each do |s|
-          labels = [@media_object.title, mf.title]
-          labels += s.xpath('ancestor::*[\'label\']').collect{|a|a.attribute('label').value.strip}
+          labels = [mf.embed_title]
+          labels += s.xpath('ancestor::Div[\'label\']').collect{|a|a.attribute('label').value.strip}
           labels << s.attribute('label')
           label = labels.reject(&:blank?).join(' - ')
           start_time = s.attribute('begin')

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -68,7 +68,10 @@ module MasterFileBehavior
   end
 
   def embed_title
-    "#{ self.media_object.title } - #{ self.title.present? ? self.title : self.file_location.split( "/" ).last }"
+    mf_title = self.structuralMetadata.section_title unless self.structuralMetadata.blank?
+    mf_title ||= self.title if self.title.present?
+    mf_title ||= self.file_location.split( "/" ).last if self.file_location.present?
+    [ self.media_object.title, mf_title ].compact.join(" - ")
   end
 
   def embed_code(width, permalink_opts = {})

--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -33,4 +33,8 @@ class StructuralMetadata < ActiveFedora::File
   def valid?
     self.class.schema.validate(self.ng_xml).empty?
   end
+
+  def section_title
+    xpath('/Item/@label').text()
+  end
 end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1057,12 +1057,14 @@ describe MediaObjectsController, type: :controller do
   end
 
   describe "#add_to_playlist" do
-    let(:media_object) { FactoryGirl.create(:media_object, ordered_master_files: [FactoryGirl.create(:master_file), master_file_with_structure], title: 'Test Item') }
-    let(:master_file_with_structure) { FactoryGirl.create(:master_file, :with_structure) }
+    let(:media_object) { FactoryGirl.create(:media_object, title: 'Test Item') }
+    let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object, title: 'Test Section') }
+    let(:master_file_with_structure) { FactoryGirl.create(:master_file, :with_structure, media_object: media_object) }
     let(:playlist) { FactoryGirl.create(:playlist) }
 
     before do
       login_as 'administrator'
+      media_object.ordered_master_files = [master_file, master_file_with_structure]
     end
 
     it "should create a single playlist_item for a single master_file" do
@@ -1075,8 +1077,8 @@ describe MediaObjectsController, type: :controller do
       expect {
         post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, masterfile_id: media_object.master_file_ids[1], playlistitem_scope: 'structure' }
       }.to change { playlist.items.count }.from(0).to(13)
-      expect(playlist.items[0].title).to eq("Test Item - CD 1 - Copland, Three Piano Excerpts from Our Town - Track 1. Story of Our Town")
-      expect(playlist.items[12].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
+      expect(playlist.items[0].title).to eq("Test Item - video.mp4 - Copland, Three Piano Excerpts from Our Town - Track 1. Story of Our Town")
+      expect(playlist.items[12].title).to eq("Test Item - video.mp4 - Track 13. Copland, Danzon Cubano")
     end
     it "should create a single playlist_item for each master_file in a media_object" do
       expect {
@@ -1091,7 +1093,7 @@ describe MediaObjectsController, type: :controller do
       }.to change { playlist.items.count }.from(0).to(14)
       expect(response.response_code).to eq(200)
       expect(playlist.items[0].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[0].title}")
-      expect(playlist.items[13].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
+      expect(playlist.items[13].title).to eq("Test Item - video.mp4 - Track 13. Copland, Danzon Cubano")
     end
   end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1077,8 +1077,8 @@ describe MediaObjectsController, type: :controller do
       expect {
         post :add_to_playlist, id: media_object.id, post: { playlist_id: playlist.id, masterfile_id: media_object.master_file_ids[1], playlistitem_scope: 'structure' }
       }.to change { playlist.items.count }.from(0).to(13)
-      expect(playlist.items[0].title).to eq("Test Item - video.mp4 - Copland, Three Piano Excerpts from Our Town - Track 1. Story of Our Town")
-      expect(playlist.items[12].title).to eq("Test Item - video.mp4 - Track 13. Copland, Danzon Cubano")
+      expect(playlist.items[0].title).to eq("Test Item - CD 1 - Copland, Three Piano Excerpts from Our Town - Track 1. Story of Our Town")
+      expect(playlist.items[12].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
     end
     it "should create a single playlist_item for each master_file in a media_object" do
       expect {
@@ -1093,7 +1093,7 @@ describe MediaObjectsController, type: :controller do
       }.to change { playlist.items.count }.from(0).to(14)
       expect(response.response_code).to eq(200)
       expect(playlist.items[0].title).to eq("#{media_object.title} - #{media_object.ordered_master_files.to_a[0].title}")
-      expect(playlist.items[13].title).to eq("Test Item - video.mp4 - Track 13. Copland, Danzon Cubano")
+      expect(playlist.items[13].title).to eq("Test Item - CD 1 - Track 13. Copland, Danzon Cubano")
     end
   end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -380,16 +380,30 @@ describe MasterFile do
   end
 
   describe "#embed_title" do
-    subject { FactoryGirl.create( :master_file, { media_object: FactoryGirl.create( :media_object, { title: "test" })})}
+    context "with structure" do
+      subject { FactoryGirl.create( :master_file, :with_structure, { media_object: FactoryGirl.create( :media_object, { title: "test" })})}
 
-    it "should have an appropriate title for the embed code with no label" do
-      expect( subject.embed_title ).to eq( "test - video.mp4" )
+      it "should favor the structure item label" do
+        expect( subject.embed_title ).to eq( "test - CD 1" )
+      end
     end
 
-    it "should have an appropriate title for the embed code with a label" do
-      subject.title = "test"
+    context "without structure" do
+      subject { FactoryGirl.create( :master_file, { media_object: FactoryGirl.create( :media_object, { title: "test" })})}
 
-      expect( subject.embed_title ).to eq( "test - test" )
+      it "should have an appropriate title for the embed code with a label" do
+        subject.title = "test"
+        expect( subject.embed_title ).to eq( "test - test" )
+      end
+
+      it "should have an appropriate title for the embed code with no label" do
+        expect( subject.embed_title ).to eq( "test - video.mp4" )
+      end
+
+      it "should have an appropriate title for the embed code with no label or file_location" do
+        subject.file_location = nil
+        expect( subject.embed_title ).to eq( "test" )
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #2249 

Exclude top level in structure when creating playlist_item titles, because it duplicates the master_file label (or filename).