### PR TITLE
Add option to include production-specific initializers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter     = Settings&.active_job&.queue_adapter || :resque
   require 'active_job/queue_adapters/better_active_elastic_job_adapter' if config.active_job.queue_adapter == :active_elastic_job
+
+  # Additional production specific initializers
+  Dir["config/environments/production/*.rb"].each {|file| load file }
 end


### PR DESCRIPTION
Such as removing skylight.io middleware probe