### PR TITLE
Exclude migration code from codeclimate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -49,3 +49,4 @@ exclude_paths:
 - db/
 - spec/
 - vendor/
+- app/migration/


### PR DESCRIPTION
Since it's really not part of Avalon and should have been a separate tool.