### PR TITLE
Remove duplicate ids from sections section

### DIFF
--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="heading0" style="border-bottom: 1px solid #ddd;">
+    <div class="panel-heading" role="tab" id="sections_heading" style="border-bottom: 1px solid #ddd;">
       <h4 class="panel-title">
         <span id="section-label">Sections</span>
         <% if current_ability.can? :create, Playlist %>


### PR DESCRIPTION
Fixes #2552 

Gives a different id to the top-level sections header div.