### PR TITLE
Make tag filtering use exact search

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -55,12 +55,12 @@ class PlaylistsController < ApplicationController
     playlistsFiltered = playlists.where("title LIKE ?", "%#{params['search']['value']}%")
     # Apply tag filter if requested
     tag_filter = params['columns']['5']['search']['value']
-    playlistsFiltered = playlistsFiltered.where("tags LIKE ?", "%#{tag_filter}%") if tag_filter.present?
+    playlistsFiltered = playlistsFiltered.where("tags LIKE ?", "%\n- #{tag_filter}\n%") if tag_filter.present?
     sort_column = params['order']['0']['column'].to_i rescue 0
     sort_direction = params['order']['0']['dir'] rescue 'asc'
     session[:playlist_sort] = [sort_column, sort_direction]
     if columns[sort_column] != 'size'
-      playlistsFiltered = playlistsFiltered.order("lower(#{columns[sort_column]}) #{sort_direction}")
+      playlistsFiltered = playlistsFiltered.order({ columns[sort_column].downcase => sort_direction })
       pagedPlaylists = playlistsFiltered.offset(params['start']).limit(params['length'])
     else
       # sort by size (item count): decorate list with playlistitem count then sort and undecorate

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -21,6 +21,7 @@ class PlaylistsController < ApplicationController
   load_and_authorize_resource except: [:import_variations_playlist, :refresh_info, :duplicate, :show, :index]
   load_resource only: [:show, :refresh_info]
   authorize_resource only: [:index]
+  before_action :get_user_playlists, only: [:index, :paged_index]
   before_action :get_all_other_playlists, only: [:edit]
   before_action :load_playlist_token, only: [:show, :refresh_info, :duplicate]
 
@@ -41,40 +42,43 @@ class PlaylistsController < ApplicationController
 
   # GET /playlists
   def index
-    # Cancan's load_resource doesn't work here anymore because we added a can with a block
-    @playlists = Playlist.where( user_id: current_user )
   end
 
   # POST /playlists/paged_index
   def paged_index
     # Playlists for index page are loaded dynamically by jquery datatables javascript which
     # requests the html for only a limited set of rows at a time.
-    playlists = Playlist.where(user_id: current_user.id)
-    recordsTotal = playlists.count
+    recordsTotal = @playlists.count
     columns = ['title','size','visibility','created_at','updated_at','tags','actions']
-    playlistsFiltered = playlists.where("title LIKE ?", "%#{params['search']['value']}%")
+
+    #Filter title
+    title_filter = params['search']['value']
+    @playlists = @playlists.title_like(title_filter) if title_filter.present?
+
     # Apply tag filter if requested
     tag_filter = params['columns']['5']['search']['value']
-    playlistsFiltered = playlistsFiltered.where("tags LIKE ?", "%\n- #{tag_filter}\n%") if tag_filter.present?
+    @playlists = @playlists.with_tag(tag_filter) if tag_filter.present?
+    playlistsFilteredTotal = @playlists.count
+
     sort_column = params['order']['0']['column'].to_i rescue 0
     sort_direction = params['order']['0']['dir'] rescue 'asc'
     session[:playlist_sort] = [sort_column, sort_direction]
     if columns[sort_column] != 'size'
-      playlistsFiltered = playlistsFiltered.order({ columns[sort_column].downcase => sort_direction })
-      pagedPlaylists = playlistsFiltered.offset(params['start']).limit(params['length'])
+      @playlists = @playlists.order({ columns[sort_column].downcase => sort_direction })
+      @playlists = @playlists.offset(params['start']).limit(params['length'])
     else
       # sort by size (item count): decorate list with playlistitem count then sort and undecorate
-      decorated = playlistsFiltered.collect{|p| [ p.items.size, p ]}
+      decorated = @playlists.collect{|p| [ p.items.size, p ]}
       decorated.sort!
