### PR TITLE
Let docker compose find FFMPEG (for poster/thumbs) in the avalon container.

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -558,6 +558,9 @@ class MasterFile < ActiveFedora::Base
 
   def get_ffmpeg_frame_data frame_source, new_width, new_height
     ffmpeg = Settings.ffmpeg.path
+    unless File.executable?(ffmpeg)
+      raise RuntimeError, "FFMPEG not at configured location: #{ffmpeg}"
+    end
     base = id.gsub(/\//,'_')
     aspect = new_width/new_height
     Tempfile.open([base,'.jpg']) do |jpeg|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - FEDORA_BASE_PATH
       - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
-      - FFMPEG_PATH=/usr/bin/ffmpeg
+      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - MASTER_FILE_PATH
       - MASTER_FILE_STRATEGY=delete
       - MATTERHORN_URL=http://matterhorn_system_account:CHANGE_ME@matterhorn:8080/


### PR DESCRIPTION
The current `docker-compose.yml` setting wasn't being respected (the container would look for FFMPEG at `/usr/local/bin/ffmpeg`, as per the setting in `config/settings.yml`).

Also: raise an error when FFMPEG isn't found at the location specified by `Settings.ffmpeg.path`.

