### PR TITLE
Downgrade to solr 7.1.0 as 7.2.0 breaks the BookmarksController

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 7.1.0
 # port: 8983
 instance_dir: tmp/solr-development
 collection:


### PR DESCRIPTION
This hopefully fixes the mysteriously failing tests in travis.
This downgrade should be temporary until we apply whatever fix the Samvera community decides upon (using `luceneMatchVersion`, staying pinned to 7.1.0, or rewriting the queries).