### PR TITLE
Avalon Intercom back end

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -86,7 +86,7 @@ class MediaObjectsController < ApplicationController
       elsif result[:status].present?
         flash[:alert] = "There was an error pushing the item. (#{result[:status]}: #{result[:message]})"
       else
-        flash[:alert] = result[:mesage]
+        flash[:alert] = result[:message]
       end
     else
       flash[:alert] = 'You do not have permission to push this media object.'

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -56,21 +56,22 @@ class MediaObjectsController < ApplicationController
   end
 
   def intercom_collections
+    intercom = Avalon::Intercom.new(user_key)
     respond_to do |format|
       format.json do
-        render json: Avalon::Intercom.user_collections(user_key).to_json
+        render json: intercom.user_collections.to_json
       end
     end
   end
 
   def intercom_push
-    result = Avalon::Intercom.push_media_object(@media_object, params[:collection_id], params[:include_structure] == 'true')
-    if result['id'].present?
-      target_url = URI.join(Avalon::Intercom.avalons['default']['url'], 'media_objects/', result['id'])
-      target_link = link_to "See it here", target_url, target: "_blank"
-      flash[:success] = "The item was pushed successfully. #{target_link}"
-    else
+    intercom = Avalon::Intercom.new(user_key)
+    result = intercom.push_media_object(@media_object, params[:collection_id], params[:include_structure] == 'true')
+    if result[:message].present?
       flash[:alert] = "There was an error pushing the item. (#{result[:status]}: #{result[:message]})"
+    else
+      target_link = link_to "See it here", result, target: "_blank"
+      flash[:success] = "The item was pushed successfully. #{target_link}"
     end
     redirect_to media_object_path(@media_object.id)
   end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -64,7 +64,7 @@ class MediaObjectsController < ApplicationController
       session[:intercom_collections] = collections
     end
     collections.each do |c|
-      c['default'] = c['id']==session[:intercom_collection]
+      c['default'] = c['id'] == session[:intercom_collection]
     end
     respond_to do |format|
       format.json do
@@ -78,12 +78,12 @@ class MediaObjectsController < ApplicationController
       intercom = Avalon::Intercom.new(user_key)
       collections = intercom.user_collections
       session[:intercom_collections] = collections
-      if collections.collect{ |c| c['id'] }.include? params[:collection_id]
+      if collections.collect { |c| c['id'] }.include? params[:collection_id]
         session[:intercom_collection] = params[:collection_id]
         result = intercom.push_media_object(@media_object, params[:collection_id], params[:include_structure] == 'true')
         if result[:link].present?
           target_link = view_context.link_to('See it here.', result[:link], target: '_blank')
-          flash[:success] = "The item was pushed successfully. #{target_link}".html_safe
+          flash[:success] = view_context.safe_join(["The item was pushed successfully. ", target_link])
         else
           flash[:alert] = "There was an error pushing the item. (#{result[:status]}: #{result[:message]})"
         end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -160,7 +160,7 @@ class Ability
 
       can :intercom_push, MediaObject do |media_object|
         # anyone who can read a media_object can also push it
-        can? :read, media_object
+        can? :edit, media_object
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -157,6 +157,11 @@ class Ability
       cannot :destroy, Admin::Collection do |collection, other_user_collections=[]|
         (not full_login?) || !@user.in?(collection.managers)
       end
+
+      can :intercom_push, MediaObject do |media_object|
+        # anyone who can read a media_object can also push it
+        can? :read, media_object
+      end
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -159,7 +159,7 @@ class Ability
       end
 
       can :intercom_push, MediaObject do |media_object|
-        # anyone who can read a media_object can also push it
+        # anyone who can edit a media_object can also push it
         can? :edit, media_object
       end
     end

--- a/app/models/concerns/derivative_intercom.rb
+++ b/app/models/concerns/derivative_intercom.rb
@@ -1,0 +1,37 @@
+# Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implie See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module DerivativeIntercom
+  def to_ingest_api_hash
+    {
+      label: "quality-#{quality}", # quality-low, quality-medium, quality-high
+      id: track_id,
+      url: location_url,
+      hls_url: hls_url,
+      duration: duration,
+      mime_type: mime_type,
+      audio_bitrate: audio_bitrate,
+      audio_codec: audio_codec,
+      video_bitrate: video_bitrate,
+      video_codec: video_codec,
+      width: (resolution.present? ? resolution.split('x')[0] || nil : nil),
+      height: (resolution.present? ? resolution.split('x')[1] || nil : nil),
+      location: location_url,
+      track_id: track_id,
+      hls_track_id: hls_track_id,
+      managed: false,
+      derivativeFile: derivativeFile
+    }
+  end
+end

