### PR TITLE
Update MEJS4 add to playlist not logged in bug

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -289,24 +289,6 @@ class MEJSPlayer {
   }
 
   /**
-   * Stub function to demonstrate future usage of MEJS4 playlist plugin
-   * @function getPlaylists
-   * @return {void}
-   */
-  getPlaylists () {
-    const obj = {
-      playlist: [{
-        src: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/mp4/BigBuckBunny.mp4',
-        title: 'Big Buck Bunny Test'
-      }, {
-        src: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/mp4/BigBuckBunny.mp4',
-        title: 'Big Buck Bunny Test 2'
-      }]
-    }
-    return {}
-  }
-
-  /**
    * Event handler for MediaElement's 'canplay' event
    * At this point can play, pause, set time on player instance
    * @function handleCanPlay

--- a/app/assets/javascripts/media_player_wrapper/mejs4_add_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_add_to_playlist.es6
@@ -38,7 +38,7 @@ Object.assign(MediaElementPlayer.prototype, {
         const t = this;
         const addTitle = 'Add to Playlist';
         let addToPlayListObj = t.addToPlayListObj;
-        addToPlayListObj.hasPlaylists = addToPlayListObj.playlistEl.dataset.hasPlaylists === 'true';
+        addToPlayListObj.hasPlaylists = addToPlayListObj.playlistEl && addToPlayListObj.playlistEl.dataset.hasPlaylists === 'true';
         addToPlayListObj.isVideo = player.isVideo;
 
         // Make player instance available outside of this method

--- a/app/views/media_objects/_mejs4_player_js.html.erb
+++ b/app/views/media_objects/_mejs4_player_js.html.erb
@@ -4,12 +4,16 @@
 <% content_for :page_scripts do %>
 <%= javascript_include_tag "mejs4_player" %>
 <% end %>
-
 <script>
+var mejs4ConfigFeatures = ['playpause', 'current', 'progress', 'duration', 'trackScrubber', 'volume', 'quality', 'createThumbnail', 'addToPlaylist', 'fullscreen'];
+
+if (<%= cannot? :create, Playlist %>) {
+  mejs4ConfigFeatures.splice(mejs4ConfigFeatures.indexOf('addToPlaylist'), 1);
+}
 // Define MediaElement 4 configuration here
 var mejs4AvalonPlayer = new MEJSPlayer({
   currentStreamInfo: <%= section_info.to_json.html_safe %>,
-  features: ['playpause', 'current', 'progress', 'duration', 'trackScrubber', 'volume', 'quality', 'createThumbnail', 'addToPlaylist', 'fullscreen'],
+  features: mejs4ConfigFeatures,
   highlightRail: true
 });
 </script>


### PR DESCRIPTION
This fixes a bug where when not logged in, the Add to Playlist control button on MEJS4 player still displayed.