### PR TITLE
Fix resetting of add_to_playlist form

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_to_playlist.es6
@@ -94,7 +94,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
     $(addToPlayListObj.alertEl).hide();
     $(addToPlayListObj.playlistEl).hide();
-    addToPlayListObj.resetForm.apply(t);
+    addToPlayListObj.resetForm.apply(addToPlayListObj);
 
     // Remove Add / Cancel button event listeners
     addToPlayListObj.addButton.removeEventListener(


### PR DESCRIPTION
Fixes #2660 

Correctly reset addToPlaylist form when switching sections. addToPlaylist resetform() was being applied to player instead of addToPlayListObj.