### PR TITLE
Use bootsnap to make app loading 50% faster

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Core rails
 gem 'rails', '4.2.9'
 gem 'sqlite3'
+gem 'bootsnap', require: false
 
 # Assets
 gem 'coffee-rails', '~> 4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,8 @@ GEM
       blacklight (~> 6.0)
       cancancan (~> 1.8)
       deprecation (~> 1.0)
+    bootsnap (1.2.1)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -857,6 +859,7 @@ DEPENDENCIES
   aws-sdk-rails
   bixby
   blacklight (= 6.11.0)
+  bootsnap
   bootstrap-toggle-rails!
   bootstrap_form
   browse-everything (~> 0.13.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
Bootsnap will be included in the default Gemfile in Rails 5.2.  It works on linux and macos so this should be tested on windows before merge (if we need to support windows native development environments instead of our current docker approach).  Bootsnap works with spring and isn't a replacement for it.

This will be helpful for many reasons.  One being our cron tasks like batch ingest which has to load the rails app every minute.

Here is the results from a quick test I ran.
Without bootsnap:
```
time rails r "exit"
/Users/cjcolvar/Documents/Code/avalon/avalon-6-fresh/config/initializers/fixnum_to_hms.rb:1: warning: constant ::Fixnum is deprecated

real	0m8.774s
user	0m5.253s
sys	0m2.976s
```

With bootsnap (first run):
```
time rails r "exit"
/Users/cjcolvar/Documents/Code/avalon/avalon-6-fresh/config/initializers/fixnum_to_hms.rb:1: warning: constant ::Fixnum is deprecated

real	0m9.355s
user	0m6.292s
sys	0m2.562s
```

With bootsnap (subsequent runs):
```
time rails r "exit"
/Users/cjcolvar/Documents/Code/avalon/avalon-6-fresh/config/initializers/fixnum_to_hms.rb:1: warning: constant ::Fixnum is deprecated

real	0m3.459s
user	0m2.916s
sys	0m0.499s
```