### PR TITLE
Move playlist sorting icons next to header titles

### DIFF
--- a/app/assets/stylesheets/datatables.css
+++ b/app/assets/stylesheets/datatables.css
@@ -13,3 +13,22 @@
 * require datatables/extensions/Scroller/scroller.bootstrap
 * require datatables/extensions/Select/select.bootstrap
 */
+
+table.dataTable thead .sorting,
+table.dataTable thead .sorting_asc,
+table.dataTable thead .sorting_desc,
+table.dataTable thead .sorting_asc_disabled,
+table.dataTable thead .sorting_desc_disabled {
+  white-space: nowrap
+}
+
+table.dataTable thead .sorting:after,
+table.dataTable thead .sorting_asc:after,
+table.dataTable thead .sorting_desc:after,
+table.dataTable thead .sorting_asc_disabled:after,
+table.dataTable thead .sorting_desc_disabled:after {
+  position: relative;
+  bottom: -2px;
+  left: 5px;
+  display: inline-block;
+}


### PR DESCRIPTION
Fixes #2168 

Put playlist sorting icons next to header titles, instead of at the right edge of column.