### PR TITLE
Install bootstrap-toggle-rails from git instead of rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'activerecord-session_store'
 gem 'acts_as_list'
 gem 'api-pagination'
 gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git', tag: 'avalon-r6'
-gem 'bootstrap-toggle-rails'
+gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-toggle-rails.git'
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,12 @@ GIT
     whenever (0.9.7)
       chronic (>= 0.6.3)
 
+GIT
+  remote: https://github.com/rkallensee/bootstrap-toggle-rails.git
+  revision: 1eaf2b57b4e2fab387f913ef6833ab735eacb0d4
+  specs:
+    bootstrap-toggle-rails (2.2.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -244,7 +250,6 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    bootstrap-toggle-rails (2.2.1.0)
     bootstrap_form (2.7.0)
     browse-everything (0.13.1)
       addressable (~> 2.5)
@@ -833,7 +838,7 @@ DEPENDENCIES
   aws-sdk (~> 2.0)
   aws-sdk-rails
   blacklight (= 6.11.0)
-  bootstrap-toggle-rails
+  bootstrap-toggle-rails!
   bootstrap_form
   browse-everything (~> 0.13.0)
   byebug


### PR DESCRIPTION
The released version of `bootstrap-toggle-rails` was built with restrictive (`0640`) permissions. Installing on AWS (or any other platform where the user running the app has a different uid/gid from the user that ran `bundle install`) results in an `Errno::EACCES` error during asset compilation. Installing from git instead of Rubygems fixes the issue.