### PR TITLE
Remove quality feature for IE

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -447,6 +447,13 @@ class MEJSPlayer {
       ? [this.playlistItem.playlist_id, this.playlistItem.id]
       : [];
 
+    // Remove quality feature for IE
+    if (!!navigator.userAgent.match(/MSIE /) || !!navigator.userAgent.match(/Trident.*rv\:11\./)) {
+      defaults.features = defaults.features.filter(
+        e => e !== 'quality'
+      );
+    }
+
     // Remove video player controls/plugins if it's not a video stream
     if (!currentStreamInfo.is_video) {
       defaults.features = defaults.features.filter(


### PR DESCRIPTION
Fixes #2661 

Removes quality feature on IE browsers.

There is a bug in the upstream MEJS quality plugin that causes the player to fail to load on IE.