### PR TITLE
Redirect back to login page when invalid credentials

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     begin
       render "modules/#{params[:provider]}_auth_form"
     rescue ActionView::MissingTemplate
-      super
+      redirect_to new_user_session_path, flash: { alert: I18n.t('devise.failure.invalid') }
     end
   end
 


### PR DESCRIPTION
Fixes #2102 

It might not be the correct way to do it, but this gives us the correct behavior for identity authentication failures.