### PR TITLE
Allow `lti.yml` to include ERB.

### DIFF
--- a/config/initializers/avalon_lti.rb
+++ b/config/initializers/avalon_lti.rb
@@ -4,7 +4,8 @@ AUTH_10_SUPPORT = true
 module Avalon
   module Lti
     begin
-      Configuration = YAML.load(File.read(File.expand_path('../../lti.yml',__FILE__)))
+      Configuration =
+        YAML.safe_load(ERB.new(File.read(File.expand_path('../../lti.yml', __FILE__))).result)
     rescue
       Configuration = {}
     end

--- a/config/initializers/avalon_lti.rb
+++ b/config/initializers/avalon_lti.rb
@@ -5,7 +5,7 @@ module Avalon
   module Lti
     begin
       Configuration =
-        YAML.safe_load(ERB.new(File.read(File.expand_path('../../lti.yml', __FILE__))).result)
+        YAML.load(ERB.new(File.read(File.expand_path('../../lti.yml', __FILE__))).result)
     rescue
       Configuration = {}
     end


### PR DESCRIPTION
Allows, for example, the lti server specified to be imported from an environment variable or from `secrets.yml`.