### PR TITLE
Speed up view page by avoiding rescue handling and duplicate calls

### DIFF
--- a/spec/helpers/media_objects_helper_spec.rb
+++ b/spec/helpers/media_objects_helper_spec.rb
@@ -37,4 +37,26 @@ describe MediaObjectsHelper do
       expect(helper.current_quality(skip_transcoded_stream_info)).to eq 'high'
     end
   end
+
+  describe "#parse_hour_min_sec" do
+    it "returns a milliseconds representation" do
+      expect(helper.parse_hour_min_sec("00:00:01")).to eq 1.0
+      expect(helper.parse_hour_min_sec("00:00:01.259")).to eq 1.259
+      expect(helper.parse_hour_min_sec("00:01:01.259")).to eq 61.259
+      expect(helper.parse_hour_min_sec("00:10:11.259")).to eq 611.259
+      expect(helper.parse_hour_min_sec("1:10:11.259")).to eq 4211.259
+      expect(helper.parse_hour_min_sec("10:11.259")).to eq 611.259
+      expect(helper.parse_hour_min_sec("11.259")).to eq 11.259
+      expect(helper.parse_hour_min_sec("xx:11.259")).to eq 11.259
+      expect(helper.parse_hour_min_sec("hello")).to eq 0.0
+    end
+  end
+
+  describe "#get_duration_from_fragment" do
+    it "returns a human readable duration" do
+      expect(helper.get_duration_from_fragment(0, 100)).to eq "01:40"
+      expect(helper.get_duration_from_fragment(100, 200)).to eq "01:40"
+      expect(helper.get_duration_from_fragment(100, 20000)).to eq "5:31:40"
+    end
+  end
 end


### PR DESCRIPTION
These two changes help further speed up the view page when a large number of sections have structural metadata.  Together they may save around 1 sec for a 88-section item making it return in around 2-3.5 seconds.  At this point, there probably isn't significant gains that can be obtained without larger changes.