--- a/app/models/concerns/master_file_intercom.rb
+++ b/app/models/concerns/master_file_intercom.rb
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MasterFileIntercom
-  def to_ingest_api_hash(include_structure=true)
+  def to_ingest_api_hash(include_structure = true)
     {
       workflow_name: workflow_name,
       percent_complete: percent_complete,

--- a/app/models/concerns/master_file_intercom.rb
+++ b/app/models/concerns/master_file_intercom.rb
@@ -1,0 +1,40 @@
+# Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module MasterFileIntercom
+  def to_ingest_api_hash
+    {
+      workflow_name: workflow_name,
+      percent_complete: percent_complete,
+      percent_succeeded: percent_succeeded,
+      percent_failed: percent_failed,
+      status_code: status_code,
+      structure:  structuralMetadata.content,
+      label: title,
+      thumbnail_offset: thumbnail_offset,
+      poster_offset: poster_offset,
+      physical_description: physical_description,
+      file_location: file_location,
+      file_size: file_size,
+      duration: duration,
+      date_digitized: date_digitized,
+      file_checksum: file_checksum,
+      file_format: file_format,
+      other_identifier: identifier,
+      captions: captions.content,
+      captions_type: caption_type,
+      files: derivatives.collect(&:to_ingest_api_hash)
+    }
+  end
+end

--- a/app/models/concerns/master_file_intercom.rb
+++ b/app/models/concerns/master_file_intercom.rb
@@ -13,14 +13,14 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MasterFileIntercom
-  def to_ingest_api_hash
+  def to_ingest_api_hash(include_structure=true)
     {
       workflow_name: workflow_name,
       percent_complete: percent_complete,
       percent_succeeded: percent_succeeded,
       percent_failed: percent_failed,
       status_code: status_code,
-      structure:  structuralMetadata.content,
+      structure:  include_structure ? structuralMetadata.content : nil,
       label: title,
       thumbnail_offset: thumbnail_offset,
       poster_offset: poster_offset,

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -1,0 +1,61 @@
+# Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module MediaObjectIntercom
+  def to_ingest_api_hash
+    {
+      files: ordered_master_files.to_a.collect(&:to_ingest_api_hash),
+      fields:
+        {
+          duration: duration,
+          avalon_resource_type: avalon_resource_type,
+          avalon_publisher: avalon_publisher,
+          avalon_uploader: avalon_uploader,
+          identifier: identifier,
+          title: title,
+          alternative_title: alternative_title,
+          translated_title: translated_title,
+          uniform_title: uniform_title,
+          statement_of_responsibility: statement_of_responsibility,
+          creator: creator,
+          date_created: date_created,
+          date_issued: date_issued,
+          copyright_date: copyright_date,
+          abstract: abstract,
+          format: format,
+          resource_type: resource_type,
+          contributor: contributor,
+          publisher: publisher,
+          genre: genre,
+          subject: subject,
+          geographic_subject: geographic_subject,
+          temporal_subject: temporal_subject,
+          topical_subject: topical_subject,
+          terms_of_use: terms_of_use,
+          table_of_contents: table_of_contents,
+          physical_description: physical_description,
+          record_identifier: record_identifier,
+          bibliographic_id: (bibliographic_id.present? ? bibliographic_id[:id] : nil),
+          bibliographic_id_label: (bibliographic_id.present? ? bibliographic_id[:source] : nil),
+          note: (note.present? ? note.collect { |n| n[:note] } : nil),
+          note_type: (note.present? ? note.collect { |n| n[:type] } : nil),
+          language: (language.present? ? language.collect { |n| n[:code] } : nil),
+          related_item_url: (related_item_url.present? ? related_item_url.collect { |n| n[:url] } : nil),
+          related_item_label: (related_item_url.present? ? related_item_url.collect { |n| n[:label] } : nil),
+          other_identifier: (other_identifier.present? ? other_identifier.collect { |n| n[:id] } : nil),
+          other_identifier_type: (other_identifier.present? ? other_identifier.collect { |n| n[:source] } : nil)
+        }
+    }
+  end
+end

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -13,9 +13,9 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MediaObjectIntercom
-  def to_ingest_api_hash(include_structure=true)
+  def to_ingest_api_hash(include_structure = true)
     {
-      files: ordered_master_files.to_a.collect{ |mf| mf.to_ingest_api_hash include_structure },
+      files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash include_structure },
       fields:
         {
           duration: duration,

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -13,9 +13,9 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MediaObjectIntercom
-  def to_ingest_api_hash
+  def to_ingest_api_hash(include_structure=true)
     {
-      files: ordered_master_files.to_a.collect(&:to_ingest_api_hash),
+      files: ordered_master_files.to_a.collect{ |mf| mf.to_ingest_api_hash include_structure },
       fields:
         {
           duration: duration,

--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -16,6 +16,7 @@ require 'avalon/stream_mapper'
 
 class Derivative < ActiveFedora::Base
   include DerivativeBehavior
+  include DerivativeIntercom
   include FrameSize
   include MigrationTarget
 

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -29,6 +29,7 @@ class MasterFile < ActiveFedora::Base
   include Identifier
   include MigrationTarget
   include MasterFileBehavior
+  include MasterFileIntercom
 
   belongs_to :media_object, class_name: 'MediaObject', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
   has_many :derivatives, class_name: 'Derivative', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isDerivationOf, dependent: :destroy

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -23,6 +23,7 @@ class MediaObject < ActiveFedora::Base
   include Identifier
   include MigrationTarget
   include SpeedyAF::OrderedAggregationIndex
+  include MediaObjectIntercom
   require 'avalon/controlled_vocabulary'
 
   include Kaminari::ActiveFedoraModelExtension

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -44,12 +44,17 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
         <%= link_to 'Edit', edit_media_object_path(@media_object), class: 'btn btn-default' %>
-        <%# This might not be the best approach because it makes accidental 
+        <%# This might not be the best approach because it makes accidental
             deletion possible just by following a link. Need to revisit when
             extra cycles are available %>
 
         <% if can? :destroy, @media_object %>
           <%= link_to 'Delete', confirm_remove_media_object_path(@media_object), class: 'btn btn-danger' %>
+        <% end %>
+
+        <% if Avalon::Intercom.get_avalons.present? %>
+          <%= button_tag(Avalon::Intercom.get_avalons['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
+          <%= render "intercom_push_form" %>
         <% end %>
       </div>
   </div>

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -52,7 +52,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= link_to 'Delete', confirm_remove_media_object_path(@media_object), class: 'btn btn-danger' %>
         <% end %>
 
-        <% if Settings.intercom.present? %>
+        <% if Settings.intercom.present? and can? :intercom_push, @media_object %>
           <%= button_tag(Settings.intercom['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
           <%= render "intercom_push_form" %>
         <% end %>

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -52,8 +52,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= link_to 'Delete', confirm_remove_media_object_path(@media_object), class: 'btn btn-danger' %>
         <% end %>
 
-        <% if Avalon::Intercom.get_avalons.present? %>
-          <%= button_tag(Avalon::Intercom.get_avalons['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
+        <% if Settings.intercom.present? %>
+          <%= button_tag(Settings.intercom['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
           <%= render "intercom_push_form" %>
         <% end %>
       </div>

--- a/app/views/media_objects/_intercom_push_form.html.erb
+++ b/app/views/media_objects/_intercom_push_form.html.erb
@@ -19,31 +19,36 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h3 class='modal-title'><%= Avalon::Intercom.get_avalons['default']['push_label'] %></h3>
+        <h3 class='modal-title'><%= Settings.intercom['default']['push_label'] %></h3>
       </div>
       <div class="modal-body">
-        <%= form_for @media_object, url: {action: "intercom_push"} do |f| %>
-          <div class="form-group">
-            <label for "collection_id">Choose Target Collection:</label>
-            <select required name="collection_id" id="collection_id" class="form-control"></select>
+        <div class="form-group">
+          <label for "collection_id">Choose Target Collection:</label>
+          <div class="input-group">
+            <select required name="collection_id" id="collection_id" class="form-control" form="intercom_push_form"></select>
+            <span class="input-group-btn">
+              <button class="btn btn-secondary" title="Refresh list" onclick="getCollections(true);"><i class="fa fa-refresh"></i></button>
+            </span>
           </div>
+        </div>
+        <%= form_for @media_object, url: {action: "intercom_push"}, html: { id: 'intercom_push_form' } do |f| %>
           <div class="form-group">
             <label for "include_structure_1">Include Structural Metadata?</label>
             <div class="form-check">
               <label class="form-check-label">
-                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_1" value="true" checked>
+                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_1" value="true" checked form="intercom_push_form">
                 Yes, include structure.
               </label>
             </div>
             <div class="form-check">
               <label class="form-check-label">
-                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_2" value="false">
+                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_2" value="false" form="intercom_push_form">
                 No, do not include structure.
               </label>
             </div>
           </div>
           <div class="form-group">
-            <button class="btn btn-primary">Push</button>
+            <button class="btn btn-primary" form="intercom_push_form" data-loading-text="<i class='fa fa-spinner fa-spin '></i> Pushing" id="intercom_push_submit_button">Push</button>
 	          <button data-dismiss="modal" aria-hidden="true" class="btn btn-danger">Cancel</button>
         <% end %>
       </div>
@@ -52,28 +57,42 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 <% content_for :page_scripts do %>
   <script>
+    $('#intercom_push_submit_button').click( function (e) {
+      $(e.target).button('loading');
+    })
     $('#intercom_push').on('shown.bs.modal', function(e){
+      getCollections(false);
+    })
+    function getCollections(force){
       modal = $('#intercom_push')
       select = modal.find('#collection_id')
-      select.find("option").remove();
-      select.append('<option value="" disabled="disabled" selected="selected">Fetching Collections from Target...</option>')
-      $.ajax({
-        type: "GET",
-        url: "<%= intercom_collections_media_objects_path %>",
-        format: 'json',
-        data: {},
-        success: function(result) {
-          select.find("option").remove();
-          $.each(result, function(i,c){
-            select.append($('<option></option')
-                  .attr("value",c['id'])
-                  .text(c['name']))
-          })
-        },
-        error: function(result) {
-          $('#intercom_push #collection_id').find('option').text('There was an error communicating with the target.')
-        }
-      });
-    })
+      if (force || select.find('option').length === 0) {
+        $('#intercom_push_submit_button').prop('disabled',true)
+        select.find("option").remove();
+        select.append('<option value="" disabled="disabled" selected="selected">Fetching Collections from Target...</option>')
+        $.ajax({
+          type: "GET",
+          url: "<%= intercom_collections_media_objects_path %>",
+          format: 'json',
+          data: { 'reload': force },
+          success: function(result) {
+            select.find("option").remove();
+            $.each(result, function(i,c){
+              var option = $('<option></option')
+                    .attr("value",c['id'])
+                    .text(c['name'])
+              if (c['default']){
+                option.prop('selected',true);
+              }
+              select.append(option)
+            })
+            $('#intercom_push_submit_button').prop('disabled',false)
+          },
+          error: function(result) {
+            $('#intercom_push #collection_id').find('option').text('There was an error communicating with the target.')
+          }
+        });
+      }
+    }
   </script>
 <% end %>

--- a/app/views/media_objects/_intercom_push_form.html.erb
+++ b/app/views/media_objects/_intercom_push_form.html.erb
@@ -1,0 +1,79 @@
+<%#
+Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<div id="intercom_push" class="modal fade" role="dialog" data-backdrop="true" data-submit_url="<%= 'create' %>" >
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h3 class='modal-title'><%= Avalon::Intercom.get_avalons['default']['push_label'] %></h3>
+      </div>
+      <div class="modal-body">
+        <%= form_for @media_object, url: {action: "intercom_push"} do |f| %>
+          <div class="form-group">
+            <label for "collection_id">Choose Target Collection:</label>
+            <select required name="collection_id" id="collection_id" class="form-control"></select>
+          </div>
+          <div class="form-group">
+            <label for "include_structure_1">Include Structural Metadata?</label>
+            <div class="form-check">
+              <label class="form-check-label">
+                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_1" value="true" checked>
+                Yes, include structure.
+              </label>
+            </div>
+            <div class="form-check">
+              <label class="form-check-label">
+                <input class="form-check-input" type="radio" name="include_structure" id="include_structure_2" value="false">
+                No, do not include structure.
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <button class="btn btn-primary">Push</button>
+	          <button data-dismiss="modal" aria-hidden="true" class="btn btn-danger">Cancel</button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<% content_for :page_scripts do %>
+  <script>
+    $('#intercom_push').on('shown.bs.modal', function(e){
+      modal = $('#intercom_push')
+      select = modal.find('#collection_id')
+      select.find("option").remove();
+      select.append('<option value="" disabled="disabled" selected="selected">Fetching Collections from Target...</option>')
+      $.ajax({
+        type: "GET",
+        url: "<%= intercom_collections_media_objects_path %>",
+        format: 'json',
+        data: {},
+        success: function(result) {
+          select.find("option").remove();
+          $.each(result, function(i,c){
+            select.append($('<option></option')
+                  .attr("value",c['id'])
+                  .text(c['name']))
+          })
+        },
+        error: function(result) {
+          $('#intercom_push #collection_id').find('option').text('There was an error communicating with the target.')
+        }
+      });
+    })
+  </script>
+<% end %>

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -1,0 +1,2 @@
+Settings.add_source!('config/intercom.yml')
+Settings.reload!

--- a/config/intercom.yml.example
+++ b/config/intercom.yml.example
@@ -1,0 +1,5 @@
+default:
+  url: https://some.avalon.com/
+  api_token: a_valid_token
+  import_bib_record: true
+  publish: false

--- a/config/intercom.yml.example
+++ b/config/intercom.yml.example
@@ -1,5 +1,6 @@
-default:
-  url: https://some.avalon.com/
-  api_token: a_valid_token
-  import_bib_record: true
-  publish: false
+intercom:
+  default:
+    url: https://some.avalon.com/
+    api_token: a_valid_token
+    import_bib_record: true
+    publish: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
       get :confirm_remove
       get :add_to_playlist_form
       post :add_to_playlist
+      patch :intercom_push
     end
     collection do
       post :create, action: :create, constraints: { format: 'json' }
@@ -101,6 +102,7 @@ Rails.application.routes.draw do
       put :update_status
       # 'delete' has special signifigance so use 'remove' for now
       delete :remove, :action => :destroy
+      get :intercom_collections
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,6 +58,8 @@ bib_retriever:
   query: rec.id='%s'
 controlled_vocabulary:
   path: config/controlled_vocabulary.yml
+intercom:
+  path: config/intercom.yml
 auth:
   configuration:
     - :name: Avalon Test Auth

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,8 +58,6 @@ bib_retriever:
   query: rec.id='%s'
 controlled_vocabulary:
   path: config/controlled_vocabulary.yml
-intercom:
-  path: config/intercom.yml
 auth:
   configuration:
     - :name: Avalon Test Auth

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -17,34 +17,34 @@ module Avalon
     def initialize(user, avalon = 'default')
       @user = user
       @avalon = Settings.intercom[avalon]
-      @user_collections = nil
+      @collections = nil
     end
 
     def user_collections(reload = false)
-      if reload || @user_collections.nil?
-        @user_collections = fetch_user_collections
+      if reload || @collections.nil?
+        @collections = fetch_user_collections
       end
-      @user_collections
+      @collections
     end
 
     def collection_valid?(collection)
-      @user_collections.collect { |c| c['id'] }.include? collection
+      user_collections.any? { |c| c['id'] == collection }
     end
 
     def push_media_object(media_object, collection_id, include_structure = true)
-      return { message: 'You are not autorized to push to this collection.' } unless collection_valid? collection_id
       return { message: 'Avalon intercom target is not configured.' } unless @avalon.present?
+      return { message: 'You are not autorized to push to this collection.' } unless collection_valid? collection_id
       begin
         resp = RestClient::Request.execute(
           method: :post,
-          url: URI.join(@avalon[:url], 'media_objects.json').to_s,
+          url: URI.join(@avalon['url'], 'media_objects.json').to_s,
           payload: build_payload(media_object, collection_id, include_structure),
-          headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon[:api_token] },
+          headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon['api_token'] },
           verify_ssl: false
         )
-        { link: URI.join(@avalon[:url], 'media_objects/', JSON.parse(resp.body)['id']).to_s }
+        { link: URI.join(@avalon['url'], 'media_objects/', JSON.parse(resp.body)['id']).to_s }
       rescue StandardError => e
-        { message: e.message, status: e.response.code }
+        { message: e.message, status: e.respond_to?(:response) ? e.response.code : 500 }
       end
     end
 
@@ -53,21 +53,21 @@ module Avalon
       def build_payload(media_object, collection_id, include_structure)
         payload = media_object.to_ingest_api_hash(include_structure)
         payload[:collection_id] = collection_id
-        payload[:import_bib_record] = @avalon[:import_bib_record]
-        payload[:publish] = @avalon[:publish]
+        payload[:import_bib_record] = @avalon['import_bib_record']
+        payload[:publish] = @avalon['publish']
         payload.to_json
       end
 
       def fetch_user_collections
         return [] unless @avalon.present?
-        uri = URI.join(@avalon[:url], 'admin/collections.json')
+        uri = URI.join(@avalon['url'], 'admin/collections.json')
         uri.query = "user=#{@user}"
         resp = RestClient::Request.execute(
           method: :get,
           url: uri.to_s,
           timeout: nil,
           open_timeout: nil,
-          headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon[:api_token] },
+          headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon['api_token'] },
           verify_ssl: false
         )
         JSON.parse(resp.body).map { |c| c.slice('id', 'name') }.sort_by { |c| c["name"] }

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -15,13 +15,9 @@
 module Avalon
   class Intercom
 
-    def self.avalons
-      Settings.intercom
-    end
-
-    def initialize(user, avalon = "default")
+    def initialize(user, avalon = 'default')
       @user = user
-      @avalon = avalons[avalon].symbolize_keys!
+      @avalon = Settings.intercom[avalon]
       @user_collections = nil
     end
 
@@ -29,40 +25,44 @@ module Avalon
       @user_collections ||= get_user_collections
     end
 
-    def push_media_object(media_object, collection_id)
+    def push_media_object(media_object, collection_id, include_structure = true)
       return [] unless @avalon.present?
       uri = URI.join(@avalon[:url], 'media_objects.json')
-      payload = media_object.to_ingest_api_hash
+      payload = media_object.to_ingest_api_hash(include_structure)
       payload[:collection_id] = collection_id
       payload[:import_bib_record] = @avalon[:import_bib_record]
       payload[:publish] = @avalon[:publish]
+      begin
+        resp = RestClient::Request.execute(
+          method: :post,
+          url: uri.to_s,
+          payload: payload.to_json,
+          headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon[:api_token] },
+          verify_ssl: false
+        )
+        result = { link: URI.join(@avalon[:url], 'media_objects/', JSON.parse(resp.body)['id']).to_s }
+      rescue StandardError => e
+        result = { status: e.response.code, message: e.message }
+      end
+      result
+    end
+
+    private
+
+    def get_user_collections
+      return [] unless @avalon.present?
+      uri = URI.join(@avalon[:url], 'admin/collections.json')
+      uri.query = "user=#{@user}"
       resp = RestClient::Request.execute(
-        method: :post,
+        method: :get,
         url: uri.to_s,
-        payload: payload.to_json,
+        timeout: nil,
+        open_timeout: nil,
         headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => @avalon[:api_token] },
         verify_ssl: false
       )
-      result = JSON.parse(resp.body)
-      result['id'].present? ? URI.join(Avalon::Intercom.avalons['default']['url'], 'media_objects/', result['id']) : result
+      JSON.parse(resp.body).map{ |c| c.slice('id', 'name') }.sort_by{ |c| c["name"] }
     end
-  end
-
-  private
-
-  def get_user_collections
-    return [] unless @avalon.present?
-    uri = URI.join(@avalon[:url], 'admin/collections.json')
-    uri.query = "user=#{@user}"
-    resp = RestClient::Request.execute(
-      method: :get,
-      url: uri.to_s,
-      timeout: nil,
-      open_timeout: nil,
-      headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => target[:api_token] },
-      verify_ssl: false
-    )
-    JSON.parse(resp.body)
   end
 
 end

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -1,0 +1,63 @@
+# Copyright 2011-2017, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# require 'rest-client'
+
+module Avalon
+  class Intercom
+    @path = Rails.root.join(Settings.intercom.path) if Settings.intercom
+
+    def self.avalons
+      avalons = {}
+      if File.file?(@path)
+        yaml = YAML.safe_load(File.read(@path))
+        avalons = yaml if yaml.present?
+      end
+      avalons
+    end
+
+    def self.user_collections(user, avalon = "default")
+      target = avalons[avalon]
+      return [] unless target.present?
+      target.symbolize_keys!
+      uri = URI.join(target[:url], 'admin/collections.json')
+      uri.query = "user=#{user}"
+      resp = RestClient::Request.execute(
+        method: :get,
+        url: uri.to_s,
+        timeout: nil,
+        open_timeout: nil,
+        headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => target[:api_token] },
+        verify_ssl: false
+      )
+      JSON.parse(resp.body)
+    end
+
+    def self.push_media_object(media_object, collection_id, avalon = "default")
+      target = avalons[avalon].symbolize_keys
+      uri = URI.join(target[:url], 'media_objects.json')
+      payload = media_object.to_ingest_api_hash
+      payload[:collection_id] = collection_id
+      payload[:import_bib_record] = target[:import_bib_record]
+      payload[:publish] = target[:publish]
+      resp = RestClient::Request.execute(
+        method: :post,
+        url: uri.to_s,
+        payload: payload.to_json,
+        headers: { content_type: :json, accept: :json, :'Avalon-Api-Key' => target[:api_token] },
+        verify_ssl: false
+      )
+      JSON.parse(resp.body)
+    end
+  end
+end

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -33,7 +33,7 @@ module Avalon
 
     def push_media_object(media_object, collection_id, include_structure = true)
       return { message: 'You are not autorized to push to this collection.' } unless collection_valid? collection_id
-      return { message: 'Avalon intercom target is not configured.'} unless @avalon.present?
+      return { message: 'Avalon intercom target is not configured.' } unless @avalon.present?
       begin
         resp = RestClient::Request.execute(
           method: :post,

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -88,6 +88,23 @@ describe MediaObjectsController, type: :controller do
     end
   end
 
+  context "Avalon Intercom methods" do
+    let!(:user_collections) { [{'id' => 'abc123', 'name' => 'Test Collection'}] }
+    describe "#intercom_collections" do
+      before do
+        login_as :user
+      end
+      it "should return collections as json from target" do
+        allow_any_instance_of(Avalon::Intercom).to receive(:user_collections).and_return user_collections
+        get 'intercom_collections', format: 'json'
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(user_collections)
+        expect(session['intercom_collections']).to eq(user_collections)
+        expect(session['intercom_default_collection']).to be nil
+      end
+    end
+  end
+
   context "JSON API methods" do
     let!(:collection) { FactoryGirl.create(:collection) }
     let!(:testdir) {'spec/fixtures/'}

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -101,6 +101,9 @@ describe MediaObjectsController, type: :controller do
         }
       }
     end
+    after :all do
+      Settings.intercom = nil
+    end
 
     describe '#intercom_collections' do
       before do
@@ -598,17 +601,6 @@ describe MediaObjectsController, type: :controller do
 
   describe "#show" do
     let!(:media_object) { FactoryGirl.create(:published_media_object, visibility: 'public') }
-    before :all do
-      Settings.intercom = {
-        'default' => {
-          'url' => 'https://target.avalon.com/',
-          'api_token' => 'a_valid_token',
-          'import_bib_record' => true,
-          'publish' => false,
-          'push_label' => 'Push to Target'
-        }
-      }
-    end
 
     context "Known items should be retrievable" do
       context 'with fedora 3 pid' do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -281,10 +281,9 @@ describe MediaObjectsController, type: :controller do
         end
         it "should create a new media_object using ingest_api_hash of existing media_object" do
           # master_file_obj = FactoryGirl.create(:master_file, master_file.slice(:files))
-          media_object = FactoryGirl.create(:fully_searchable_media_object)
+          media_object = FactoryGirl.create(:fully_searchable_media_object, :with_completed_workflow)
           master_file = FactoryGirl.create(:master_file, :with_derivative, :with_thumbnail, :with_poster, :with_structure, :with_captions)
           media_object.ordered_master_files += [master_file]
-          media_object.workflow.last_completed_step = 'access-control'
           media_object.update_dependent_properties!
           api_hash = media_object.to_ingest_api_hash
           post 'create', format: 'json', fields: api_hash[:fields], files: api_hash[:files], collection_id: media_object.collection_id

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -40,9 +40,11 @@ FactoryGirl.define do
         geographic_subject { [Faker::Address.country] }
         physical_description { [Faker::Lorem.word] }
         table_of_contents { [Faker::Lorem.paragraph] }
-        note { [{note: Faker::Lorem.paragraph, type: 'general'}] }
-        other_identifier { [{id: Faker::Lorem.word, source: ['local']}] }
+        note { [{ note: Faker::Lorem.paragraph, type: 'general' }] }
+        other_identifier { [{ id: Faker::Lorem.word, source: 'local' }] }
         language { ['eng'] }
+        related_item_url { [{ url: Faker::Internet.url, label: Faker::Lorem.sentence }]}
+        bibliographic_id { { id: Faker::Lorem.word, source: 'local' } }
         # after(:create) do |mo|
         #   mo.update_datastream(:descMetadata, {
         #     note: {note[Faker::Lorem.paragraph],

--- a/spec/features/media_object_spec.rb
+++ b/spec/features/media_object_spec.rb
@@ -21,17 +21,6 @@ describe 'MediaObject' do
     @user = FactoryGirl.create(:administrator)
     login_as @user, scope: :user
   end
-  before :all do
-    Settings.intercom = {
-      'default' => {
-        'url' => 'https://target.avalon.com/',
-        'api_token' => 'a_valid_token',
-        'import_bib_record' => true,
-        'publish' => false,
-        'push_label' => 'Push to Target'
-      }
-    }
-  end
   it 'can visit a media object' do
     media_object.save
     visit media_object_url(media_object)

--- a/spec/features/media_object_spec.rb
+++ b/spec/features/media_object_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -20,6 +20,17 @@ describe 'MediaObject' do
   before :each do
     @user = FactoryGirl.create(:administrator)
     login_as @user, scope: :user
+  end
+  before :all do
+    Settings.intercom = {
+      'default' => {
+        'url' => 'https://target.avalon.com/',
+        'api_token' => 'a_valid_token',
+        'import_bib_record' => true,
+        'publish' => false,
+        'push_label' => 'Push to Target'
+      }
+    }
   end
   it 'can visit a media object' do
     media_object.save

--- a/spec/lib/avalon/intercom_spec.rb
+++ b/spec/lib/avalon/intercom_spec.rb
@@ -27,6 +27,10 @@ describe Avalon::Intercom do
       }
     }
   end
