### PR TITLE
Warn user about large upload sets and prevent re-tries with modal

### DIFF
--- a/app/assets/javascripts/file_browse.js.coffee
+++ b/app/assets/javascripts/file_browse.js.coffee
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -19,6 +19,13 @@ $ ->
   initialized = false
   $('#browse-btn').browseEverything()
     .show ->
+      alertMsg = $('<div>')
+        .html('Warning! Uploading too many files at once can lead to ingest failures.')
+        .addClass('alert')
+        .addClass('alert-danger')
+        .css('margin','3px')
+        .css('text-align','center')
+      $('.ev-body').prepend(alertMsg)
       unless $('#browse-everything input[name=workflow]').length > 0
         skip_box = $('#web_upload input[name=workflow]').closest('span')
           .clone().removeClass().css('margin-right','10px')
@@ -26,7 +33,8 @@ $ ->
 
       $('.ev-providers .ev-container a').click()
       initialized = true
-    .done (data) -> 
+    .done (data) ->
       if data.length > 0
+        $('#uploading').modal('show')
         $('#dropbox_form input[name=workflow]').val($('#browse-everything input[name=workflow]:checked').val())
-        $('#dropbox_form').submit() 
+        $('#dropbox_form').submit()


### PR DESCRIPTION
Fixes #2811 

Adds warning to dropbox modal about uploading too many files.
Displays "Uploading" modal to prevent further concurrent uploads.