### PR TITLE
Only require AWS related code if using active_elastic_job active_job adapter.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,6 +84,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  require 'active_job/queue_adapters/better_active_elastic_job_adapter'
   config.active_job.queue_adapter     = Settings&.active_job&.queue_adapter || :resque
+  require 'active_job/queue_adapters/better_active_elastic_job_adapter' if config.active_job.queue_adapter == :active_elastic_job
 end


### PR DESCRIPTION
Required to deploy to staging.