### PR TITLE
Move cache_store and TrafficControl config to initializers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,16 +35,6 @@ module Avalon
 
     config.active_job.queue_adapter = :resque
 
-    redis_host = Settings.redis.host
-    redis_port = Settings.redis.port || 6379
-    config.cache_store = :redis_store, {
-      host: redis_host,
-      port: redis_port,
-      db: 0,
-      namespace: 'avalon'
-    }
-    ActiveJob::TrafficControl.client = Redis.new(config.cache_store[1])
-
     config.action_dispatch.default_headers = { 'X-Frame-Options' => 'ALLOWALL' }
   end
 end

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,0 +1,11 @@
+config = Rails.application.config
+
+redis_host = Settings.redis.host
+redis_port = Settings.redis.port || 6379
+config.cache_store = :redis_store, {
+  host: redis_host,
+  port: redis_port,
+  db: 0,
+  namespace: 'avalon'
+}
+

--- a/config/initializers/traffic_control.rb
+++ b/config/initializers/traffic_control.rb
@@ -1,0 +1,3 @@
+# This initializer depends on the cache_store initializer being run first and the cache store being redis
+ActiveJob::TrafficControl.client = Redis.new(Rails.application.config.cache_store[1])
+


### PR DESCRIPTION
The problem is environment variables not able to override Settings config at the stage where application.rb is loaded, thus I couldn't change the Redis host to something that's not "localhost".