### PR TITLE
Position audio player at bottom of iframe when embedding

### DIFF
--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -35,3 +35,8 @@ body {
   height: 100%;
   max-width: none;
 }
+
+.mejs__audio {
+  position: absolute;
+  bottom: 0;
+}


### PR DESCRIPTION
Fixes #2510 
Where time float getting clipped off by iframe.