### PR TITLE
[WIP] Listen to durationchange instead of canplay to better handle updating…

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -72,7 +72,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
     // Handle canplay event, which defines a 'state' needed before we can call other setup functions
     media.addEventListener(
-      'canplay',
+      'durationchange',
       playlistItemsObj.handleCanPlay.bind(playlistItemsObj)
     );
   },


### PR DESCRIPTION
… panels for mobile devices

I tested on spruce with an ipad 4 and it works but playing after autoadvance starts from beginning of file instead of beginning of clip and on desktop it causes the playlist to start playing on load of each new source including on page load.

This issue is that `canplay` isn't being emitted until the user clicks play on the ipad I'm testing on.  A good way to see what events happen when is to play around with this player: http://jplayer.org/HTML5.Media.Event.Inspector/