### PR TITLE
Turn all_comments into a helper in order to use SpeedyAF and avoid…

### DIFF
--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -253,4 +253,14 @@ EOF
      def get_duration_from_fragment(start, stop)
        milliseconds_to_formatted_time((stop.to_i - start.to_i) * 1000)
      end
+
+     # This method mirrors the one in the MediaObject model but makes use of the master files passed in which can be SpeedyAF Objects
+     # This would be good to refactor in the future but speeds things up considerably for now
+     def gather_all_comments(media_object, master_files)
+       media_object.comment.sort + master_files.collect do |mf|
+         mf.comment.reject(&:blank?).collect do |c|
+           mf.display_title.present? ? "[#{mf.display_title}] #{c}" : c
+         end.sort
+       end.flatten.uniq
+     end
 end

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -47,7 +47,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= display_metadata('Related Item', display_related_item(@media_object)) %>
   <%= display_metadata('Notes', display_notes(@media_object)) %>
   <%= display_metadata('Other Identifier', display_other_identifiers(@media_object)) %>
-  <%= display_metadata('Comments', @media_object.all_comments) %>
+  <%= display_metadata('Comments', gather_all_comments(@media_object, @masterFiles)) %>
 
 </dl>
 <% if can? :inspect, @media_object %>

--- a/spec/helpers/media_objects_helper_spec.rb
+++ b/spec/helpers/media_objects_helper_spec.rb
@@ -59,4 +59,21 @@ describe MediaObjectsHelper do
       expect(helper.get_duration_from_fragment(100, 20000)).to eq "5:31:40"
     end
   end
+
+  describe '#gather_all_comments' do
+    let(:media_object) { instance_double("MediaObject", comment: ['MO Comment']) }
+    let(:master_files) { [instance_double("MasterFile", comment: [])] }
+
+    it 'returns a list of unique comment strings' do
+      expect(helper.gather_all_comments(media_object, master_files)).to eq ["MO Comment"]
+    end
+
+    context 'with a master file comment' do
+      let(:master_files) { [instance_double("MasterFile", comment: ["MF Comment"], display_title: "MF1")] }
+
+      it 'returns a list of unique comment strings' do
+        expect(helper.gather_all_comments(media_object, master_files)).to eq ["MO Comment", "[MF1] MF Comment"]
+      end
+    end
+  end
 end


### PR DESCRIPTION
…requesting each master file for showing metadata