### PR TITLE
Restore the FontAwesome ➡️ arrow in the margin before the active section

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -122,6 +122,7 @@ class MEJSPlayer {
    * @return {void}
    */
   getNewStreamAjax(id, url, playlistItemsT) {
+    $('.media-show-page').removeClass('ready-to-play')
     $.ajax({
       url: url + '/stream',
       dataType: 'json',
@@ -149,6 +150,7 @@ class MEJSPlayer {
   handleCanPlay() {
     this.mediaElement.removeEventListener('canplay');
     // Do we play a specified range of the media file?
+    $('.media-show-page').addClass('ready-to-play')
     if (this.switchPlayerHelper.active) {
       this.playRange();
     }
@@ -234,7 +236,7 @@ class MEJSPlayer {
         : parseFloat(this.segmentsMap[target.id].fragmentbegin);
       this.mediaElement.setCurrentTime(time);
     }
-    
+
     this.mejsUtility.showControlsBriefly(this.player);
   }
 

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_to_playlist.es6
@@ -110,14 +110,18 @@ Object.assign(MediaElementPlayer.prototype, {
     addToPlayListObj.resetForm.apply(addToPlayListObj);
 
     // Remove Add / Cancel button event listeners
-    addToPlayListObj.addButton.removeEventListener(
-      'click',
-      addToPlayListObj.bindHandleAdd
-    );
-    addToPlayListObj.cancelButton.removeEventListener(
-      'click',
-      addToPlayListObj.bindHandleCancel
-    );
+    if (addToPlayListObj.addButton !== null) {
+      addToPlayListObj.addButton.removeEventListener(
+        'click',
+        addToPlayListObj.bindHandleAdd
+      );
+    }
+    if (addToPlayListObj.cancelButton !== null) {
+      addToPlayListObj.cancelButton.removeEventListener(
+        'click',
+        addToPlayListObj.bindHandleCancel
+      );
+    }
   },
 
   // Other optional public methods (all documented according to JSDoc specifications)
@@ -201,6 +205,25 @@ Object.assign(MediaElementPlayer.prototype, {
       }
 
       return defaultTitle;
+    },
+
+    /**
+     * Checks whether the form elements which make up the Add To Playlist form are
+     * present in the DOM.  If no playlists have been created, the values will be 'null'.
+     * If playlists have been created, then the values will be DOM element references.
+     * @function formHasDefinedInputs
+     * @return {Boolean} Does the Add to Playlist form have DOM element inputs?
+     */
+    formHasDefinedInputs: function() {
+      let hasInputs = true;
+      const formInputs = this.formInputs;
+
+      for (let prop in formInputs) {
+        if (!formInputs[prop]) {
+          hasInputs = false;
+        }
+      }
+      return hasInputs;
     },
 
     /**
@@ -312,7 +335,7 @@ Object.assign(MediaElementPlayer.prototype, {
     /**
      * Handle click events on the Sections and structural metadata links.
      * @function handleSectionLinkClick
-     * @param  {MouseEvent} e [description]
+     * @param  {MouseEvent} e
      * @return {void}
      */
     handleSectionLinkClick: function(e) {
@@ -323,7 +346,7 @@ Object.assign(MediaElementPlayer.prototype, {
         // because if it's a different player type (ie. say audio, then the form
         // will be reset automatically)
         const incomingIsVideo = e.target.dataset['isVideo'] === 'true';
-        if (incomingIsVideo === addToPlayListObj.isVideo) {
+        if (addToPlayListObj.formHasDefinedInputs() && incomingIsVideo === addToPlayListObj.isVideo) {
           addToPlayListObj.populateFormValues.apply(this);
         }
       }
@@ -371,7 +394,7 @@ Object.assign(MediaElementPlayer.prototype, {
       let formInputs = t.formInputs;
 
       for (let prop in formInputs) {
-        if (prop !== 'playlist') {
+        if (formInputs[prop] !== null && prop !== 'playlist') {
           formInputs[prop].value = '';
         }
       }

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -622,23 +622,14 @@ Object.assign(MediaElementPlayer.prototype, {
       const liItems = this.$sidePlaylist[0].getElementsByTagName('li');
       let array = [...liItems];
       let clickedEl = el.parentNode;
-      const arrowNode = document.createElement('i');
-
-      arrowNode.className = `fa fa-arrow-circle-right`;
 
       // Loop through all children list items
       array.forEach(li => {
-        const children = [...li.children];
-        let arrow = children.find(e => e.nodeName === 'I');
         // Remove styles
         li.classList.remove('now_playing');
         li.classList.remove('queue');
-        if (arrow) {
-          li.removeChild(arrow);
-        }
         // Conditionally add styles to the item clicked
         if (li === clickedEl) {
-          li.insertBefore(arrowNode, el);
           li.classList.add('now_playing');
         } else {
           li.classList.add('queue');

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -853,10 +853,10 @@ $accordionPadding: 20px;
   }
 }
 
-@mixin current-stream-indicator($margin) {
+@mixin current-stream-indicator($margin, $left: -6px) {
   @extend #{'.fa','.fa-arrow-circle-right'};
   position: relative;
-  left: -6px;
+  left: $left;
   margin-left: $margin;
 }
 
@@ -1103,8 +1103,12 @@ h5.panel-title {
   padding-left: 2rem;
   li {
     margin-top: .2em;
+    margin-left: 21px;
     float: left;
     width:100%;
+    &.now_playing:before {
+      @include current-stream-indicator(-16px, -24px);
+    }
 
     i {
       margin-right: 3px;
@@ -1115,6 +1119,7 @@ h5.panel-title {
   }
   .pull-right {
     text-align:right;
+    margin-right: 21px;
   }
 }
 #section-label {

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -853,12 +853,32 @@ $accordionPadding: 20px;
   }
 }
 
+@mixin current-stream-indicator($margin) {
+  @extend #{'.fa','.fa-arrow-circle-right'};
+  position: relative;
+  left: -6px;
+  margin-left: $margin;
+}
+
+.ready-to-play {
+  .structure.current-stream:before {
+    @include current-stream-indicator(-12px);
+  }
+
+  .current-section:before {
+    @include current-stream-indicator(-15px);
+  }
+
+  .current-section, .current-stream {
+    font-weight: bold;
+    border-radius: 3px;
+    margin-left: -5px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+}
+
 .current-section, .current-stream {
-  font-weight: bold;
-  border-radius: 3px;
-  margin-left: -5px;
-  padding-left: 5px;
-  padding-right: 5px;
   &:link { @hidden-disabled-link }
   &:hover { @hidden-disabled-link }
   &:active { @hidden-disabled-link }

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -226,7 +226,7 @@ EOF
          url = "#{share_link_for( section )}?t=#{start},#{stop}"
          segment_id = "#{section.id}-#{tracknumber}"
          data = {segment: section.id, is_video: section.file_format != 'Sound', native_url: native_url, fragmentbegin: start, fragmentend: stop}
-         link = link_to label, url, id: segment_id, data: data, class: 'playable wrap'+(is_current_section?(section) ? ' current-stream' : '' )
+         link = link_to label, url, id: segment_id, data: data, class: 'playable structure wrap'
          return "<li class='stream-li'>#{link}</li>", tracknumber
        end
      end


### PR DESCRIPTION
Restores the `fa-arrow-circle-right` glyph to the section list in front of the currently playing section.

Before PR:
![no arrow](https://user-images.githubusercontent.com/196872/35468158-2373351e-02de-11e8-926f-e509f4ef13f6.png)

After PR:
![arrow](https://user-images.githubusercontent.com/196872/35468174-8d9363c4-02de-11e8-87e9-d201865e865c.png)

Unlike the Avalon pre-6.3 version of this effect, it's entirely CSS-driven with no DOM manipulation.