### PR TITLE
Fix playlist where first item is inaccessible

### DIFF
--- a/app/views/playlists/_mejs4_playlist_item.html.erb
+++ b/app/views/playlists/_mejs4_playlist_item.html.erb
@@ -18,21 +18,21 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% clip = clip_map[item.clip_id] %>
 
 <% if clip.master_file.present? && can?(:read, clip.master_file.media_object) %>
-  <% masterfile = clip.master_file %>
-  <% item_type = (clip.master_file.file_format=='Moving image')? 'fa-film' : 'fa-music' %>
+  <% master_file = clip.master_file %>
+  <% item_type = (master_file.file_format=='Moving image')? 'fa-film' : 'fa-music' %>
 
   <li class="<%= item_class %>" data-is-video="<%= clip.master_file.is_video? %>" data-playlist-item-id="<%= item.id %>">
     <% if item_class == 'now_playing' %>
       <i class="fa fa-arrow-circle-right"></i>
     <% end %>
-    <% if can?(:read, @current_playlist_item.clip.master_file.media_object) %>
+    <% if can?(:read, master_file.media_object) %>
       <% dataset = { 'playlist-id' => item.playlist_id,
                      'playlist-item-id' => item.id,
                      'clip-start-time' => clip.start_time,
                      'clip-end-time' => clip.end_time,
                      'clip-source' => clip.source,
-                     'media-object-id' => masterfile.media_object_id,
-                     'master-file-id' => masterfile.id,
+                     'media-object-id' => master_file.media_object_id,
+                     'master-file-id' => master_file.id,
                      'can-edit-playlist-item' => (can? :edit, item) } %>
       <%= link_to playlist_path(@playlist, position: clip.playlist_position(@playlist)), data: dataset do %>
         <%= clip.title %>


### PR DESCRIPTION
Fixes #2675 

Checks read ability on each playlist item, not just the current playlist item. Also renames variable masterfile to master_file.