### PR TITLE
Directly patch MEJS: avoid player resize if embedded

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -4141,11 +4141,14 @@ var MediaElementPlayer = function () {
 				}, 0);
 
 				t.globalResizeCallback = function () {
+                                    // don't resize inside a frame/iframe
+                                    if (window.top === window.self) {
 					if (!(t.isFullScreen || _constants.HAS_TRUE_NATIVE_FULLSCREEN && _document2.default.webkitIsFullScreen)) {
 						t.setPlayerSize(t.width, t.height);
 					}
 
 					t.setControlsSize();
+                                    }
 				};
 
 				t.globalBind('resize', t.globalResizeCallback);


### PR DESCRIPTION
Fixes #2632 

Tested on spruce and physical ipad 4.