### PR TITLE
Create error file when package is invalid to avoid rerunning ingest on it

### DIFF
--- a/lib/avalon/batch/ingest.rb
+++ b/lib/avalon/batch/ingest.rb
@@ -39,6 +39,7 @@ module Avalon
           package_validation
           package_valid = @current_package_errors.empty?
           unless package_valid
+            @current_package.manifest.error!
             send_invalid_package_email
             next
           end

--- a/spec/lib/avalon/batch_ingest_spec.rb
+++ b/spec/lib/avalon/batch_ingest_spec.rb
@@ -318,6 +318,8 @@ describe Avalon::Batch::Ingest do
       allow_any_instance_of(Avalon::Dropbox).to receive(:find_new_packages).and_return [batch]
       batch_ingest.should_receive(:send_invalid_package_email).once
       expect { batch_ingest.scan_for_packages }.to_not change { BatchRegistries.count }
+      # it should create an error file and not attempt to reregister the package until user action
+      expect(batch.manifest.error?).to be true
     end
   end
 end


### PR DESCRIPTION
Fixes #2417.