### PR TITLE
Add visibility help text

### DIFF
--- a/app/assets/javascripts/avalon_playlists/playlists.js.coffee
+++ b/app/assets/javascripts/avalon_playlists/playlists.js.coffee
@@ -71,3 +71,8 @@ $('#copy-playlist-form').bind('ajax:success',
         if ( $('#with_refresh').val() )
           location.reload()
 )
+$('input[name="playlist[visibility]"]').on('click', () ->
+  new_val = $(this).val()
+  new_text = $('.human_friendly_visibility_'+new_val).attr('title')
+  $('.visibility-help-text').text(new_text)
+)

--- a/app/helpers/playlists_helper.rb
+++ b/app/helpers/playlists_helper.rb
@@ -14,22 +14,25 @@
 
 module PlaylistsHelper
   def human_friendly_visibility(visibility)
-    if (visibility == Playlist::PUBLIC)
-      safe_join([icon_only_visibility(visibility),t("playlist.unlockText")], ' ')
-    elsif (visibility == Playlist::PRIVATE)
-      safe_join([icon_only_visibility(visibility),t("playlist.lockText")], ' ')
-    else
-      safe_join([icon_only_visibility(visibility),t("playlist.shareText")], ' ')
-    end
+    content_tag(:span,
+      safe_join([icon_only_visibility(visibility),t("playlist.#{visibility}Text")], ' '),
+      class: "human_friendly_visibility_#{visibility}",
+      title: visibility_description(visibility))
   end
 
   def icon_only_visibility(visibility)
-    if (visibility == Playlist::PUBLIC)
-      content_tag(:span, '', class:"fa fa-globe fa-lg", title: t("playlist.unlockAltText"))
-    elsif (visibility == Playlist::PRIVATE)
-      content_tag(:span, '', class:"fa fa-lock fa-lg", title: t("playlist.lockAltText"))
-    else
-      content_tag(:span, '', class:"fa fa-link fa-lg", title: t("playlist.shareText"))
+    icon = case visibility
+      when Playlist::PUBLIC
+        "fa-globe"
+      when Playlist::PRIVATE
+        "fa-lock"
+      else
+        "fa-link"
     end
+    content_tag(:span, '', class:"fa #{icon} fa-lg", title: visibility_description(visibility))
+  end
+
+  def visibility_description(visibility)
+    t("playlist.#{visibility}AltText")
   end
 end

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -38,6 +38,9 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= f.radio_button(:visibility, Playlist::PRIVATE_WITH_TOKEN, class: 'share-playlist') %>
           <%= human_friendly_visibility Playlist::PRIVATE_WITH_TOKEN %>
         </label>
+        <p class="text-info visibility-help-text" style="padding-top:5px;font-style:italic;">
+          <%= visibility_description @playlist.visibility %>
+        </p>
       </div>
     </div>
     <div class="row">

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -40,12 +40,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="row">
       <div class="col-sm-2"><%= t("blacklight/folders/folder.visibility", scope: "helpers.label") %></div>
       <div class="col-sm-10">
-        <% if @playlist.visibility==Playlist::PUBLIC %>
-          <%= human_friendly_visibility Playlist::PUBLIC %>
-        <% elsif @playlist.visibility==Playlist::PRIVATE %>
-          <%= human_friendly_visibility Playlist::PRIVATE %>
-        <% else %>
-          <%= human_friendly_visibility Playlist::PRIVATE_WITH_TOKEN %>
+        <%= human_friendly_visibility @playlist.visibility %> - <i><%= visibility_description @playlist.visibility %></i>
+        <% if @playlist.visibility == Playlist::PRIVATE_WITH_TOKEN %>
           <div class="row" style="margin-top:9px;">
             <div class="col-xs-9">
               <div class="input-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,12 +185,14 @@ en:
 
   playlist:
     ago: "%{time} ago"
-    lockAltText: "This playlist is private."
-    unlockAltText: "This playlist is public."
-    shareAltText: "This playlist is shared by link."
-    lockText: "Private"
-    unlockText: "Public"
-    shareText: "Share by link"
+
+    privateAltText: "This playlist can only be viewed by you."
+    publicAltText: "This playlist can be viewed by anyone on the web."
+    private-with-tokenAltText: "This playlist can only be viewed by users who have the unique link."
+
+    privateText: "Private"
+    publicText: "Public"
+    private-with-tokenText: "Share by link"
 
     new:
       action: "Create"


### PR DESCRIPTION
fixes #2264 
 - Added help text below the visibility settings in the edit form
 - Changed the alt text to the descriptions @joncameron provided
 - Made the playlist helper functions less redundant
 - Added the descriptions to the playlist edit page's playlist description section
 - Renamed the locals for playlists to match our wording in the rest of avalon