### PR TITLE
Exclude HDToggle feature for embedded audio

### DIFF
--- a/app/views/master_files/_mejs4_player_js.html.erb
+++ b/app/views/master_files/_mejs4_player_js.html.erb
@@ -6,10 +6,12 @@
 <% end %>
 
 <script>
+<%# Do not include quality or HDtoggle feature for embedded audio because adaptive streaming %>
+<% quality_feature = section_info[:is_video] ? "'quality', " : '' %>
 <!-- Missing title and logo features -->
 var mejs4AvalonPlayer = new MEJSPlayer({
   currentStreamInfo: <%= section_info.to_json.html_safe %>,
-  features: ['playpause', 'current', 'progress', 'duration', 'volume', 'tracks', '<%= section_info[:is_video] ? "quality" : "hdToggle" %>', 'linkBack', 'fullscreen'],
+  features: ['playpause', 'current', 'progress', 'duration', 'volume', 'tracks', <%= quality_feature.html_safe %>'linkBack', 'fullscreen'],
   highlightRail: true,
   defaultQuality: '<%= current_quality(section_info) %>'
 });


### PR DESCRIPTION
Fixes #2866 

Because adaptive streaming adds 'auto' quality for any section that has more than one derivative, and because we don't want the HDToggle selector for embedded audio with adaptive streaming, never include HDToggle feature for embedded audio.