### PR TITLE
Correctly identify uuuu EDTF dates

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -72,10 +72,17 @@ class MediaObject < ActiveFedora::Base
   end
 
   def validate_dates
-    [:date_created, :date_issued, :copyright_date].each do |d|
-      if self.send(d).present? && Date.edtf(self.send(d)).nil?
-        errors.add(d, I18n.t("errors.messages.dateformat", date: self.send(d)))
-      end
+    validate_date :date_created
+    validate_date :date_issued
+    validate_date :copyright_date
+  end
+
+  def validate_date(date_field)
+    date = send(date_field)
+    return if date.blank?
+    edtf_date = Date.edtf(date)
+    if edtf_date.nil? || edtf_date.class == EDTF::Unknown # remove second condition to allow 'uuuu'
+      errors.add(date_field, I18n.t("errors.messages.dateformat", date: date))
     end
   end
 

--- a/app/models/mods_behaviors.rb
+++ b/app/models/mods_behaviors.rb
@@ -187,22 +187,22 @@ module ModsBehaviors
     parsed = Date.edtf(date)
     return Array.new if parsed.nil?
     years =
-    if parsed.respond_to?(:unknown?) && parsed.unknown?
-      ['Unknown']
-    elsif parsed.respond_to?(:map)
-      parsed.map(&:year_precision!)
-      parsed.map(&:year)
-    elsif parsed.unspecified?(:year)
-      parsed.precision = :year
-      if parsed.unspecified.year[2]
-	EDTF::Interval.new(parsed, parsed.next(99).last).map(&:year)
-      elsif parsed.unspecified.year[3]
-	EDTF::Interval.new(parsed, parsed.next(9).last).map(&:year)
+      if (parsed.respond_to?(:unknown?) && parsed.unknown?) || (parsed.class == EDTF::Unknown)
+        ['Unknown']
+      elsif parsed.respond_to?(:map)
+        parsed.map(&:year_precision!)
+        parsed.map(&:year)
+      elsif parsed.unspecified?(:year)
+        parsed.precision = :year
+        if parsed.unspecified.year[2]
+          EDTF::Interval.new(parsed, parsed.next(99).last).map(&:year)
+        elsif parsed.unspecified.year[3]
+          EDTF::Interval.new(parsed, parsed.next(9).last).map(&:year)
+        end
+      else
+        parsed.year_precision!
+        Array(parsed.year)
       end
-    else
-      parsed.year_precision!
-      Array(parsed.year)
-    end
     years.map(&:to_s).uniq
   end
 


### PR DESCRIPTION
Fixes #2488 

Correctly identify EDTF dates with value 'uuuu'.

The PR, as it is now, rejects dates with format 'uuuu'. To accept them, simply remove the noted if-condition. 