### PR TITLE
Fix adaptive streaming hls playlists when using Wowza and native playback

### DIFF
--- a/app/views/master_files/hls_adaptive_manifest.m3u8.erb
+++ b/app/views/master_files/hls_adaptive_manifest.m3u8.erb
@@ -1,5 +1,5 @@
 #EXTM3U
 <% @hls_streams.each do |hls| %>
-#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=<%= hls[:bitrate] %>
+#EXT-X-STREAM-INF:BANDWIDTH=<%= hls[:bitrate] %>
 <%= hls[:url] %>
 <% end %>

--- a/lib/avalon/m3u8_reader.rb
+++ b/lib/avalon/m3u8_reader.rb
@@ -17,75 +17,72 @@ require 'uri'
 
 module Avalon
   class M3U8Reader
-
     attr_reader :playlist
 
     def self.read(io, recursive: true)
       if io.is_a?(IO)
-        self.new(io.read, recursive: recursive)
+        new(io.read, recursive: recursive)
       elsif io.is_a?(String)
         if io =~ /^https?:/
-          open(io) { |resp| self.new(resp, URI.parse(io), recursive: recursive) }
+          open(io) { |resp| new(resp, URI.parse(io), recursive: recursive) }
         elsif io =~ /\.m3u8?$/i
-          self.new(File.read(io), io, recursive: recursive)
+          new(File.read(io), io, recursive: recursive)
         else
-          self.new(io, recursive: recursive)
+          new(io, recursive: recursive)
         end
       end
     end
 
-    def initialize(playlist, base='', recursive: true)
+    def initialize(playlist, base = '', recursive: true)
       @base = base
       @playlist = { files: [], playlists: [] }
       tags = {}
-      playlist.lines.each { |l|
+      playlist.lines.each do |l|
         line = l.chomp
         if line =~ /^#EXTM3U/
           # ignore
         elsif line =~ /^#EXT-X-(.+):(.+)$/
-          value = $2
-          tag = $1.downcase.gsub(/-/,"_")
+          value = Regexp.last_match(2)
+          tag = Regexp.last_match(1).downcase.tr('-', "_")
           @playlist[tag] = value
         elsif line =~ /^#EXTINF:(.+),(.*)$/
-          tags[:duration] = $1.to_f
-          tags[:title] = $2
+          tags[:duration] = Regexp.last_match(1).to_f
+          tags[:title] = Regexp.last_match(2)
         elsif line =~ /\.m3u8?.*$/i && recursive
-          url = @base.is_a?(URI) ? @base.merge(line).to_s : File.expand_path(line,@base.to_s)
+          url = @base.is_a?(URI) ? @base.merge(line).to_s : File.expand_path(line, @base.to_s)
           @playlist.merge!(Avalon::M3U8Reader.read(url).playlist)
         elsif line =~ /\.m3u8?.*$/i
-          url = @base.is_a?(URI) ? @base.merge(line).to_s : File.expand_path(line,@base.to_s)
+          url = @base.is_a?(URI) ? @base.merge(line).to_s : File.expand_path(line, @base.to_s)
           @playlist[:playlists] << url
         elsif line =~ /^[^#]/
           tags[:filename] = line
           @playlist[:files] << tags
           tags = {}
         end
-      }
+      end
     end
 
     def duration
-      files.inject(0.0) { |v,f| v + f[:duration] }
+      files.inject(0.0) { |v, f| v + f[:duration] }
     end
 
     def at(offset)
       offset = offset.to_i
-      if offset < 0
-        raise RangeError, "Offset out of range"
-      end
+      raise RangeError, "Offset out of range" if offset < 0
       elapsed = 0.0
-      files.each { |f|
+      files.each do |f|
         duration = f[:duration] * 1000
         if elapsed + duration > offset
-          location = @base.is_a?(URI) ? @base.merge(f[:filename]).to_s : File.expand_path(f[:filename],@base.to_s)
+          location = @base.is_a?(URI) ? @base.merge(f[:filename]).to_s : File.expand_path(f[:filename], @base.to_s)
           return { location: location, filename: f[:filename], offset: offset - elapsed }
         end
         elapsed += duration
-      }
+      end
       raise RangeError, "Offset out of range"
     end
 
     def method_missing(sym, *args)
-      if @playlist.has_key?(sym)
+      if @playlist.key?(sym)
         @playlist[sym]
       else
         super


### PR DESCRIPTION
Avalon's naive adaptive streaming hls master playlists are broken because HLS client implementations only follow one level of nesting of m3u8 playlists and Wowza only returns a master playlist with a playlist reference inside (instead of the child .ts files).  See https://www.wowza.com/docs/how-to-troubleshoot-apple-hls-playback#callflow.

This PR fetches the wowza playlists, parses them, and passes that info along to the Avalon adaptive streaming hls manifest generator.  This is a non-ideal approach but is workable at the moment.  This request takes between 0.5 and 1.5 seconds to return and appears to be run for every page load.

This PR also removes the PROGRAM-ID from the hls manifest since it isn't necessary and is listed as deprecated by the Apple hls stream validator. (Tool available with Apple Developer ID at https://developer.apple.com/go/?id=http-live-streaming-tools)

IU will test locally and if successful this PR can be merged.