### PR TITLE
Move authorization of playlists that are private with token into the ability.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -164,13 +164,13 @@ class Ability
     if @user.id.present?
       can :manage, Playlist, user: @user
       # can :create, Playlist
+      can :duplicate, Playlist, visibility: Playlist::PUBLIC
+      can :duplicate, Playlist do |playlist|
+        playlist.valid_token?(@options[:playlist_token])
+      end
     end
     can :read, Playlist, visibility: Playlist::PUBLIC
     can :read, Playlist do |playlist|
-      playlist.valid_token?(@options[:playlist_token])
-    end
-    can :duplicate, Playlist, visibility: Playlist::PUBLIC
-    can :duplicate, Playlist do |playlist|
       playlist.valid_token?(@options[:playlist_token])
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -166,7 +166,13 @@ class Ability
       # can :create, Playlist
     end
     can :read, Playlist, visibility: Playlist::PUBLIC
+    can :read, Playlist do |playlist|
+      playlist.valid_token?(@options[:playlist_token])
+    end
     can :duplicate, Playlist, visibility: Playlist::PUBLIC
+    can :duplicate, Playlist do |playlist|
+      playlist.valid_token?(@options[:playlist_token])
+    end
   end
 
   def playlist_item_permissions

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -85,12 +85,11 @@ class Playlist < ActiveRecord::Base
     clips
   end
 
-  class << self
-    # Find the playlists that belong to this user/ability
-    def for_ability(ability)
-      accessible_by(ability, :update).order('playlists.created_at DESC')
-    end
+  def valid_token?(token)
+    access_token == token && visibility == Playlist::PRIVATE_WITH_TOKEN
+  end
 
+  class << self
     # Find the i18n default playlist name
     def default_folder_name
       I18n.translate(:'playlists.default_playlist_name')

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170530173242) do
+ActiveRecord::Schema.define(version: 20170816135530) do
 
   create_table "annotations", force: :cascade do |t|
     t.string  "uuid"
@@ -112,11 +112,12 @@ ActiveRecord::Schema.define(version: 20170530173242) do
 
   create_table "playlists", force: :cascade do |t|
     t.string   "title"
-    t.integer  "user_id",    null: false
+    t.integer  "user_id",      null: false
     t.string   "comment"
     t.string   "visibility"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "access_token"
   end
 
   add_index "playlists", ["user_id"], name: "index_playlists_on_user_id"

--- a/spec/models/avalon_marker_spec.rb
+++ b/spec/models/avalon_marker_spec.rb
@@ -72,6 +72,19 @@ describe AvalonMarker, type: :model do
         let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object) }
 
         it { is_expected.to be_able_to(:read, avalon_marker) }
+
+        context 'when playlist is share by link' do
+          let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PRIVATE_WITH_TOKEN) }
+
+          context 'when token is given' do
+            let(:ability) { Ability.new(user, {playlist_token: playlist.access_token}) }
+            it { is_expected.to be_able_to(:read, avalon_marker) }
+          end
+
+          context 'when token is not given' do
+            it { is_expected.not_to be_able_to(:read, avalon_marker) }
+          end
+        end
       end
     end
 
@@ -92,6 +105,19 @@ describe AvalonMarker, type: :model do
         let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object) }
 
         it { is_expected.to be_able_to(:read, avalon_marker) }
+
+        context 'when playlist is share by link' do
+          let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PRIVATE_WITH_TOKEN) }
+
+          context 'when token is given' do
+            let(:ability) { Ability.new(user, {playlist_token: playlist.access_token}) }
+            it { is_expected.to be_able_to(:read, avalon_marker) }
+          end
+
+          context 'when token is not given' do
+            it { is_expected.not_to be_able_to(:read, avalon_marker) }
+          end
+        end
       end
     end
   end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -93,6 +93,50 @@ RSpec.describe Playlist, type: :model do
         end
       end
     end
