### PR TITLE
Add user constraint to api for collections index

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -19,7 +19,7 @@ class Admin::CollectionsController < ApplicationController
   respond_to :html
 
   def load_and_authorize_collections
-    @collections = get_user_collections
+    @collections = get_user_collections(params[:user])
     authorize!(params[:action].to_sym, Admin::Collection)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,11 +78,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def get_user_collections
-    if can? :manage, Admin::Collection
+  # Returns collections for current_user or requested user
+  # @param [String] The user to match against (optional)
+  # @return [Collection] Collections to which current_user or requested user has manage access
+  def get_user_collections(user = nil)
+    # return all collections to admin, unless specific user is passed in
+    if user.blank? && can?(:manage, Admin::Collection)
       Admin::Collection.all
     else
-      Admin::Collection.where("inheritable_edit_access_person_ssim" => user_key).to_a
+      Admin::Collection.where("inheritable_edit_access_person_ssim" => user || user_key).to_a
     end
   end
   helper_method :get_user_collections

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,10 +83,14 @@ class ApplicationController < ActionController::Base
   # @return [Collection] Collections to which current_user or requested user has manage access
   def get_user_collections(user = nil)
     # return all collections to admin, unless specific user is passed in
-    if user.blank? && can?(:manage, Admin::Collection)
-      Admin::Collection.all
+    if can?(:manage, Admin::Collection)
+      if user.blank?
+        Admin::Collection.all
+      else
+        Admin::Collection.where("inheritable_edit_access_person_ssim" => user).to_a
+      end
     else
-      Admin::Collection.where("inheritable_edit_access_person_ssim" => user || user_key).to_a
+      Admin::Collection.where("inheritable_edit_access_person_ssim" => user_key).to_a
     end
   end
   helper_method :get_user_collections

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,6 +60,11 @@ describe ApplicationController do
       login_as :user
       expect(controller.get_user_collections).to be_empty
     end
+    it 'returns only relevant collections for user parameter' do
+      login_as :administrator
+      expect(controller.get_user_collections collection1.managers.first).to include(collection1)
+      expect(controller.get_user_collections collection1.managers.first).not_to include(collection2)
+    end
   end
 
   describe "exceptions handling" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,7 +60,11 @@ describe ApplicationController do
       login_as :user
       expect(controller.get_user_collections).to be_empty
     end
-    it 'returns only relevant collections for user parameter' do
+    it 'returns no collections to end-user, even when passing user param' do
+      login_as :user
+      expect(controller.get_user_collections collection1.managers.first).to be_empty
+    end
+    it 'returns requested user\'s collections for an administrator' do
       login_as :administrator
       expect(controller.get_user_collections collection1.managers.first).to include(collection1)
       expect(controller.get_user_collections collection1.managers.first).not_to include(collection2)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -162,6 +162,14 @@ describe Admin::CollectionsController, type: :controller do
       expect(json.first['roles']['editors']).to eq(collection.editors)
       expect(json.first['roles']['depositors']).to eq(collection.depositors)
     end
+    it "should return list of collections for good user" do
+      get 'index', user: collection.managers.first, format:'json'
+      expect(json.count).to eq(1)
+    end
+    it "should return no collections for bad user" do
+      get 'index', user: 'foobar', format:'json'
+      expect(json.count).to eq(0)
+    end
   end
 
   describe 'pagination' do


### PR DESCRIPTION
For avalon to avalon push. Adds ability to use the api to query for collections based on a user instead of all.