### PR TITLE
Throttling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
 bundler_args: --with postgres aws --without development debug
 services:
   - mysql2
+  - redis-server
 before_install:
   - sudo rm -vf /etc/apt/sources.list.d/*riak*
   - sudo rm -vf /etc/apt/sources.list.d/*hhvm*

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'mediaelement-track-scrubber', git: 'https://github.com/avalonmediasystem/me
 gem 'redis-rails'
 gem 'resque', '~> 1.27.0'
 gem 'resque-scheduler', '~> 4.3.0'
+gem 'activejob-traffic_control'
 
 # Coding Patterns
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,10 @@ GEM
     activejob (4.2.9)
       activesupport (= 4.2.9)
       globalid (>= 0.3.0)
+    activejob-traffic_control (0.1.3)
+      activejob (>= 4.2)
+      activesupport (>= 4.2)
+      suo
     activemodel (4.2.9)
       activesupport (= 4.2.9)
       builder (~> 3.1)
@@ -320,6 +324,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
     daemons (1.2.4)
+    dalli (2.7.6)
     database_cleaner (1.6.1)
     debug_inspector (0.0.3)
     declarative (0.0.10)
@@ -511,6 +516,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.0)
     mono_logger (1.1.0)
+    msgpack (1.2.0)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -780,6 +786,10 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stomp (1.4.4)
+    suo (0.3.2)
+      dalli
+      msgpack
+      redis
     sxp (1.0.0)
       rdf (~> 2.0)
     temple (0.8.0)
@@ -837,6 +847,7 @@ DEPENDENCIES
   active_encode (~> 0.1.1)
   active_fedora-datastreams
   active_fedora-noid (~> 2.0.2)
+  activejob-traffic_control
   activerecord-session_store
   acts_as_list
   api-pagination

--- a/app/jobs/active_encode_job.rb
+++ b/app/jobs/active_encode_job.rb
@@ -33,6 +33,8 @@ module ActiveEncodeJob
   class Create < ActiveJob::Base
     include ActiveEncodeJob::Core
     queue_as :active_encode_create
+    throttle threshold: Settings.encode_throttling.create_jobs_throttle_threshold, period: Settings.encode_throttling.create_jobs_spacing, drop: false
+
     def perform(master_file_id, input, options)
       mf = MasterFile.find(master_file_id)
       encode = mf.encoder_class.new(input, options.merge({output_key_prefix: "#{mf.id}/"}))
@@ -51,7 +53,7 @@ module ActiveEncodeJob
   class Update < ActiveJob::Base
     include ActiveEncodeJob::Core  #I'm not sure if the error callback is really makes sense here!
     queue_as :active_encode_update
-    throttle threshold: Settings.batch_throttling.update_jobs_throttle_threshold, period: Settings.batch_throttling.update_jobs_spacing, drop: false
+    throttle threshold: Settings.encode_throttling.update_jobs_throttle_threshold, period: Settings.encode_throttling.update_jobs_spacing, drop: false
 
     def perform(master_file_id)
       Rails.logger.info "Updating encode progress for MasterFile: #{master_file_id}"

--- a/app/jobs/active_encode_job.rb
+++ b/app/jobs/active_encode_job.rb
@@ -51,6 +51,8 @@ module ActiveEncodeJob
   class Update < ActiveJob::Base
     include ActiveEncodeJob::Core  #I'm not sure if the error callback is really makes sense here!
     queue_as :active_encode_update
+    throttle threshold: Settings.batch_throttling.update_jobs_throttle_threshold, period: Settings.batch_throttling.update_jobs_spacing, drop: false
+
     def perform(master_file_id)
       Rails.logger.info "Updating encode progress for MasterFile: #{master_file_id}"
       mf = MasterFile.find(master_file_id)

--- a/app/jobs/ingest_batch_entry_job.rb
+++ b/app/jobs/ingest_batch_entry_job.rb
@@ -14,10 +14,6 @@
 
 class IngestBatchEntryJob < ActiveJob::Base
   queue_as :ingest
-  # Throttle to this per second to stay within limit
-  # for submitting to AWS Elastic Transcoder
-  # https://docs.aws.amazon.com/elastictranscoder/latest/developerguide/limits.html
-  throttle threshold: Settings.batch_throttling.ingest_jobs_throttle_threshold, period: Settings.batch_throttling.ingest_jobs_spacing.seconds, drop: false
 
   # ActiveJob will serialize/deserialize the batch_entry automatically using GlobalIDs
   def perform(batch_entry)

--- a/app/jobs/ingest_batch_entry_job.rb
+++ b/app/jobs/ingest_batch_entry_job.rb
@@ -14,6 +14,10 @@
 
 class IngestBatchEntryJob < ActiveJob::Base
   queue_as :ingest
+  # Throttle to this per second to stay within limit
+  # for submitting to AWS Elastic Transcoder
+  # https://docs.aws.amazon.com/elastictranscoder/latest/developerguide/limits.html
+  throttle threshold: Settings.batch_throttling.ingest_jobs_throttle_threshold, period: Settings.batch_throttling.ingest_jobs_spacing.seconds, drop: false
 
   # ActiveJob will serialize/deserialize the batch_entry automatically using GlobalIDs
   def perform(batch_entry)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,7 @@ module Avalon
         db: 0,
         namespace: 'avalon'
       }
+      ActiveJob::TrafficControl.client = Redis.new(config.cache_store[1])
     end
 
     config.action_dispatch.default_headers = { 'X-Frame-Options' => 'ALLOWALL' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,6 +58,11 @@ bib_retriever:
   query: rec.id='%s'
 controlled_vocabulary:
   path: config/controlled_vocabulary.yml
+encode_throttling:
+  create_jobs_throttle_threshold: 2
+  create_jobs_spacing: 5
+  update_jobs_throttle_threshold: 3
+  update_jobs_spacing: 10
 auth:
   configuration:
     - :name: Avalon Test Auth


### PR DESCRIPTION
Cherry-pick of NU's throttling commit and refocused to more generic active encode job throttling (to be useful when using either Elastic Transcoder or Matterhorn adapters for active_encode).

Related to https://github.com/avalonmediasystem/avalon/issues/2770.