### PR TITLE
Turn off feature tests in travis until randomly failing tests are fixed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,11 @@ task default: [:ci]
 
 Rails.application.load_tasks
 
+RSpec::Core::RakeTask.new(:rspec) do |task|
+  # Disable feature tests in travis until the intermittent failures are fixed
+  task.rspec_opts = "--tag ~type:feature" if ENV['TRAVIS']
+end
+
 task :ci do
   run_server 'test' do
     Rake::Task['spec'].invoke

--- a/spec/features/capybara_homepage_spec.rb
+++ b/spec/features/capybara_homepage_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-describe 'homepage' do
+describe 'homepage', type: :feature do
   after { Warden.test_reset! }
   it 'validates presence of header and footer on homepage' do
     visit 'http://0.0.0.0:3000'

--- a/spec/features/capybara_navigation_spec.rb
+++ b/spec/features/capybara_navigation_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-describe 'checks navigation after logging in' do
+describe 'checks navigation after logging in', type: :feature do
   after { Warden.test_reset! }
   it 'checks navigation to Browse' do
     user = FactoryGirl.create(:administrator)

--- a/spec/features/capybara_playlist_spec.rb
+++ b/spec/features/capybara_playlist_spec.rb
@@ -16,7 +16,7 @@ require 'rails_helper'
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
-describe 'Playlist' do
+describe 'Playlist', type: :feature do
   after { Warden.test_reset! }
   it 'checks navigation when create new playlist is accessed' do
     user = FactoryGirl.create(:administrator)

--- a/spec/features/media_object_spec.rb
+++ b/spec/features/media_object_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-describe 'MediaObject' do
+describe 'MediaObject', type: :feature do
   after { Warden.test_reset! }
   let(:media_object) { FactoryGirl.build(:media_object).tap {|mo| mo.workflow.last_completed_step = "resource-description"} }
   before :each do

--- a/spec/features/secure_routes_spec.rb
+++ b/spec/features/secure_routes_spec.rb
@@ -14,7 +14,7 @@
 
 require 'rails_helper'
 
-describe "Secure Routes" do
+describe "Secure Routes", type: :feature do
   after { Warden.test_reset! }
   let!(:admin) { FactoryGirl.create(:administrator) }
   let!(:user)  { FactoryGirl.create(:user) }


### PR DESCRIPTION
The randomly failing feature tests are really slowing down PRs.  There is work ongoing on #2281 but until that work is finished I would like to turn off feature tests when rspec is run by travis.