### PR TITLE
Fix for playlist item click to cue up the range start time

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -483,6 +483,9 @@ class MEJSPlayer {
   removePlayer() {
     let tagEls = null;
 
+    if (!this.player) { return; }
+
+    // Pause the player
     if (!this.player.paused) {
       this.player.pause();
     }

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -361,13 +361,13 @@ Object.assign(MediaElementPlayer.prototype, {
      * @return {void}
      */
     setupNextItem() {
+      this.setCurrentItemInternally();
+      this.player.setCurrentTime(this.startEndTimes.start);
+      mejs4AvalonPlayer.highlightTimeRail([
+        this.startEndTimes.start,
+        this.startEndTimes.end
+      ]);
       if (this.isAutoplay()) {
-        this.setCurrentItemInternally();
-        this.player.setCurrentTime(this.startEndTimes.start);
-        mejs4AvalonPlayer.highlightTimeRail([
-          this.startEndTimes.start,
-          this.startEndTimes.end
-        ]);
         this.player.play();
       }
     },


### PR DESCRIPTION
I think this is needed because otherwise activating the "next" item will never happen unless Autoplay is on.  When a playlist item link is clicked, Autoplay is set to off, before the code below is executed. 

We can chat on this if you want.  Maybe I'm missing the use-case...