### PR TITLE
Update API for new comment fields

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -225,7 +225,7 @@ class MediaObjectsController < ApplicationController
       error_messages += ['Failed to create media object:']+@media_object.errors.full_messages
     elsif master_files_params.respond_to?('each')
       old_ordered_master_files = @media_object.ordered_master_files.to_a.collect(&:id)
-      master_files_params.each do |file_spec|
+      master_files_params.each_with_index do |file_spec, index|
         master_file = MasterFile.new(file_spec.except(:structure, :captions, :captions_type, :files, :other_identifier, :label))
         # master_file.media_object = @media_object
         master_file.structuralMetadata.content = file_spec[:structure] if file_spec[:structure].present?
@@ -236,7 +236,8 @@ class MediaObjectsController < ApplicationController
         # TODO: This inconsistency should eventually be addressed by updating the API
         master_file.title = file_spec[:label] if file_spec[:label].present?
         master_file.date_digitized = DateTime.parse(file_spec[:date_digitized]).to_time.utc.iso8601 if file_spec[:date_digitized].present?
-        master_file.identifier += Array(file_spec[:other_identifier])
+        master_file.identifier += Array(params[:files][index][:other_identifier])
+        master_file.comment += Array(params[:files][index][:comment])
         master_file._media_object = @media_object
         if file_spec[:files].present?
           if master_file.update_derivatives(file_spec[:files], false)
@@ -583,23 +584,23 @@ class MediaObjectsController < ApplicationController
                              :other_identifier,
                              :structure,
                              :physical_description,
-                             :files => [:label,
-                                        :id,
-                                        :url,
-                                        :hls_url,
-                                        :duration,
-                                        :mime_type,
-                                        :audio_bitrate,
-                                        :audio_codec,
-                                        :video_bitrate,
-                                        :video_codec,
-                                        :width,
-                                        :height,
-                                        :location,
-                                        :track_id,
-                                        :hls_track_id,
-                                        :managed,
-                                        :derivativeFile]])[:files]
+                             files: [:label,
+                                     :id,
+                                     :url,
+                                     :hls_url,
+                                     :duration,
+                                     :mime_type,
+                                     :audio_bitrate,
+                                     :audio_codec,
+                                     :video_bitrate,
+                                     :video_codec,
+                                     :width,
+                                     :height,
+                                     :location,
+                                     :track_id,
+                                     :hls_track_id,
+                                     :managed,
+                                     :derivativeFile]])[:files]
   end
 
   def api_params

--- a/app/models/concerns/master_file_intercom.rb
+++ b/app/models/concerns/master_file_intercom.rb
@@ -34,6 +34,7 @@ module MasterFileIntercom
       other_identifier: identifier,
       captions: captions.content,
       captions_type: caption_type,
+      comment: comment,
       files: derivatives.collect(&:to_ingest_api_hash)
     }
   end

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -46,6 +46,7 @@ module MediaObjectIntercom
           table_of_contents: table_of_contents,
           physical_description: physical_description,
           record_identifier: record_identifier,
+          comment: comment,
           bibliographic_id: (bibliographic_id.present? ? bibliographic_id[:id] : nil),
           bibliographic_id_label: (bibliographic_id.present? ? bibliographic_id[:source] : nil),
           note: (note.present? ? note.collect { |n| n[:note] } : nil),

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -357,8 +357,7 @@ describe MediaObjectsController, type: :controller do
         it "should create a new media_object using ingest_api_hash of existing media_object" do
           # master_file_obj = FactoryGirl.create(:master_file, master_file.slice(:files))
           media_object = FactoryGirl.create(:fully_searchable_media_object, :with_completed_workflow)
-          master_file = FactoryGirl.create(:master_file, :with_derivative, :with_thumbnail, :with_poster, :with_structure, :with_captions)
-          media_object.ordered_master_files += [master_file]
+          master_file = FactoryGirl.create(:master_file, :with_derivative, :with_thumbnail, :with_poster, :with_structure, :with_captions, :with_comments, media_object: media_object)
           media_object.update_dependent_properties!
           api_hash = media_object.to_ingest_api_hash
           post 'create', format: 'json', fields: api_hash[:fields], files: api_hash[:files], collection_id: media_object.collection_id
@@ -372,6 +371,7 @@ describe MediaObjectsController, type: :controller do
           expect(new_media_object.format).to eq media_object.format
           expect(new_media_object.note).to eq media_object.note
           expect(new_media_object.language).to eq media_object.language
+          expect(new_media_object.all_comments).to eq media_object.all_comments
           expect(new_media_object.bibliographic_id).to eq media_object.bibliographic_id
           expect(new_media_object.related_item_url).to eq media_object.related_item_url
           expect(new_media_object.other_identifier).to eq media_object.other_identifier

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -19,6 +19,7 @@ FactoryGirl.define do
     percent_complete {"#{rand(100)}"}
     workflow_name 'avalon'
     duration {'200000'}
+    identifier ['other identifier']
 
     trait :with_media_object do
       association :media_object #, factory: :media_object
@@ -56,6 +57,9 @@ FactoryGirl.define do
         mf.captions.content = File.read('spec/fixtures/captions.vtt')
         mf.save
       end
+    end
+    trait :with_comments do
+      comment ['MF Comment 1', 'MF Comment 2']
     end
   end
 end

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -45,6 +45,7 @@ FactoryGirl.define do
         language { ['eng'] }
         related_item_url { [{ url: Faker::Internet.url, label: Faker::Lorem.sentence }]}
         bibliographic_id { { id: Faker::Lorem.word, source: 'local' } }
+        comment { ['MO comment'] }
         # after(:create) do |mo|
         #   mo.update_datastream(:descMetadata, {
         #     note: {note[Faker::Lorem.paragraph],


### PR DESCRIPTION
Adds new comment fields to api for media_objects and master_files.

Rails strong parameters weren't working correctly for scalar array fields nested within hashes (comments and other_identifiers), so refer to those fields directly.