### PR TITLE
Find `lsof`, if available.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/lib/avalon/batch.rb
+++ b/lib/avalon/batch.rb
@@ -23,9 +23,6 @@ require "timeout"
 
 module Avalon
   module Batch
-    class Error < StandardError; end
-    class IncompletePackageError < StandardError; end
-
     def self.find_open_files(files, base_directory = '.')
       found_files = []
       lsof = find_lsof

--- a/lib/avalon/batch.rb
+++ b/lib/avalon/batch.rb
@@ -23,6 +23,8 @@ require "timeout"
 
 module Avalon
   module Batch
+    # Breaking the next method up further would only obscure logic
+    # rubocop:disable Metrics/MethodLength
     def self.find_open_files(files, base_directory = '.')
       found_files = []
       lsof = find_lsof
@@ -41,9 +43,10 @@ module Avalon
         rescue Timeout::Error
           Rails.logger.warn('lsof blocking; continuing without open file checking')
         end
-        found_files
       end
+      found_files
     end
+    # rubocop:enable Metrics/MethodLength
 
     def self.find_lsof
       (['/usr/sbin', '/usr/bin'] + ENV['PATH'].split(File::PATH_SEPARATOR))


### PR DESCRIPTION
Ubuntu recently moved `lsof` from `/usr/sbin` to `/usr/bin`, breaking some avalon code on that platform.
Also, the back tick operator doesn't always raise `Errno::ENOENT` when a command isn't found, e.g.,

```
$ irb
2.4.1 :001 > `/usr/sbin/lsof`
Errno::ENOENT: No such file or directory - /usr/sbin/lsof
        from (irb):1:in ``'
        from (irb):1
        from /home/cwant/.rvm/rubies/ruby-2.4.1/bin/irb:11:in `<main>'
2.4.1 :002 > 

$ bundle exec rails c     
/home/cwant/gitwork/avalon-6.3/config/initializers/fixnum_to_hms.rb:1: warning: constant ::Fixnum is deprecated         
Loading development environment (Rails 4.2.9)               
[1] pry(main)> `/usr/sbin/lsof`                             
bin/rails: No such file or directory - /usr/sbin/lsof       
=> nil                        
```
(irb raises an error, rails doesn't)

This pull request makes avalon explicitly search for `lsof` rather than looking for it at a hard-coded path and trying to catch an error when it's not found there.
