### PR TITLE
Exclude feature tests from travis

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,9 +23,14 @@ task default: [:ci]
 
 Rails.application.load_tasks
 
+RSpec::Core::RakeTask.new('rspec') do |task|
+  # Disable feature tests in travis until the intermittent failures are fixed
+  task.rspec_opts = "--tag ~type:feature" if ENV['TRAVIS']
+end
+
 task :ci do
   run_server 'test' do
-    Rake::Task['spec'].invoke
+    Rake::Task['rspec'].invoke
   end
 end
 


### PR DESCRIPTION
The randomly failing feature tests are really slowing down PRs. There is work ongoing on #2281 but until that work is finished I would like to turn off feature tests when rspec is run by travis.