### PR TITLE
Auto hide controls in video player

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -287,7 +287,6 @@ class MEJSPlayer {
     let currentStreamInfo = this.currentStreamInfo;
     // Mediaelement default root level configuration
     let defaults = {
-      alwaysShowControls: true,
       pluginPath: "/assets/mediaelement/shims/",
       features: this.features,
       poster: currentStreamInfo.poster_image || null,


### PR DESCRIPTION
For feature parity with MEJS2 and because we now fix the aspect ratio, there are videos where controls always obscure part of the video content. Also auto hide is important in fullscreen mode.