### PR TITLE
include links to the successful media objects

### DIFF
--- a/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
+++ b/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
@@ -47,8 +47,11 @@ Unless required by applicable law or agreed to in writing, software distributed
     </tr>
     <% @completed_items.each do |be_completed| %>
       <tr>
+        <% media_object = MediaObject.find(be_completed.media_object_pid) %>
+        <% link_url = media_object.permalink %>
+        <% link_url = media_object_url(media_object) if link_url.empty? %>
         <td> <%= be_completed.position + 2 %> </td>
-        <td> <%= be_completed.media_object_pid %> </td>
+        <td> <% content_tag(:a, href: link_url) do %><span><%=be_completed.media_object_pid%></span><%end%></td>
       </tr>
     <% end %>
   </table>


### PR DESCRIPTION
Fixes #2640 

Yes I know enchancement, extra c

@cjcolvar I feel link of bad about this one in terms of the ugly code in the `.erb`.  I was wondering moving it into the mailer job, but `@be_completed` is an array of `BatchEntries`, so I can't just (easily) inject URLs into those.  I did consider making BatchEntries track a URL like how Switchyard does and I'd be okay with that, except that is messing with the model really close to code freeze.  Your thoughts are welcome.  