### PR TITLE
Use custom event handler which skips player resize if embedded

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -274,6 +274,10 @@ class MEJSPlayer {
       this.player = this.mediaElement;
     }
 
+    // Replace resize event handler with custom handler
+    this.player.globalUnbind('resize', this.player.globalResizeCallback);
+    this.player.globalBind('resize', this.customGlobalResizeCallback);
+
     this.emitSuccessEvent();
 
     // Handle 'canplay' events fired by player
@@ -488,6 +492,10 @@ class MEJSPlayer {
     if (!this.player.paused) {
       this.player.pause();
     }
+
+    // Unbind custom resize event handler
+    this.player.globalUnbind('resize', this.customGlobalResizeCallback)
+
     this.player.remove();
     delete this.player;
     // Grab either the <audio> or <video> element
@@ -534,5 +542,24 @@ class MEJSPlayer {
       document.getElementById('accordion'),
       currentStreamInfo
     );
+  }
+
+  /**
+   * Resize event handler copied from mediaelement
+   * which skips player resize if embedded in an iframe
+   */
+  customGlobalResizeCallback() {
+    const t = this.player;
+
+    // don't resize inside a frame/iframe
+    if (window.top === window.self) {
+      // don't resize for fullscreen mode
+      if (!(t.isFullScreen || (HAS_TRUE_NATIVE_FULLSCREEN && document.webkitIsFullScreen))) {
+        t.setPlayerSize(t.width, t.height);
+      }
+    }
+
+    // always adjust controls
+    t.setControlsSize();
   }
 }


### PR DESCRIPTION
I tested locally for non-iOS embedding and it looks fine and the normal player looks fine to me.  I'm not able to test on iOS from my local dev since I don't have https setup.

This PR replicates the change made by @mbklein here: https://github.com/avalonmediasystem/mediaelement/commit/882db358b11aa057b43d10cb52367c3ae1daa3a9