### PR TITLE
Bugfix/2459

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
@@ -5,6 +5,7 @@
 class MEJSMarkersHelper {
   constructor() {
     this.$accordion = $('#accordion');
+    this.mejsUtility = new MEJSUtility();
   }
 
   /**
@@ -176,9 +177,12 @@ class MEJSMarkersHelper {
    * @return {Promise} Resolves to either a block of markup or an empty string.
    */
   ajaxPlaylistItemsHTML(playlistId, playlistItemId, panelSection) {
+    const t = this;
+
     return new Promise((resolve, reject) => {
       $.ajax({
-        url: `/playlists/${playlistId}/items/${playlistItemId}/${panelSection}`
+        url: `/playlists/${playlistId}/items/${playlistItemId}/${panelSection}`,
+        data: { token: t.mejsUtility.getUrlParameter('token') }
       })
         .done(response => {
           resolve(response);

--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
@@ -236,6 +236,8 @@ class MEJSMarkersHelper {
    * @return {Array} Array of marker start times
    */
   getMarkers(playlistId, playlistItemId) {
+    const t = this;
+
     return new Promise((resolve, reject) => {
       // Check if a playlist item is specified, because playlist items use markers
       // and we'll need to grab markers from the playlist item
@@ -246,6 +248,7 @@ class MEJSMarkersHelper {
         $.ajax({
           url:
             '/playlists/' + playlistId + '/items/' + playlistItemId + '.json',
+          data: { token: t.mejsUtility.getUrlParameter("token") },
           dataType: 'json'
         })
           .done(response => {

--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
@@ -139,4 +139,13 @@ class MEJSUtility {
         .classList.add('current-section');
     }
   }
+
+  getUrlParameter(name) {
+    name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    var results = regex.exec(location.search);
+    return results === null
+      ? ''
+      : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  }
 }

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_marker_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_marker_to_playlist.es6
@@ -135,9 +135,12 @@ Object.assign(MediaElementPlayer.prototype, {
       let t = this;
 
       // Set click listeners for Add Marker to Playlist form elements
-      t.addButton.addEventListener('click', t.bindHandleAdd);
-      t.cancelButton.addEventListener('click', t.bindHandleCancel);
-
+      if (t.addButton) {
+        t.addButton.addEventListener('click', t.bindHandleAdd);
+      }
+      if (t.cancelButton) {
+        t.cancelButton.addEventListener('click', t.bindHandleCancel);
+      }
       // Set click listeners on the current markers UI table
       // t.mejsMarkersHelper.addMarkersTableListeners();
     },

--- a/app/controllers/playlist_items_controller.rb
+++ b/app/controllers/playlist_items_controller.rb
@@ -14,7 +14,7 @@
 
 class PlaylistItemsController < ApplicationController
   before_action :set_playlist, only: [:create, :update, :show, :markers, :related_items]
-  before_action :authenticate_user!
+  before_action :load_playlist_token, only: [:show, :markers, :related_items, :source_details]
   load_resource only: [:show, :update, :markers]
 
   # POST /playlists/1/items
@@ -111,6 +111,7 @@ class PlaylistItemsController < ApplicationController
   end
 
   def show
+    authorize! :read, @playlist_item
     unless (can? :read, @playlist_item)
       render json: { message: 'You are not authorized to perform this action.' }, status: 401 and return
     end
@@ -140,6 +141,11 @@ class PlaylistItemsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_playlist
     @playlist = Playlist.find(params[:playlist_id])
+  end
+
+  def load_playlist_token
+    @playlist_token = params[:token]
+    current_ability.options[:playlist_token] = @playlist_token
   end
 
   def playlist_item_params

--- a/app/controllers/playlist_items_controller.rb
+++ b/app/controllers/playlist_items_controller.rb
@@ -111,7 +111,6 @@ class PlaylistItemsController < ApplicationController
   end
 
   def show
-    authorize! :read, @playlist_item
     unless (can? :read, @playlist_item)
       render json: { message: 'You are not authorized to perform this action.' }, status: 401 and return
     end

--- a/spec/controllers/playlist_items_controller_spec.rb
+++ b/spec/controllers/playlist_items_controller_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
       it "all return 401 unauthorized" do
         expect(post :create, playlist_id: playlist.to_param, playlist_item: valid_attributes).to have_http_status(:unauthorized)
         expect(put :update, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
+        expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
@@ -57,6 +58,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
         let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
 
         it "returns the playlist item info snippets" do
+          expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id).to be_success
           expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
           expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
           expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
@@ -66,6 +68,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
         let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
 
         it "returns the playlist item info page snippets" do
+          expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
@@ -79,6 +82,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
       it "all return 401 unauthorized" do
         expect(post :create, playlist_id: playlist.to_param, playlist_item: valid_attributes).to have_http_status(:unauthorized)
         expect(put :update, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
+        expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
@@ -87,6 +91,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
         let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
 
         it "returns the playlist item info snippets" do
+          expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id).to be_success
           expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
           expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
           expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
@@ -96,6 +101,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
         let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
 
         it "returns the playlist item info page snippets" do
+          expect(xhr :get, :show, playlist_id: playlist.to_param, id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
           expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success

--- a/spec/controllers/playlist_items_controller_spec.rb
+++ b/spec/controllers/playlist_items_controller_spec.rb
@@ -37,33 +37,69 @@ RSpec.describe PlaylistItemsController, type: :controller do
 
   let(:playlist_owner) { login_as :user }
   let(:playlist) { FactoryGirl.create(:playlist, user: playlist_owner) }
-  let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object, duration: "100000") }
-  let(:media_object) { FactoryGirl.create(:published_media_object, read_users: [playlist_owner]) }
+  let(:playlist_item) { FactoryGirl.create(:playlist_item, playlist: playlist, clip: clip) }
+  let(:master_file) { FactoryGirl.create(:master_file, media_object: media_object) }
+  let(:media_object) { FactoryGirl.create(:published_media_object, visibility: 'public') }
+  let(:clip) { AvalonClip.create(master_file: master_file) }
 
   describe 'security' do
     let(:playlist) { FactoryGirl.create(:playlist) }
-    let(:playlist_item) { FactoryGirl.create(:playlist_item, playlist: playlist) }
-    let(:master_file) { FactoryGirl.create(:master_file, :with_media_object, duration: "100000") }
 
     context 'with unauthenticated user' do
-      it "all routes should redirect to sign in" do
-        expect(post :create, playlist_id: playlist.to_param, playlist_item: valid_attributes).to redirect_to(new_user_session_path)
-        expect(put :update, playlist_id: playlist.to_param, id: playlist_item.id).to redirect_to(new_user_session_path)
-        expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to redirect_to(new_user_session_path)
-        expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to redirect_to(new_user_session_path)
-        expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to redirect_to(new_user_session_path)
+      it "all return 401 unauthorized" do
+        expect(post :create, playlist_id: playlist.to_param, playlist_item: valid_attributes).to have_http_status(:unauthorized)
+        expect(put :update, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
+        expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
+        expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
+        expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
+      end
+      context 'with a public playlist' do
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
+
+        it "returns the playlist item info snippets" do
+          expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+          expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+          expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+        end
+      end
+      context 'with a private playlist and token' do
+        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
+
+        it "returns the playlist item info page snippets" do
+          expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+          expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+          expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+        end
       end
     end
     context 'with end-user' do
       before do
         login_as :user
       end
-      it "all routes should return 401" do
+      it "all return 401 unauthorized" do
         expect(post :create, playlist_id: playlist.to_param, playlist_item: valid_attributes).to have_http_status(:unauthorized)
         expect(put :update, playlist_id: playlist.to_param, id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
         expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to have_http_status(:unauthorized)
+      end
+      context 'with a public playlist' do
+        let(:playlist) { FactoryGirl.create(:playlist, visibility: Playlist::PUBLIC) }
+
+        it "returns the playlist item info snippets" do
+          expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+          expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+          expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id).to be_success
+        end
+      end
+      context 'with a private playlist and token' do
+        let(:playlist) { FactoryGirl.create(:playlist, :with_access_token) }
+
+        it "returns the playlist item info page snippets" do
+          expect(get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+          expect(get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+          expect(get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id, token: playlist.access_token).to be_success
+        end
       end
     end
   end
@@ -132,8 +168,6 @@ RSpec.describe PlaylistItemsController, type: :controller do
   end
 
   describe 'GET #source_details' do
-    let(:clip) { AvalonClip.create(master_file: master_file) }
-    let(:playlist_item) { FactoryGirl.create(:playlist_item, playlist: playlist, clip: clip) }
     it 'returns HTML' do
       get :source_details, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id
       expect(response).to have_http_status(:ok)
@@ -142,8 +176,6 @@ RSpec.describe PlaylistItemsController, type: :controller do
   end
 
   describe 'GET #markers' do
-    let(:clip) { AvalonClip.create(master_file: master_file) }
-    let(:playlist_item) { FactoryGirl.create(:playlist_item, playlist: playlist, clip: clip) }
     it 'returns HTML' do
       get :markers, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id
       expect(response).to have_http_status(:ok)
@@ -152,8 +184,6 @@ RSpec.describe PlaylistItemsController, type: :controller do
   end
 
   describe 'GET #related_items' do
-    let(:clip) { AvalonClip.create(master_file: master_file) }
-    let(:playlist_item) { FactoryGirl.create(:playlist_item, playlist: playlist, clip: clip) }
     it 'returns HTML' do
       allow_any_instance_of(Playlist).to receive(:related_clips).and_return([clip]);
       get :related_items, playlist_id: playlist.to_param, playlist_item_id: playlist_item.id
@@ -161,5 +191,4 @@ RSpec.describe PlaylistItemsController, type: :controller do
       expect(response).to render_template(:_related_items)
     end
   end
-  
 end


### PR DESCRIPTION
Fixes #2459.

This also sets all of the playlist items controller endpoints to always return 401 when not authorized instead of trying to redirect.