### PR TITLE
Use MEJS4 unless told to do otherwise

### DIFF
--- a/app/helpers/player_helper.rb
+++ b/app/helpers/player_helper.rb
@@ -14,10 +14,10 @@
 
 module PlayerHelper
   def is_mejs_2?
-    !is_mejs_4?
+    session['mejs_version'] == 2 || params['mejs4'] === 'false'
   end
 
   def is_mejs_4?
-    session['mejs_version'] == 4 || params['mejs4'] === 'true'
+    !is_mejs_2?
   end
 end


### PR DESCRIPTION
Make the switch since we're close and don't really need to test with MEJS2 anymore.  This will make testing easier for 6.3 release.