### PR TITLE
Use Bixby for Samvera-style style checking

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,12 @@
 ---
+prepare:
+  fetch:
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_default.yml"
+    path: "bixby_default.yml"
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_rails_enabled.yml"
+    path: "bixby_rails_enabled.yml"
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_rspec_enabled.yml"
+    path: "bixby_rspec_enabled.yml"
 engines:
   brakeman:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,6 +22,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
+    channel: rubocop-0-50
     checks:
       Rubocop/Metrics/AbcSize:
         enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,6 +23,8 @@ engines:
   rubocop:
     enabled: true
     channel: rubocop-0-50
+    config:
+      file: .rubocop.cc.yml
     checks:
       Rubocop/Metrics/AbcSize:
         enabled: false

--- a/.rubocop.cc.yml
+++ b/.rubocop.cc.yml
@@ -1,8 +1,8 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 # require: rubocop-rspec
 
-inherit_gem:
-  bixby: bixby_default.yml
+inherit_from:
+  - bixby_default.yml
 
 AllCops:
   DisplayCopNames: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 # require: rubocop-rspec
+inherit_gem:
+  bixby: bixby_default.yml
+
 AllCops:
   DisplayCopNames: true
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - mysql2
 before_install:
   - sudo rm -vf /etc/apt/sources.list.d/*riak*
+  - sudo rm -vf /etc/apt/sources.list.d/*hhvm*
   - sudo apt-get update
   - sudo apt-get install mediainfo
   - sudo ln -s /usr/bin/lsof /usr/sbin/lsof

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,8 @@ group :development do
   gem 'capistrano-rvm', require: false
   gem 'capistrano-passenger', require: false
 
-  gem 'rubocop', '~> 0.40.0', require: false
+  # Use Bixby instead of rubocop directly
+  gem 'bixby', require: false
   gem 'web-console', '~> 2.0'
   gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,9 @@ GEM
       bcrypt (>= 3.1.3)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bixby (0.3.1)
+      rubocop (~> 0.49, <= 0.50.0)
+      rubocop-rspec (~> 1.15, <= 1.18.0)
     blacklight (6.11.0)
       bootstrap-sass (~> 3.2)
       deprecation
@@ -545,8 +548,8 @@ GEM
     orm_adapter (0.5.0)
     os (0.9.6)
     parallel (1.12.0)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     pg (0.21.0)
     poltergeist (1.16.0)
       capybara (~> 2.1)
@@ -593,7 +596,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.1.0)
+    rake (12.3.0)
     rb-readline (0.5.5)
     rchardet (1.6.1)
     rdf (2.2.10)
@@ -688,12 +691,15 @@ GEM
     rspec-retry (0.5.5)
       rspec-core (> 3.3, < 3.7)
     rspec-support (3.6.0)
-    rubocop (0.40.0)
-      parser (>= 2.3.1.0, < 3.0)
+    rubocop (0.50.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.18.0)
+      rubocop (>= 0.50.0)
     ruby-box (1.15.0)
       addressable
       json
@@ -837,6 +843,7 @@ DEPENDENCIES
   avalon-workflow!
   aws-sdk (~> 2.0)
   aws-sdk-rails
+  bixby
   blacklight (= 6.11.0)
   bootstrap-toggle-rails!
   bootstrap_form
@@ -906,7 +913,6 @@ DEPENDENCIES
   rsolr (~> 1.0)
   rspec-rails
   rspec-retry
-  rubocop (~> 0.40.0)
   rubyhorn!
   sass (= 3.4.22)
   sass-rails (~> 5.0)


### PR DESCRIPTION
(This will also deal with the rubocop version issue by updating to 0.50.0.  Although the warning will persist until we release to master.)