+    context 'when not logged in' do
+      let(:ability) { Ability.new(nil) }
+      context('playlist public') do
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
+
+        it{ is_expected.not_to be_able_to(:manage, playlist) }
+        it{ is_expected.not_to be_able_to(:duplicate, playlist) }
+        it{ is_expected.not_to be_able_to(:create, playlist) }
+        it{ is_expected.to be_able_to(:read, playlist) }
+        it{ is_expected.not_to be_able_to(:update, playlist) }
+        it{ is_expected.not_to be_able_to(:delete, playlist) }
+      end
+      context('playlist private') do
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PRIVATE) }
+
+        it{ is_expected.not_to be_able_to(:manage, playlist) }
+        it{ is_expected.not_to be_able_to(:duplicate, playlist) }
+        it{ is_expected.not_to be_able_to(:create, playlist) }
+        it{ is_expected.not_to be_able_to(:read, playlist) }
+        it{ is_expected.not_to be_able_to(:update, playlist) }
+        it{ is_expected.not_to be_able_to(:delete, playlist) }
+      end
+      context('playlist private with token') do
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PRIVATE_WITH_TOKEN) }
+        context('when no token given') do
+          it{ is_expected.not_to be_able_to(:manage, playlist) }
+          it{ is_expected.not_to be_able_to(:duplicate, playlist) }
+          it{ is_expected.not_to be_able_to(:create, playlist) }
+          # One is still not allowed to read the playlist, but the controller bypasses this when the token is passed as a query param
+          it{ is_expected.not_to be_able_to(:read, playlist) }
+          it{ is_expected.not_to be_able_to(:update, playlist) }
+          it{ is_expected.not_to be_able_to(:delete, playlist) }
+        end
+        context('when token given') do
+          let(:ability) { Ability.new(nil, {playlist_token: playlist.access_token}) }
+          it{ is_expected.not_to be_able_to(:manage, playlist) }
+          it{ is_expected.not_to be_able_to(:duplicate, playlist) }
+          it{ is_expected.not_to be_able_to(:create, playlist) }
+          it{ is_expected.to be_able_to(:read, playlist) }
+          it{ is_expected.not_to be_able_to(:update, playlist) }
+          it{ is_expected.not_to be_able_to(:delete, playlist) }
+        end
+      end
+    end
   end
 
   describe 'related items' do

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -73,14 +73,24 @@ RSpec.describe Playlist, type: :model do
       end
       context('playlist private with token') do
         let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PRIVATE_WITH_TOKEN) }
-
-        it{ is_expected.not_to be_able_to(:manage, playlist) }
-        it{ is_expected.not_to be_able_to(:duplicate, playlist) }
-        it{ is_expected.not_to be_able_to(:create, playlist) }
-        # One is still not allowed to read the playlist, but the controller bypasses this when the token is passed as a query param
-        it{ is_expected.not_to be_able_to(:read, playlist) }
-        it{ is_expected.not_to be_able_to(:update, playlist) }
-        it{ is_expected.not_to be_able_to(:delete, playlist) }
+        context('when no token given') do
+          it{ is_expected.not_to be_able_to(:manage, playlist) }
+          it{ is_expected.not_to be_able_to(:duplicate, playlist) }
+          it{ is_expected.not_to be_able_to(:create, playlist) }
+          # One is still not allowed to read the playlist, but the controller bypasses this when the token is passed as a query param
+          it{ is_expected.not_to be_able_to(:read, playlist) }
+          it{ is_expected.not_to be_able_to(:update, playlist) }
+          it{ is_expected.not_to be_able_to(:delete, playlist) }
+        end
+        context('when token given') do
+          let(:ability) { Ability.new(user, {playlist_token: playlist.access_token}) }
+          it{ is_expected.not_to be_able_to(:manage, playlist) }
+          it{ is_expected.to be_able_to(:duplicate, playlist) }
+          it{ is_expected.not_to be_able_to(:create, playlist) }
+          it{ is_expected.to be_able_to(:read, playlist) }
+          it{ is_expected.not_to be_able_to(:update, playlist) }
+          it{ is_expected.not_to be_able_to(:delete, playlist) }
+        end
       end
     end
   end
@@ -139,6 +149,24 @@ RSpec.describe Playlist, type: :model do
       expect(playlist.access_token).to be_nil
       playlist.save
       expect(playlist.access_token).not_to be_nil
+    end
+  end
+
+  describe '#valid_token?' do
+    let(:playlist) { FactoryGirl.build(:playlist, visibility: Playlist::PRIVATE_WITH_TOKEN) }
+    let(:token) { playlist.access_token }
+
+    it 'returns true for a valid token' do
+      expect(playlist.valid_token?(token)).to be true
+    end
+
+    it 'returns false for an invalid token' do
+      expect(playlist.valid_token?('bad-token')).to be false
+    end
+
+    it 'returns false for a playlist that is not private with token' do
+      playlist.visibility = Playlist::PRIVATE
+      expect(playlist.valid_token?('bad-token')).to be false
     end
   end
 end


### PR DESCRIPTION
Fixes #2332 and other bug mentioned this morning that doesn't have a ticket yet: playlists that are private with token don't show the copy playlist button on the view page.

The fix to exposing the copy playlist button reveals a different problem that causes copying from playlists that are private with token to fail.  @lealeelu is working on it.