### PR TITLE
Ensure currentPlaylistItem is set on the audio/video element on first…

### DIFF
--- a/app/views/playlists/_mejs2_player_js.html.erb
+++ b/app/views/playlists/_mejs2_player_js.html.erb
@@ -36,6 +36,7 @@
         displayTrackScrubber: true,
         autostart: <%= params[:autostart] == 'true' ? 'true' : 'false' %>,
         success: function(mediaElement, domObject, player) {
+          avalonPlayer.player.domNode.dataset['currentPlaylistItem'] = '<%= @current_playlist_item.id %>';
           <%# turn off autoadvance if scrubber is clicked %>
           var scrubber =  $('.mejs-time-total')[0];
           var oldclick = scrubber.onmousedown;


### PR DESCRIPTION
… load of playlist

Fixes #2322.

I'm setting this on the playlist player initialization success callback because it is specific to playlists.
This regression was introduced when I refactored the player partials and is not present in Avalon 6.1.