### PR TITLE
Have git ignore the docker-compose.override.yml file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,11 @@ migration_report
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# Ignore the docker-compose override file
+docker-compose.override.yml
+
+# Emacs files
+*~
+\#*
+.\#*


### PR DESCRIPTION
Bonus: have git ignore files that emacs litters all over the place.

This page documents the use of the `docker-compose.override.yml` file:

https://docs.docker.com/compose/extends/

As an example, my `docker-compose.override.yml` can have:

```
version: '2'

services:
  avalon:
    environment:
      - ASSET_HOST=http://206.167.180.187:3000
      - SETTINGS__DOMAIN=http://206.167.180.187:3000
      - SETTINGS__STREAMING__HTTP_BASE=http://206.167.180.187:8880/avalon
```

`docker-compose` will take all of it's settings from `docker-compose.yml`, but will override the settings found in `docker-compose.override.yml`.

Having this file not being tracked by version control prevents accidentally commiting it.