### PR TITLE
Use blank? because link_url could be nil if there is no permalink

### DIFF
--- a/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
+++ b/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
@@ -49,7 +49,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <tr>
         <% media_object = MediaObject.find(be_completed.media_object_pid) %>
         <% link_url = media_object.permalink %>
-        <% link_url = media_object_url(media_object) if link_url.empty? %>
+        <% link_url = media_object_url(media_object) if link_url.blank? %>
         <td> <%= be_completed.position + 2 %> </td>
         <td> <% content_tag(:a, href: link_url) do %><span><%=be_completed.media_object_pid%></span><%end%></td>
       </tr>


### PR DESCRIPTION
Issue found by @Karthikeya212 during testing.