### PR TITLE
Enforce playlist token on refresh_info

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -177,10 +177,10 @@ class Ability
       can [:create, :update, :delete], PlaylistItem do |playlist_item|
         can? :manage, playlist_item.playlist
       end
-      can :read, PlaylistItem do |playlist_item|
-        (can? :read, playlist_item.playlist) &&
-        (can? :read, playlist_item.master_file)
-      end
+    end
+    can :read, PlaylistItem do |playlist_item|
+      (can? :read, playlist_item.playlist) &&
+      (can? :read, playlist_item.master_file)
     end
   end
 

--- a/app/views/playlists/_info.html.erb
+++ b/app/views/playlists/_info.html.erb
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<%# @current_playlist_item ||= Playlist.find(params[:playlist_id]).items.where(position: params[:position].to_i).first %>
+<%# @current_playlist_item ||= @playlist_item %>
 <%# @current_clip ||= AvalonClip.find(@current_playlist_item.clip_id) %>
 <%# @current_masterfile ||= MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
 <%# @current_mediaobject ||= MediaObject.find(@current_masterfile.media_object_id) %>

--- a/app/views/playlists/_playlist_item.html.erb
+++ b/app/views/playlists/_playlist_item.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
     <% masterfile = clip.master_file %>
     <% if @current_masterfile.is_video? == masterfile.is_video? && can?(:read, @current_playlist_item.clip.master_file.media_object) %>
-      <%= link_to playlist_refresh_info_path(@playlist, position: item.position, autostart: true), remote: true do%>
+      <%= link_to refresh_info_playlist_path(@playlist, position: item.position, token: @playlist_token, autostart: true), remote: true do%>
         <%= clip.title %>
       <% end %>
     <% else %>

--- a/app/views/playlists/refresh_info.js.erb
+++ b/app/views/playlists/refresh_info.js.erb
@@ -13,8 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% @playlist = Playlist.find(params[:playlist_id]) %>
-<% @current_playlist_item = @playlist.items.where(position: params[:position].to_i).first %>
+<% @current_playlist_item = @playlist_item %>
 <% @current_clip = AvalonClip.find(@current_playlist_item.clip_id) %>
 <% @current_masterfile = MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
 <% @current_mediaobject = MediaObject.find(@current_masterfile.media_object_id) %>
@@ -22,7 +21,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% clip_end = @current_clip.end_time / 1000.0 %>
 <% clip_frag = "?t=#{clip_start},#{clip_end}" %>
 <% link = section_stream_media_object_path(@current_mediaobject, @current_masterfile.id) + clip_frag %>
-<% target_href = "a[href*='position=#{params[:position]}']".html_safe%>
+<% target_href = "a[href*='position=#{@position}']".html_safe%>
 $('#accordion').replaceWith("<%= escape_javascript(render partial: 'info') %>");
 reload_player('<%= @current_masterfile.id %>', '<%= link %>', <%= @current_masterfile.is_video? %>);
 $('.fa-arrow-circle-right').remove();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
       patch 'update_multiple'
       delete 'update_multiple'
       patch 'regenerate_access_token'
+      get 'refresh_info'
     end
     collection do
       post 'duplicate'
@@ -136,7 +137,6 @@ Rails.application.routes.draw do
         post 'import_variations_playlist'
       end
     end
-    get 'refresh_info', to: 'playlists#refresh_info'
   end
 
   resources :avalon_marker, only: [:create, :show, :update, :destroy]

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -52,7 +52,12 @@ RSpec.describe PlaylistsController, type: :controller do
   let(:user) { login_as :user }
 
   describe 'security' do
-    let(:playlist) { FactoryGirl.create(:playlist) }
+    let(:playlist) { FactoryGirl.create(:playlist, items: [playlist_item]) }
+    let(:playlist_item) { FactoryGirl.create(:playlist_item, clip: clip) }
+    let(:clip) { FactoryGirl.create(:avalon_clip, master_file: master_file) }
+    let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object) }
+    let(:media_object) { FactoryGirl.create(:published_media_object, visibility: 'public') }
+
     context 'with unauthenticated user' do
       # New is isolated here due to issues caused by the controller instance not being regenerated
       it "should redirect to sign in" do
@@ -65,24 +70,28 @@ RSpec.describe PlaylistsController, type: :controller do
         expect(put :update, id: playlist.id).to redirect_to(new_user_session_path)
         expect(put :update_multiple, id: playlist.id).to redirect_to(new_user_session_path)
         expect(delete :destroy, id: playlist.id).to redirect_to(new_user_session_path)
+        expect(xhr :get, :refresh_info, id: playlist.id, position: 1).to redirect_to(new_user_session_path)
       end
       context 'with a public playlist' do
-        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC, items: [playlist_item]) }
         it "should return the playlist view page" do
           expect(get :show, id: playlist.id).not_to redirect_to(new_user_session_path)
           expect(get :show, id: playlist.id).to be_success
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1).to be_success
         end
       end
       context 'with a private playlist' do
         it "should NOT return the playlist view page" do
           expect(get :show, id: playlist.id).to redirect_to(new_user_session_path)
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1).to redirect_to(new_user_session_path)
         end
       end
       context 'with a private playlist and token' do
-        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
+        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token, items: [playlist_item]) }
         it "should return the playlist view page" do
           expect(get :show, id: playlist.id, token: playlist.access_token).not_to redirect_to(root_path)
           expect(get :show, id: playlist.id, token: playlist.access_token).to be_success
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1, token: playlist.access_token).to be_success
         end
       end
     end
@@ -95,24 +104,28 @@ RSpec.describe PlaylistsController, type: :controller do
         expect(put :update, id: playlist.id).to redirect_to(root_path)
         expect(put :update_multiple, id: playlist.id).to redirect_to(root_path)
         expect(delete :destroy, id: playlist.id).to redirect_to(root_path)
+        expect(xhr :get,  :refresh_info, id: playlist.id, position: 1).to redirect_to(root_path)
       end
       context 'with a public playlist' do
-        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC, items: [playlist_item]) }
         it "should return the playlist view page" do
           expect(get :show, id: playlist.id).not_to redirect_to(root_path)
           expect(get :show, id: playlist.id).to be_success
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1).to be_success
         end
       end
       context 'with a private playlist' do
         it "should NOT return the playlist view page" do
           expect(get :show, id: playlist.id).to redirect_to(root_path)
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1).to redirect_to(root_path)
         end
       end
       context 'with a private playlist and token' do
-        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
+        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token, items: [playlist_item]) }
         it "should return the playlist view page" do
           expect(get :show, id: playlist.id, token: playlist.access_token).not_to redirect_to(root_path)
           expect(get :show, id: playlist.id, token: playlist.access_token).to be_success
+          expect(xhr :get, :refresh_info, id: playlist.id, position: 1, token: playlist.access_token).to be_success
         end
       end
     end

--- a/spec/factories/playlist.rb
+++ b/spec/factories/playlist.rb
@@ -23,5 +23,9 @@ FactoryGirl.define do
       visibility { Playlist::PRIVATE_WITH_TOKEN }
       access_token { Faker::Lorem.characters(10) }
     end
+
+    trait :with_playlist_item do
+      items { [FactoryGirl.create(:playlist_item)] }
+    end
   end
 end


### PR DESCRIPTION
Fixes #2332.  This fixes #2332 so markers show for playlist items other than the first.