### PR TITLE
Fix playlist markers in Safari

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -65,7 +65,10 @@ class MEJSPlayer {
   addSectionsClickListener() {
     const $accordionEl = $('#accordion.media-show-page');
     if ($accordionEl.length > 0) {
-      $accordionEl[0].addEventListener('click', this.handleSectionClick.bind(this));
+      $accordionEl[0].addEventListener(
+        'click',
+        this.handleSectionClick.bind(this)
+      );
     }
   }
 
@@ -93,13 +96,8 @@ class MEJSPlayer {
    * @return {void}
    */
   emitSuccessEvent() {
-    // TODO: This is an example of something we could hook into.  Don't need quite yet but might...
-    const myEvent = new CustomEvent('mejs4handleSuccess', {
-      detail: {
-        foo: 'bar'
-      }
-    });
-    document.getElementById('content').dispatchEvent(myEvent);
+    const event = new CustomEvent('mejs4handleSuccess');
+    document.dispatchEvent(event);
   }
 
   /**

--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_markers.es6
@@ -32,7 +32,7 @@ class MEJSMarkersHelper {
           offset: +offset
         }
       });
-      
+
       player.setCurrentTime(+offset);
       document.dispatchEvent(event);
     });
@@ -276,6 +276,87 @@ class MEJSMarkersHelper {
   }
 
   /**
+   * Get jquery element with markup for a new marker and click handler applied
+   * @function newMarkerElement
+   * @param {String} marker_id Id to use for new marker
+   * @param {Float} offset StartTime of the marker
+   * @param {Float} offset_percent StartTime as percentage of total timerail
+   * @return {jquery_object} New jquery object representing the marker
+   */
+  newMarkerElement(marker_id, offset, offset_percent) {
+    const new_marker = $(
+      '<span class="fa fa-chevron-up scrubber-marker" style="left: ' +
+        offset_percent +
+        '%" data-marker="' +
+        marker_id +
+        '"></span>'
+    )
+      .bind('click', e => {
+        mejs4AvalonPlayer.player.setCurrentTime(offset);
+      })
+      .bind('mouseenter', e => {
+        $(
+          '.mejs__time-float-marker[data-marker="' +
+            e.target.dataset.marker +
+            '"]'
+        ).show();
+      })
+      .bind('mouseleave', e => {
+        $(
+          '.mejs__time-float-marker[data-marker="' +
+            e.target.dataset.marker +
+            '"]'
+        ).hide();
+      });
+    return new_marker;
+  }
+
+  /**
+   * Get jquery element with markup for a new marker popover
+   * @function newMarkerFloatElement
+   * @param {String} marker_id Id to use for new marker float
+   * @param {String} title Title to use for new marker float
+   * @param {Float} offset StartTime of the marker
+   * @param {Float} offset_percent StartTime as percentage of total timerail
+   * @return {jquery_object} New jquery object representing the marker popover
+   */
+  newMarkerFloatElement(marker_id, title, offset, offset_percent) {
+    return $(
+      '<span class="mejs__time-float-marker" data-marker="' +
+        marker_id +
+        '" style="display: none; left: ' +
+        offset_percent +
+        '%" ><span class="mejs__time-float-current-marker">' +
+        title +
+        ' [' +
+        mejs.Utils.secondsToTimeCode(offset) +
+        ']' +
+        '</span><span class="mejs__time-float-corner-marker"></span></span>'
+    );
+  }
+
+  /**
+   * Re-build the markers table and player markers
+   * @function rebuildMarkers
+   * @return {void}
+   */
+  rebuildMarkers() {
+    this.rebuildMarkersTable();
+    this.updateVisualMarkers();
+  }
+
+  /**
+   * Set the width of the marker rail
+   * @function resizeMarkerRail
+   * @param {jquery_object} marker_rail The marker_rail element
+   * @param {jquery_object} total The mejs time rail element
+   * @return {void}
+   */
+  resizeMarkerRail(marker_rail, total) {
+    marker_rail.width(total.width());
+  }
+
+  /**
    * Re-build the markers table after an add or edit
    * @function rebuildMarkersTable
    * @return {void}
@@ -351,16 +432,6 @@ class MEJSMarkersHelper {
   }
 
   /**
-   * Re-build the markers table and player markers
-   * @function rebuildMarkers
-   * @return {void}
-   */
-  rebuildMarkers() {
-    this.rebuildMarkersTable();
-    this.updateVisualMarkers();
-  }
-
-  /**
    * Update markers in Mediaelement player's time rail
    * @function updateVisualMarkers
    * @return {void}
@@ -374,6 +445,7 @@ class MEJSMarkersHelper {
         const duration = mejs4AvalonPlayer.player.duration;
         const scrubber = $('.mejs__time-rail').css('position', 'relative');
         const total = $('.mejs__time-total');
+
         // remove the existing marker rail and all it children/event
         $('.mejs__time-rail-marker').remove();
         // create a new marker rail
@@ -402,77 +474,6 @@ class MEJSMarkersHelper {
           this.resizeMarkerRail(marker_rail, total);
         });
       }
-    );
-  }
-
-  /**
-   * Set the width of the marker rail
-   * @function resizeMarkerRail
-   * @param {jquery_object} marker_rail The marker_rail element
-   * @param {jquery_object} total The mejs time rail element
-   * @return {void}
-   */
-  resizeMarkerRail(marker_rail, total) {
-    marker_rail.width(total.width());
-  }
-
-  /**
-   * Get jquery element with markup for a new marker and click handler applied
-   * @function newMarkerElement
-   * @param {String} marker_id Id to use for new marker
-   * @param {Float} offset StartTime of the marker
-   * @param {Float} offset_percent StartTime as percentage of total timerail
-   * @return {jquery_object} New jquery object representing the marker
-   */
-  newMarkerElement(marker_id, offset, offset_percent) {
-    const new_marker = $(
-      '<span class="fa fa-chevron-up scrubber-marker" style="left: ' +
-        offset_percent +
-        '%" data-marker="' +
-        marker_id +
-        '"></span>'
-    )
-      .bind('click', e => {
-        mejs4AvalonPlayer.player.setCurrentTime(offset);
-      })
-      .bind('mouseenter', e => {
-        $(
-          '.mejs__time-float-marker[data-marker="' +
-            e.target.dataset.marker +
-            '"]'
-        ).show();
-      })
-      .bind('mouseleave', e => {
-        $(
-          '.mejs__time-float-marker[data-marker="' +
-            e.target.dataset.marker +
-            '"]'
-        ).hide();
-      });
-    return new_marker;
-  }
-
-  /**
-   * Get jquery element with markup for a new marker popover
-   * @function newMarkerFloatElement
-   * @param {String} marker_id Id to use for new marker float
-   * @param {String} title Title to use for new marker float
-   * @param {Float} offset StartTime of the marker
-   * @param {Float} offset_percent StartTime as percentage of total timerail
-   * @return {jquery_object} New jquery object representing the marker popover
-   */
-  newMarkerFloatElement(marker_id, title, offset, offset_percent) {
-    return $(
-      '<span class="mejs__time-float-marker" data-marker="' +
-        marker_id +
-        '" style="display: none; left: ' +
-        offset_percent +
-        '%" ><span class="mejs__time-float-current-marker">' +
-        title +
-        ' [' +
-        mejs.Utils.secondsToTimeCode(offset) +
-        ']' +
-        '</span><span class="mejs__time-float-corner-marker"></span></span>'
     );
   }
 }

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -40,13 +40,6 @@ Object.assign(MediaElementPlayer.prototype, {
     // Track the number of MEJS 'timeupdate' events which fire after the end time of a playlist item
     playlistItemsObj.endTimeCount = 0;
 
-    // Rebuild playlist info panels
-    const currentPlaylistIds = playlistItemsObj.mejsMarkersHelper.getCurrentPlaylistIds();
-    playlistItemsObj.rebuildPlaylistInfoPanels(
-      currentPlaylistIds['playlistId'],
-      currentPlaylistIds['playlistItemId']
-    );
-
     // Show/hide add marker button on player
     playlistItemsObj.mejsMarkersHelper.showHideAddMarkerButton();
 
@@ -77,10 +70,10 @@ Object.assign(MediaElementPlayer.prototype, {
     // Set current playing item in this class context
     playlistItemsObj.setCurrentItemInternally();
 
-    // Handle canplay event, start the player at the playlist item start time
+    // Handle canplay event, which defines a 'state' needed before we can call other setup functions
     media.addEventListener(
       'canplay',
-      playlistItemsObj.goToPlaylistItemStartTime.bind(playlistItemsObj)
+      playlistItemsObj.handleCanPlay.bind(playlistItemsObj)
     );
   },
 
@@ -148,11 +141,7 @@ Object.assign(MediaElementPlayer.prototype, {
             let playlistId = e.target.dataset.playlistId;
             let playlistItemId = e.target.dataset.playlistItemId;
             let related = this.$sidePlaylist.find(
-              'a[data-playlist-id=' +
-                playlistId +
-                '][data-playlist-item-id=' +
-                playlistItemId +
-                ']'
+              `a[data-playlist-id="${playlistId}"][data-playlist-item-id="${playlistItemId}"]`
             );
             related.click();
           }
@@ -259,6 +248,22 @@ Object.assign(MediaElementPlayer.prototype, {
         this.player.play();
       }
       this.player.avalonWrapper.isFirstLoad = false;
+    },
+
+    /**
+     * Handle Mediaelement 'canplay' event in this plugin file.
+     * When 'canplay' fires, then we have the information on the player we need to execute
+     * the internal functions defined below.
+     * @return {void}
+     */
+    handleCanPlay() {
+      const t = this;
+      const currentPlaylistIds = t.mejsMarkersHelper.getCurrentPlaylistIds();
+      t.rebuildPlaylistInfoPanels(
+        currentPlaylistIds['playlistId'],
+        currentPlaylistIds['playlistItemId']
+      );
+      t.goToPlaylistItemStartTime();
     },
 
     /**


### PR DESCRIPTION
Note the only thing I really changed here creating a `"canplay"` event handling function in the playlist items plugin.  When that event fires, then we have `duration`, and everything works as expected in Safari.

The other diffs here are mostly alphabetizing functions in the plugin/class.  It's really helpful to keep these organized, and saves time (at least for me).