### PR TITLE
Make playlist sort order sticky

### DIFF
--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -87,6 +87,7 @@ $(document).ready( function () {
       url: '/playlists/paged_index',
       type: 'POST'
     },
+    order: [<%= "[#{session[:playlist_sort][0]}, '#{session[:playlist_sort][1]}']".html_safe if session[:playlist_sort] %>],
     "sDom": '<"playlists_top"i<"playlist_filter_container"f>>tr<"playlists_bottom"lp>',
     "columns": [
       null,


### PR DESCRIPTION
Fixes #2260 

Puts most recent playlist sorting choice into the session and uses it to set default sorting for next playlists index page load.