### PR TITLE
Bugfix/#2024 close fullscreen

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_add_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_add_to_playlist.es6
@@ -228,7 +228,9 @@ Object.assign(MediaElementPlayer.prototype, {
       handleControlClick: function (e) {
         const t = this;
         let addToPlayListObj = t.addToPlayListObj;
-
+        if (addToPlayListObj.player.isFullScreen){
+          addToPlayListObj.player.exitFullScreen();
+        }
         if (!addToPlayListObj.active) {
           // Close any open alert displays
           $(t.addToPlayListObj.alertEl).slideUp();

--- a/app/assets/javascripts/media_player_wrapper/mejs4_create_thumbnail.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_create_thumbnail.es6
@@ -171,6 +171,10 @@ Object.assign(MediaElementPlayer.prototype, {
        */
       handleControlClick: function (e) {
         let createThumbnailObj = this.createThumbnailObj;
+        if (createThumbnailObj.player.isFullScreen){
+          createThumbnailObj.player.exitFullScreen();
+        }
+
         const $modalEl = $(createThumbnailObj.modalEl);
         let $imgPolaroid = $modalEl.find('.img-polaroid');
 

--- a/app/assets/javascripts/media_player_wrapper/mejs4_track_scrubber.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_track_scrubber.es6
@@ -128,6 +128,9 @@ Object.assign(MediaElementPlayer.prototype, {
        * @return {void}
        */
       handleControlClick: function (e) {
+        if (this.trackScrubberObj.player.isFullScreen){
+          this.trackScrubberObj.player.exitFullScreen();
+        }
         this.trackScrubberObj.showTrackScrubber(this.trackScrubberObj.scrubberEl.classList.contains('hidden'));
       },
 


### PR DESCRIPTION
Fixes #2024 
When in fullscreen mode and a control is clicked that requires a modal, exit fullscreen mode before showing modal.