### PR TITLE
Make sure vendored assets and stylesheets behave w/r/t asset pipeline

### DIFF
--- a/app/assets/stylesheets/avalon.scss.erb
+++ b/app/assets/stylesheets/avalon.scss.erb
@@ -878,7 +878,7 @@ div.status-detail {
 .structure_add_to_playlist {
   float: right;
   height: 1.5em;
-  background: $blue url(add_to_playlist_icon.svg) no-repeat;
+  background: $blue url(<%= image_path 'add_to_playlist_icon.svg' %>) no-repeat;
   background-position: 3px 0px;
   border-color: $blue !important;
   margin-top: -2px;

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,21 +1,21 @@
 # Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.tap do |assets|
+  # Version of your assets, change this if you want to expire all your assets.
+  assets.version = '1.0'
 
-# Add additional assets to the asset load path
-# Rails.application.config.assets.paths << Emoji.images_path
+  # Add additional assets to the asset load path
+  # assets.paths << Emoji.images_path
 
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # assets.precompile += %w( search.js )
 
-Rails.application.config.assets.precompile += %w( embed.css )
+  assets.precompile += %w( embed.css )
 
-# MediaElement 4 files
-Rails.application.config.assets.precompile += %w( mejs4_player.js )
-Rails.application.config.assets.precompile += %w( mejs4_player.scss )
-
-# MediaElement 2 files
-Rails.application.config.assets.precompile += %w( mejs2_player.js )
-Rails.application.config.assets.precompile += %w( mejs2_player.scss )
+  # MediaElement 4 files
+  assets.precompile += %w( mejs4_player.js mejs4_player.scss )
+  assets.precompile += Dir[Rails.root + 'vendor/assets/stylesheets/mediaelement/mejs-controls.*']
+  # MediaElement 2 files
+  assets.precompile += %w( mejs2_player.js mejs2_player.scss )
+end


### PR DESCRIPTION
Our testing should probably include at least one system that turns on-the-fly asset serving off.