### PR TITLE
Use consistent route for section links

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -440,6 +440,7 @@ class MediaObjectsController < ApplicationController
     @currentStreamInfo = @currentStream.nil? ? {} : secure_streams(@currentStream.stream_details)
     @currentStreamInfo['t'] = view_context.parse_media_fragment(params[:t]) # add MediaFragment from params
     @currentStreamInfo['lti_share_link'] = view_context.lti_share_url_for(@currentStream)
+    @currentStreamInfo['link_back_url'] = view_context.share_link_for(@currentStream)
   end
 
   def load_player_context

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -52,9 +52,6 @@ module MasterFileBehavior
       captions_format = self.captions.mime_type
     end
 
-    link_back_url = permalink unless permalink.blank?
-    link_back_url ||= Rails.application.routes.url_helpers.master_file_url(self)
-
     # Returns the hash
     return({
       id: self.id,
@@ -67,8 +64,7 @@ module MasterFileBehavior
       captions_path: captions_path,
       captions_format: captions_format,
       duration: (duration.to_f / 1000),
-      embed_title: embed_title,
-      link_back_url: link_back_url
+      embed_title: embed_title
     })
   end
 

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -48,8 +48,12 @@ describe BookmarksController, type: :controller do
 
   describe "#update_status" do
     context 'publishing' do
-      before(:each) do
+      before(:all) do
         Permalink.on_generate { |obj| "http://example.edu/permalink" }
+      end
+
+      after(:all) do
+        Permalink.on_generate { nil }
       end
 
       it "should publish multiple items" do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -817,9 +817,14 @@ describe MediaObjectsController, type: :controller do
     end
 
     context 'publishing' do
-      before(:each) do
+      before(:all) do
         Permalink.on_generate { |obj| "http://example.edu/permalink" }
       end
+
+      after(:all) do
+        Permalink.on_generate { nil }
+      end
+
       it 'publishes media object' do
         media_object = FactoryGirl.create(:media_object, collection: collection)
         get 'update_status', id: media_object.id, status: 'publish'
@@ -913,8 +918,12 @@ describe MediaObjectsController, type: :controller do
     end
 
     context 'large objects' do
-      before(:each) do
+      before(:all) do
         Permalink.on_generate { |obj| sleep(0.5); "http://example.edu/permalink" }
+      end
+
+      after(:all) do
+        Permalink.on_generate { nil }
       end
 
       let!(:media_object) do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -529,7 +529,7 @@ describe MediaObjectsController, type: :controller do
           xhr :get, :show_stream_details, id: media_object.id, content: part.id
           json_obj = JSON.parse(response.body)
           expect(json_obj['is_video']).to eq(part.is_video?)
-          expect(json_obj['link_back_url']).to eq(Rails.application.routes.url_helpers.master_file_url(part))
+          expect(json_obj['link_back_url']).to eq(Rails.application.routes.url_helpers.id_section_media_object_url(media_object, part))
         }
       end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -524,22 +524,18 @@ describe MediaObjectsController, type: :controller do
       end
 
       it "should provide a JSON stream description to the client" do
-        FactoryGirl.create(:master_file, media_object: media_object)
-        media_object.master_files.each { |part|
-          xhr :get, :show_stream_details, id: media_object.id, content: part.id
-          json_obj = JSON.parse(response.body)
-          expect(json_obj['is_video']).to eq(part.is_video?)
-          expect(json_obj['link_back_url']).to eq(Rails.application.routes.url_helpers.id_section_media_object_url(media_object, part))
-        }
+        part = FactoryGirl.create(:master_file, media_object: media_object)
+        xhr :get, :show_stream_details, id: media_object.id, content: part.id
+        json_obj = JSON.parse(response.body)
+        expect(json_obj['is_video']).to eq(part.is_video?)
+        expect(json_obj['link_back_url']).to eq(Rails.application.routes.url_helpers.id_section_media_object_url(media_object, part))
       end
 
       it "should provide a JSON stream description with permalink to the client" do
-        FactoryGirl.create(:master_file, media_object: media_object, permalink: 'https://permalink.host/path/id')
-        media_object.master_files.each { |part|
-          xhr :get, :show_stream_details, id: media_object.id, content: part.id
-          json_obj = JSON.parse(response.body)
-          expect(json_obj['link_back_url']).to eq('https://permalink.host/path/id')
-        }
+        part = FactoryGirl.create(:master_file, media_object: media_object, permalink: 'https://permalink.host/path/id')
+        xhr :get, :show_stream_details, id: media_object.id, content: part.id
+        json_obj = JSON.parse(response.body)
+        expect(json_obj['link_back_url']).to eq('https://permalink.host/path/id')
       end
 
       it "should choose the correct default master_file" do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -529,6 +529,16 @@ describe MediaObjectsController, type: :controller do
           xhr :get, :show_stream_details, id: media_object.id, content: part.id
           json_obj = JSON.parse(response.body)
           expect(json_obj['is_video']).to eq(part.is_video?)
+          expect(json_obj['link_back_url']).to eq(Rails.application.routes.url_helpers.master_file_url(part))
+        }
+      end
+
+      it "should provide a JSON stream description with permalink to the client" do
+        FactoryGirl.create(:master_file, media_object: media_object, permalink: 'https://permalink.host/path/id')
+        media_object.master_files.each { |part|
+          xhr :get, :show_stream_details, id: media_object.id, content: part.id
+          json_obj = JSON.parse(response.body)
+          expect(json_obj['link_back_url']).to eq('https://permalink.host/path/id')
         }
       end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -528,26 +528,4 @@ describe MasterFile do
       expect { MasterFile.new(workflow_id: '1', status_code: 'RUNNING').send(:stop_processing!) }.not_to raise_error
     end
   end
-
-  describe 'stream_details' do
-    let(:media_object) { instance_double("media_object", title: 'Test') }
-    before do
-      allow(master_file).to receive(:media_object).and_return(media_object)
-      allow(media_object).to receive(:ordered_master_files).and_return([master_file])
-    end
-    context 'with a permalink' do
-      let(:master_file) { FactoryGirl.build(:master_file, permalink: permalink) }
-      let(:permalink) { 'https://permalink.host/path/id' }
-      it 'returns the permalink as the link_back_url' do
-        expect(master_file.stream_details[:link_back_url]).to eq permalink
-      end
-    end
-    context 'without a permalink' do
-      # Have to create in order to get an id
-      let(:master_file) { FactoryGirl.create(:master_file) }
-      it 'returns the master file url as the link_back_url' do
-        expect(master_file.stream_details[:link_back_url]).to eq Rails.application.routes.url_helpers.master_file_url(master_file)
-      end
-    end
-  end
 end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -580,6 +580,10 @@ describe MediaObject do
       Permalink.on_generate{ |obj,target| 'http://www.example.com/perma-url' }
     }
 
+    after(:each) do
+      Permalink.on_generate { nil }
+    end
+
     context 'unpublished' do
       it 'is empty when unpublished' do
         expect(media_object.permalink).to be_blank


### PR DESCRIPTION
Use consistent route for section links in media_object page and stream_details ajax endpoint.