### PR TITLE
Do not include filename in playlist title if only 1 section in mediaobject

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -73,14 +73,14 @@ module MasterFileBehavior
   end
 
   def display_title
-    mf_title = self.structuralMetadata.section_title unless self.structuralMetadata.blank?
-    mf_title ||= self.title if self.title.present?
-    mf_title ||= self.file_location.split( "/" ).last if self.file_location.present?
+    mf_title = structuralMetadata.section_title unless structuralMetadata.blank?
+    mf_title ||= title if title.present?
+    mf_title ||= file_location.split("/").last if file_location.present? && (media_object.ordered_master_files.to_a.size > 1)
     mf_title.blank? ? nil : mf_title
   end
 
   def embed_title
-    [ self.media_object.title, display_title ].compact.join(" - ")
+    [ media_object.title, display_title ].compact.join(" - ")
   end
 
   def embed_code(width, permalink_opts = {})

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -80,7 +80,7 @@ module MasterFileBehavior
   end
 
   def embed_title
-    [ media_object.title, display_title ].compact.join(" - ")
+    [media_object.title, display_title].compact.join(" - ")
   end
 
   def embed_code(width, permalink_opts = {})

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -225,7 +225,7 @@ describe MasterFilesController do
 
   describe "#embed" do
     let!(:master_file) {FactoryGirl.create(:master_file)}
-    let(:media_object) { instance_double('MediaObject', title: 'Media Object') }
+    let(:media_object) { instance_double('MediaObject', title: 'Media Object', ordered_master_files: [master_file]) }
     before do
       allow_any_instance_of(MasterFile).to receive(:media_object).and_return(media_object)
       disableCanCan!

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -396,8 +396,13 @@ describe MasterFile do
         expect( subject.embed_title ).to eq( "test - test" )
       end
 
-      it "should have an appropriate title for the embed code with no label" do
-        expect( subject.embed_title ).to eq( "test - video.mp4" )
+      it "should have an appropriate title for the embed code with no label (only one section)" do
+        expect( subject.embed_title ).to eq( "test" )
+      end
+
+      it 'should have an appropriate title for the embed code with no label (more than 1 section)' do
+        allow(subject.media_object).to receive(:ordered_master_files).and_return([subject,subject])
+        expect( subject.embed_title ).to eq( 'test - video.mp4' )
       end
 
       it "should have an appropriate title for the embed code with no label or file_location" do
@@ -528,6 +533,7 @@ describe MasterFile do
     let(:media_object) { instance_double("media_object", title: 'Test') }
     before do
       allow(master_file).to receive(:media_object).and_return(media_object)
+      allow(media_object).to receive(:ordered_master_files).and_return([master_file])
     end
     context 'with a permalink' do
       let(:master_file) { FactoryGirl.build(:master_file, permalink: permalink) }


### PR DESCRIPTION
Fixes #2326 

Do not include filename in playlist tile when only one section in media_object.

