### PR TITLE
Monkey patch speedy_af

### DIFF
--- a/config/initializers/speedy_af.rb
+++ b/config/initializers/speedy_af.rb
@@ -1,0 +1,7 @@
+class SpeedyAF::Base
+  def respond_to_missing?(sym, _include_private = false)
+    @attrs.key?(sym) ||
+      model.respond_to?(:reflections) && model.reflections[sym].present? ||
+      model.instance_methods.include?(sym)
+  end
+end


### PR DESCRIPTION
Items with structural metadata ingested though the API caused speedy_af to bomb.