-      playlistsFiltered = decorated.collect{|p| p[1]}
-      playlistsFiltered.reverse! if sort_direction=='desc'
-      pagedPlaylists = playlistsFiltered.slice(params['start'].to_i, params['length'].to_i)
+      @playlists = decorated.collect{|p| p[1]}
+      @playlists.reverse! if sort_direction=='desc'
+      @playlists = @playlists.slice(params['start'].to_i, params['length'].to_i)
     end
     response = {
       "draw": params['draw'],
       "recordsTotal": recordsTotal,
-      "recordsFiltered": playlistsFiltered.count,
-      "data": pagedPlaylists.collect do |playlist|
+      "recordsFiltered": playlistsFilteredTotal,
+      "data": @playlists.collect do |playlist|
         copy_button = view_context.button_tag( type: 'button', data: { playlist: playlist },
           class: 'copy-playlist-button btn btn-default btn-xs') do
           "<span class='fa fa-clone'> Copy </span>".html_safe
@@ -266,8 +270,12 @@ class PlaylistsController < ApplicationController
 
   private
 
+  def get_user_playlists
+    @playlists = Playlist.by_user(current_user)
+  end
+
   def get_all_other_playlists
-    @playlists = Playlist.where( user_id: current_user ).where.not( id: @playlist )
+    @playlists = Playlist.by_user(current_user).where.not( id: @playlist )
   end
 
   def load_playlist_token

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -14,6 +14,9 @@
 
 class Playlist < ActiveRecord::Base
   belongs_to :user
+  scope :by_user, ->(user) { where(user_id: user.id) }
+  scope :title_like, ->(title_filter) { where("title LIKE ?", "%#{title_filter}%")}
+  scope :with_tag, ->(tag_filter) { where("tags LIKE ?", "%\n- #{tag_filter}\n%") }
 
   validates :user, presence: true
   validates :title, presence: true

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -139,6 +139,50 @@ RSpec.describe Playlist, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe 'by_user' do
+      let(:user){ FactoryGirl.create(:user) }
+      let(:playlist_owner) { FactoryGirl.create(:playlist, user: user) }
+      let(:playlist) { FactoryGirl.create(:playlist) }
+      it 'returns playlists by user' do
+        expect(Playlist.by_user(user)).to include(playlist_owner)
+      end
+      it 'does not return playlists by another user' do
+        expect(Playlist.by_user(user)).not_to include(playlist)
+      end
+    end
+    describe 'title_like' do
+      let(:playlist1) { FactoryGirl.create(:playlist, title: 'Moose tunes') }
+      let(:playlist2) { FactoryGirl.create(:playlist, title: 'My favorite by smoose') }
+      let(:playlist3) { FactoryGirl.create(:playlist, title: 'Favorites') }
+      let(:title_filter) { 'moose' }
+      it 'returns playlists with matching titles' do
+        expect(Playlist.title_like(title_filter)).to include(playlist1)
+        expect(Playlist.title_like(title_filter)).to include(playlist2)
+      end
+      it 'does not return playlists without matching titles' do
+        expect(Playlist.title_like(title_filter)).not_to include(playlist3)
+      end
+    end
+    describe 'with_tag' do
+      let(:playlist1) { FactoryGirl.create(:playlist, tags: ['Moose']) }
+      let(:playlist2) { FactoryGirl.create(:playlist, tags: ['Goose', 'moose']) }
+      let(:playlist3) { FactoryGirl.create(:playlist, tags: ['smoose', 'Goose']) }
+      let(:playlist4) { FactoryGirl.create(:playlist, tags: ['Goose']) }
+      let(:tag_filter) { 'moose' }
+      it 'returns playlists with exact matching tags' do
+        expect(Playlist.with_tag(tag_filter)).to include(playlist1)
+        expect(Playlist.with_tag(tag_filter)).to include(playlist2)
+      end
+      it 'does not return playlists with partial matching tag' do
+        expect(Playlist.with_tag(tag_filter)).not_to include(playlist3)
+      end
+      it 'does not return playlists with without the tag' do
+        expect(Playlist.with_tag(tag_filter)).not_to include(playlist4)
+      end
+    end
+  end
+
   describe 'related items' do
     let(:user){ FactoryGirl.create(:user) }
     subject(:video_master_file) { FactoryGirl.create(:master_file, :with_media_object) }


### PR DESCRIPTION
Fixes #2379 

Makes tag filter for playlists use exact search.

This is complicated by the fact that tags are a 'serialized' activerecord field and the search is over the serialized data. This *might* be dependent on dbms implemented.