### PR TITLE
Exclude migration stuff from test coverage report

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ if ENV['COVERAGE'] || ENV['TRAVIS']
 
   SimpleCov.start('rails') do
     add_filter '/spec'
+    add_filter '/app/migration'    
   end
   SimpleCov.command_name 'spec'
 end


### PR DESCRIPTION
Since it's a tool meant to run once and we don't have any tests for it anyway. Fixes #2383 