+  after :each do
+    Settings.intercom = nil
+  end
+
   let!(:username) { 'test_username' }
   let!(:user_collections) {
     [{"id"=>"cupcake_collection",

--- a/spec/lib/avalon/intercom_spec.rb
+++ b/spec/lib/avalon/intercom_spec.rb
@@ -1,0 +1,97 @@
+# Copyright 2011-2018, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+require 'avalon/intercom'
+
+describe Avalon::Intercom do
+  before :each do
+    Settings.intercom = {
+      'default' => {
+        'url' => 'https://target.avalon.com/',
+        'api_token' => 'a_valid_token',
+        'import_bib_record' => true,
+        'publish' => false,
+        'push_label' => 'Push to Target'
+      }
+    }
+  end
+  let!(:username) { 'test_username' }
+  let!(:user_collections) {
+    [{"id"=>"cupcake_collection",
+      "name"=>"The Art and History of Cupcakes",
+      "unit"=>"Default Unit",
+      "description"=>"",
+      "object_count"=>{"total"=>9, "published"=>2, "unpublished"=>7},
+      "roles"=>{"managers"=>["archivist1@example.com"], "editors"=>[], "depositors"=>[]}
+    }]
+  }
+  let!(:intercom) { Avalon::Intercom.new(username) }
+  let!(:request) {
+    stub_request(:get, "https://target.avalon.com/admin/collections.json?user=test_username").to_return(
+        status: 200,
+        body: user_collections.to_json,
+        headers: { content_type: 'application/json;' }
+      )
+  }
+
+  describe 'user_collections' do
+    it "should return correct collections for user" do
+      response = intercom.user_collections
+      expect(response).to eq([{"id"=>"cupcake_collection", "name"=>"The Art and History of Cupcakes"}])
+    end
+  end
+  describe 'collection_valid?' do
+    it "should return true for valid collection" do
+      response = intercom.collection_valid? 'cupcake_collection'
+      expect(response).to be true
+    end
+    it "should return false for invalid collection" do
+      response = intercom.collection_valid? 'invalid_collection'
+      expect(response).to be false
+    end
+  end
+  describe 'push_media_object' do
+    let(:media_object) { FactoryGirl.create(:media_object) }
+    let(:master_file_with_structure) { FactoryGirl.create(:master_file, :with_structure, media_object: media_object) }
+
+    it "should respond to unpermitted collection with error" do
+      response = intercom.push_media_object(media_object, 'invalid_collection', false)
+      expect(response[:message]).to eq('You are not autorized to push to this collection.')
+    end
+    it "should respond to unconfigured intercom with error" do
+      Settings.intercom = {}
+      response = Avalon::Intercom.new(username).push_media_object(media_object, 'cupcake_collection', false)
+      expect(response[:message]).to eq('Avalon intercom target is not configured.')
+    end
+    it "should respond to a failed api call with error" do
+      allow(RestClient::Request).to receive(:execute).and_call_original
+      allow(RestClient::Request).to receive(:execute).with(hash_including(method: :post)).and_raise(StandardError)
+      response = intercom.push_media_object(media_object, 'cupcake_collection', false)
+      expect(response).to eq({ message: 'StandardError', status: 500 })
+    end
+    it "should respond with a link to the pushed object on target" do
+      media_object.ordered_master_files=[master_file_with_structure]
+      media_object_hash = media_object.to_ingest_api_hash(false)
+      media_object_hash.merge!(
+        { 'collection_id' => 'cupcake_collection', 'import_bib_record' => true, 'publish' => false }
+      )
+      media_object_json = media_object_hash.to_json
+      stub_request(:post, "https://target.avalon.com/media_objects.json").
+        with(body: media_object_json).to_return(status: 200, body: { 'id' => 'def456' }.to_json, headers: {})
+      response = intercom.push_media_object(media_object, 'cupcake_collection', false)
+      expect(response).to eq({ link: 'https://target.avalon.com/media_objects/def456'})
+    end
+  end
+end


### PR DESCRIPTION
Provides support for an ingest API client that will allow media objects to be pushed from one Avalon instance to another. As with current use of the ingest API, this pushes not include actual derivative files, but rather it is assumed that the target Avalon will stream from the same source as the origin Avalon. 