### PR TITLE
Avoid duplicate stream token entries in the session

### DIFF
--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -30,6 +30,7 @@ class StreamToken < ActiveRecord::Base
     result = find_or_create_by!(token: hash_token.to_s, target: target)
     result.renew!
     session[:hash_tokens] << result.token
+    session[:hash_tokens].uniq! # Avoid duplicate entry
     result.token
   end
 

--- a/spec/models/stream_token_spec.rb
+++ b/spec/models/stream_token_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -22,6 +22,18 @@ describe StreamToken do
 
     it 'should create a token' do
       expect(StreamToken.find_or_create_session_token(session, target)).to match(/^[0-9a-f]{40}$/)
+    end
+
+    it 'stores the token in the session' do
+      token = StreamToken.find_or_create_session_token(session, target)
+      expect(session[:hash_tokens]).to include token
+    end
+
+    it 'stores the token once in the session' do
+      token = StreamToken.find_or_create_session_token(session, target)
+      token2 = StreamToken.find_or_create_session_token(session, target)
+      expect(token).to eq token2
+      expect(session[:hash_tokens].count(token)).to eq 1
     end
   end
 


### PR DESCRIPTION
This helps with the session overflow error we're seeing sparsely in production.  We'll still need to think about bumping up the session size to avoid these errors when a user visits many items during their session and within the timeout window of the stream tokens.