### PR TITLE
Revert "Remove unneeded blacklight facet_load override"

### DIFF
--- a/app/assets/javascripts/blacklight/facet_load.js
+++ b/app/assets/javascripts/blacklight/facet_load.js
@@ -1,0 +1,23 @@
+/*global Blacklight */
+
+(function($) {
+  'use strict';
+  
+  Blacklight.doResizeFacetLabelsAndCounts = function() {
+    // adjust width of facet columns to fit their contents
+    function longer (a,b){ return b.textContent.length - a.textContent.length; }
+
+    $('ul.facet-values, ul.pivot-facet').each(function(){
+      var longest = $(this).find('span.facet-count').sort(longer).first();
+      var clone = longest.clone()
+        .css('visibility','hidden').css('width', 'auto');
+      $('span.facet-count:visible:first').append(clone);
+      $(this).find('.facet-count').first().width(clone.width());
+      clone.remove();
+    });
+  };
+
+  Blacklight.onLoad(function() {
+    Blacklight.doResizeFacetLabelsAndCounts();
+  });
+})(jQuery);


### PR DESCRIPTION
Reverts avalonmediasystem/avalon#2527

We actually still need this until the version of blacklight we use is updated.