### PR TITLE
Fix to sections links causing page refresh

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -63,9 +63,9 @@ class MEJSPlayer {
    * @return {void}
    */
   addSectionsClickListener() {
-    const click_sections = $('#markers_section, #related_items_section');
-    if (click_sections.length > 0) {
-      click_sections.click(this.handleSectionClick.bind(this));
+    const $accordionEl = $('#accordion.media-show-page');
+    if ($accordionEl.length > 0) {
+      $accordionEl[0].addEventListener('click', this.handleSectionClick.bind(this));
     }
   }
 

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% show_progress = sections.any? { |s| s.status_code != 'COMPLETED' } %>
 <% unless hide_sections?(sections) and not show_progress %>
 
-<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+<div class="panel-group media-show-page" id="accordion" role="tablist" aria-multiselectable="true">
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="sections_heading" style="border-bottom: 1px solid #ddd;">
       <h4 class="panel-title">


### PR DESCRIPTION
This reverses https://github.com/avalonmediasystem/avalon/commit/b9928ea240b85777c6d41f06ec1f25ee05b69b5c

So now section  links are fixed.  I'm going to check and see how click listeners for "Related Items" are being applied.