### PR TITLE
Fix for iOS iPad; removes quality plugin loading; loads playlist item…

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
@@ -114,6 +114,15 @@ class MEJSUtility {
   }
 
   /**
+   * Helper function - is current environment mobile?
+   * @return {Boolean}
+   */
+  isMobile() {
+    const features = mejs.Features;
+    return features.isAndroid || features.isiOS;
+  }
+
+  /**
    * Update section links to reflect active section playing
    * @function highlightSectionLink
    * @param  {string} segmentId - HTML node of section link clicked on <a>

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -75,6 +75,10 @@ Object.assign(MediaElementPlayer.prototype, {
       'canplay',
       playlistItemsObj.handleCanPlay.bind(playlistItemsObj)
     );
+
+    if (playlistItemsObj.mejsUtility.isMobile()) {
+      playlistItemsObj.handleCanPlayMobile();
+    }
   },
 
   // Optionally, each feature can be destroyed setting a `clean` method
@@ -259,11 +263,34 @@ Object.assign(MediaElementPlayer.prototype, {
     handleCanPlay() {
       const t = this;
       const currentPlaylistIds = t.mejsMarkersHelper.getCurrentPlaylistIds();
+
       t.rebuildPlaylistInfoPanels(
         currentPlaylistIds['playlistId'],
         currentPlaylistIds['playlistItemId']
       );
       t.goToPlaylistItemStartTime();
+    },
+
+    /**
+     * Helper function for mobile/iOS as the 'canplay' event never reaches this plugin for some reason.
+     * @function handleCanPlayMobile
+     * @return {void}
+     */
+    handleCanPlayMobile() {
+      const t = this;
+
+      // Custom poller function which checks if currentPlaylistIds are ready yet, every 1 second until they are.
+      const poller = () => {
+        setTimeout(() => {
+          const currentPlaylistIds = t.mejsMarkersHelper.getCurrentPlaylistIds();
+          if (!currentPlaylistIds) {
+            poller();
+          } else {
+            t.handleCanPlay();
+          }
+        }, 1000);
+      };
+      poller();
     },
 
     /**


### PR DESCRIPTION
… panel content on page load.

The issue causing this ticket is that in certain iOS environments, MEJS events like 'canplay', 'loadedmetadata', cannot be counted on and are erratic between iPhone/iPad then versions with each.   Some fire, some don't.

So, this `poller()` pattern is something else we could maybe think about as a more reliable way to handle application timing, in certain scenarios?   Just something to think about.

Note I also included code here which filters out the quality selector plugin for mobile, which was causing errors for some reason in iOS.  Even after my other PR fix for the quality selector plugin...