### PR TITLE
Fix refresh_token.js console error by validating token variable

### DIFF
--- a/app/assets/javascripts/refresh_token.js.coffee
+++ b/app/assets/javascripts/refresh_token.js.coffee
@@ -15,7 +15,7 @@
 $ ->
   refreshToken = ->
     token = currentPlayer.media.src.split('?')[1]
-    if token.match(/^token=/)
+    if token && token.match(/^token=/)
       mount_point = $('body').data('mountpoint')
       $.get("#{mount_point}authorize.txt?#{token}")
         .done -> console.log("Token refreshed")


### PR DESCRIPTION
Fixes #2549 

This is a pretty quick fix to get rid of the console error.  @cjcolvar Does the fact `token` doesn't exist mean there's another issue?