### PR TITLE
Don't force-load all sections just to get a count

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -78,7 +78,7 @@ module MasterFileBehavior
   def display_title
     mf_title = structuralMetadata.section_title unless structuralMetadata.blank?
     mf_title ||= title if title.present?
-    mf_title ||= file_location.split("/").last if file_location.present? && (media_object.ordered_master_files.to_a.size > 1)
+    mf_title ||= file_location.split("/").last if file_location.present? && (media_object.master_file_ids.size > 1)
     mf_title.blank? ? nil : mf_title
   end
 

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -225,7 +225,8 @@ describe MasterFilesController do
 
   describe "#embed" do
     let!(:master_file) {FactoryGirl.create(:master_file)}
-    let(:media_object) { instance_double('MediaObject', title: 'Media Object', ordered_master_files: [master_file]) }
+    let(:media_object) { instance_double('MediaObject', title: 'Media Object',
+      ordered_master_files: [master_file], master_file_ids: [master_file.id]) }
     before do
       allow_any_instance_of(MasterFile).to receive(:media_object).and_return(media_object)
       disableCanCan!

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -402,6 +402,7 @@ describe MasterFile do
 
       it 'should have an appropriate title for the embed code with no label (more than 1 section)' do
         allow(subject.media_object).to receive(:ordered_master_files).and_return([subject,subject])
+        allow(subject.media_object).to receive(:master_file_ids).and_return([subject.id,subject.id])
         expect( subject.embed_title ).to eq( 'test - video.mp4' )
       end
 


### PR DESCRIPTION
`MediaObject#ordered_master_files` is expensive. `MediaObject#master_file_ids` is cheap.