### PR TITLE
Delete the manifest file after read and before any processing has happened...

### DIFF
--- a/lib/avalon/batch/ingest.rb
+++ b/lib/avalon/batch/ingest.rb
@@ -64,6 +64,9 @@ module Avalon
           @current_package = package
         end
 
+        # We have a valid batch so we can go ahead and delete the manifest file
+        @current_package.manifest.delete
+
         br = register_batch unless replay?
         br = register_replay if replay?
         @current_batch_registry = br.reload
@@ -81,7 +84,6 @@ module Avalon
         else
           logger.error "Persisting BatchRegistry failed for package #{@current_package.title}"
         end
-        @current_package.manifest.delete
       end
 
       # Register the individual rows on a spreadsheet for a valid package


### PR DESCRIPTION
...to avoid race condition or missing deleting it due to uncaught errors.

Fixes #2916.

This was tested on pawpaw and proven to avoid the infinite loop.  This needs additional testing to ensure the change is safe.  The only concern I have is that maybe the manifest is being deleted off too prematurely and if a DB error happens it might leave no trace of the package either on the file system or DB.

I wonder if there are issues with sending email on pawpaw that are the underlying cause that surfaced this issue.