### PR TITLE
Be able to add options to ActiveFedora request

### DIFF
--- a/config/initializers/active_fedora_request_options.rb
+++ b/config/initializers/active_fedora_request_options.rb
@@ -1,0 +1,14 @@
+class ActiveFedora::Fedora
+  def request_options
+    @config[:request]
+  end
+
+  def authorized_connection
+    options = {}
+    options[:request] = request_options if request_options
+    connection = Faraday.new(host, options)
+    connection.basic_auth(user, password)
+    connection
+  end
+end
+


### PR DESCRIPTION
For example:
  `request: { timeout: 2000, open_timeout: 100}`