### PR TITLE
Broaden rescue because SQLite3::BusyException is a subclass of Standa…

### DIFF
--- a/app/jobs/ingest_batch_entry_job.rb
+++ b/app/jobs/ingest_batch_entry_job.rb
@@ -38,7 +38,7 @@ class IngestBatchEntryJob < ActiveJob::Base
     end
     # TODO any post processing to update status?
 
-  rescue RuntimeError => e
+  rescue StandardError => e
     process_error(batch_entry, e)
   end
 


### PR DESCRIPTION
…rdError but not RuntimeError

The batch entries were left in limbo because their ingest jobs had failed but hadn't recorded themselves as failed.