### PR TITLE
Test important redirects from Fedora 3 pid to Avalon noid

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -79,11 +79,6 @@ describe ApplicationController do
   end
 
   describe "rewrite_v4_ids" do
-    xit 'skips miration controllers' do
-      get :show, id: 'avalon:1234', controller: 'MigrationStatusController'
-      expect(response).to have_http_status(:ok)
-    end
-
     it 'skips when id is not a Fedora 3 pid' do
       get :show, id: 'abc1234'
       expect(response).not_to have_http_status(304)
@@ -92,12 +87,6 @@ describe ApplicationController do
     it 'skips post requests' do
       post :create, id: 'avalon:1234'
       expect(response).not_to have_http_status(304)
-    end
-
-    xit 'redirects' do
-      master_file = FactoryGirl.create(:master_file, identifier: ['avalon:1234'])
-      get :show, id: 'avalon:1234'
-      expect(response).to redirect_to(url_for(master_file.id))
     end
   end
 end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -213,18 +213,33 @@ describe MasterFilesController do
       get :show, id: master_file.id, t:'10'
       expect(response).to redirect_to("#{id_section_media_object_path(master_file.media_object.id, master_file.id)}?t=10")
     end
+    context 'with fedora 3 pid' do
+      let!(:master_file) {FactoryGirl.create(:master_file, identifier: [fedora3_pid])}
+      let(:fedora3_pid) { 'avalon:1234' }
+
+      it "should redirect" do
+        expect(get :show, id: fedora3_pid).to redirect_to(master_file_url(master_file.id))
+      end
+    end
   end
 
   describe "#embed" do
-    let(:master_file) {FactoryGirl.create(:master_file)}
-    let(:media_object) { double }
+    let!(:master_file) {FactoryGirl.create(:master_file)}
+    let(:media_object) { instance_double('MediaObject', title: 'Media Object') }
     before do
       allow_any_instance_of(MasterFile).to receive(:media_object).and_return(media_object)
-      allow(media_object).to receive(:title).and_return("Media Object")
       disableCanCan!
     end
     it "should render embed layout" do
       expect(get :embed, id: master_file.id).to render_template(layout: 'embed')
+    end
+    context 'with fedora 3 pid' do
+      let!(:master_file) {FactoryGirl.create(:master_file, identifier: [fedora3_pid])}
+      let(:fedora3_pid) { 'avalon:1234' }
+
+      it "should redirect" do
+        expect(get :embed, id: fedora3_pid).to redirect_to(embed_master_file_url(master_file.id))
+      end
     end
   end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -497,6 +497,15 @@ describe MediaObjectsController, type: :controller do
     let!(:media_object) { FactoryGirl.create(:published_media_object, visibility: 'public') }
 
     context "Known items should be retrievable" do
+      context 'with fedora 3 pid' do
+        let!(:media_object) {FactoryGirl.create(:published_media_object, visibility: 'public', identifier: [fedora3_pid])}
+        let(:fedora3_pid) { 'avalon:1234' }
+
+        it "should redirect" do
+          expect(get :show, id: fedora3_pid).to redirect_to(media_object_url(media_object.id))
+        end
+      end
+
       it "should be accesible by its PID" do
         get :show, id: media_object.id
         expect(response.response_code).to eq(200)

--- a/spec/controllers/migration_status_controller_spec.rb
+++ b/spec/controllers/migration_status_controller_spec.rb
@@ -1,0 +1,41 @@
+# Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe MigrationStatusController do
+  let(:obj) { FactoryGirl.create(:master_file, migrated_from: [fedora3_pid]) }
+  let(:fedora3_pid) { 'avalon:12345' }
+  let(:avalon_noid) { obj.id }
+
+  before do
+    login_as :administrator
+    MigrationStatus.create!(f3_pid: fedora3_pid, f4_pid: avalon_noid, source_class: obj.class)
+  end
+
+  describe '#detail' do
+    context 'with a Fedora 3 pid' do
+      it 'returns the details' do
+        get :detail, id: fedora3_pid
+        expect(response).to have_http_status(:ok)
+      end
+    end
+    context 'with an Avalon noid' do
+      it 'returns the details' do
+        get :detail, id: avalon_noid
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2381.  The code previously committed was working but not verified through testing.  This PR tests the important instances (determined via Honeybadger warnings) we want to verify.