### PR TITLE
Enable MEJS4 player for embedding

### DIFF
--- a/app/views/master_files/_mejs4_player_js.html.erb
+++ b/app/views/master_files/_mejs4_player_js.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_styles do %>
+<%= stylesheet_link_tag 'mejs4_player' %>
+<% end %>
+<% content_for :page_scripts do %>
+<%= javascript_include_tag "mejs4_player" %>
+<% end %>
+
+<script>
+<!-- Missing title and logo features -->
+var mejs4AvalonPlayer = new MEJSPlayer({
+  currentStreamInfo: <%= section_info.to_json.html_safe %>,
+  features: ['playpause', 'current', 'progress', 'duration', 'volume', 'quality', 'fullscreen'],
+  highlightRail: true
+});
+</script>

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -21,7 +21,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if is_mejs_2? %>
     <%= render partial: "mejs2_player_js", locals: {section: @master_file, section_info: @stream_info} %>
   <% else %>
-    <%#= render partial: "mejs4_player_js", locals: {section: @master_file, section_info: @stream_info} %>
+    <%= render partial: "mejs4_player_js", locals: {section: @master_file, section_info: @stream_info} %>
   <% end %>
 
   <script>


### PR DESCRIPTION
In support of #2276.  Note that the title and logo features aren't included yet since they haven't been ported/configured for MEJS4 yet.