### PR TITLE
Strip leading and trailing whitespace from related item urls

### DIFF
--- a/app/models/concerns/media_object_mods.rb
+++ b/app/models/concerns/media_object_mods.rb
@@ -338,7 +338,7 @@ module MediaObjectMods
 
   # has_attributes :related_item_url, datastream: :descMetadata, at: [:related_item_url], multiple: true
   def related_item_url
-    descMetadata.related_item_url.zip(descMetadata.related_item_label).map{|a|{url: a[0],label: a[1]}}
+    descMetadata.related_item_url.zip(descMetadata.related_item_label).map{|a|{url: a[0].strip, label: a[1]}}
   end
 
   def related_item_url=(value_hashes)

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -783,4 +783,27 @@ describe MediaObject do
       expect(media_object.workflow.original_name).to eq 'workflow.xml'
     end
   end
+
+  describe '#related_item_url' do
+    let(:media_object) { FactoryGirl.build(:media_object) }
+    let(:url) { 'http://example.com/' }
+
+    before do
+      media_object.descMetadata.content = <<~EOF
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+          <relatedItem displayLabel="Program">
+            <location>
+              <url>
+                http://example.com/
+              </url>
+            </location>
+          </relatedItem>
+        </mods>
+      EOF
+    end
+
+    it 'strips trailing new line characters' do
+      expect(media_object.related_item_url.first[:url]).to eq url
+    end
+  end
 end


### PR DESCRIPTION
Without this links maybe incorrect in the UI with trailing url encoded whitespace.

Fixes #2888.