### PR TITLE
Minimal exposition of broken before_validation for upstream analysis.

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -31,6 +31,9 @@ class MediaObject < ActiveFedora::Base
   has_and_belongs_to_many :governing_policies, class_name: 'ActiveFedora::Base', predicate: ActiveFedora::RDF::ProjectHydra.isGovernedBy
   belongs_to :collection, class_name: 'Admin::Collection', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection
 
+  before_validation :terms_of_use_set_to_before_validation_bogus
+  before_save :terms_of_use_set_to_before_save_bogus
+
   before_save :update_dependent_properties!, prepend: true
   before_save :update_permalink, if: Proc.new { |mo| mo.persisted? && mo.published? }, prepend: true
   before_save :assign_id!, prepend: true
@@ -55,6 +58,14 @@ class MediaObject < ActiveFedora::Base
   validate  :validate_dates, if: :resource_description_active?
   validate  :validate_note_type, if: :resource_description_active?
   validate  :report_missing_attributes, if: :resource_description_active?
+
+  def terms_of_use_set_to_before_validation_bogus
+    self.terms_of_use = 'Bogus before_valdiation terms of use!'
+  end
+
+  def terms_of_use_set_to_before_save_bogus
+    self.terms_of_use = 'Bogus before_save terms of use!'
+  end
 
   def resource_description_active?
     workflow.completed?("file-upload")

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -22,6 +22,29 @@ describe MediaObject do
     # Force the validations to run by being on the resource-description workflow step
     let(:media_object) { FactoryGirl.build(:media_object).tap {|mo| mo.workflow.last_completed_step = "resource-description"} }
 
+    describe 'before_validation does not work' do
+      it 'does not modify terms of use before validation ... why?' do
+        media_object.terms_of_use = 'I should ideally get modified'
+        # before_validation callback should get run here:
+        media_object.valid?
+        # What we expect ...
+        # expect(media_object.terms_of_use).to eq('Bogus before_validation terms of use!')
+        # What really happens ...
+        expect(media_object.terms_of_use).to eq('I should ideally get modified')
+      end
+
+      it 'does however modify terms of use during save via before save' do
+        media_object.terms_of_use = 'I should ideally get modified'
+        media_object.valid?
+        # Because before_validation is broken we get...
+        expect(media_object.terms_of_use).to eq('I should ideally get modified')
+        media_object.save
+        # But the before_save callback does actually gets run ...
+        expect(media_object.terms_of_use).to eq('Bogus before_save terms of use!')
+      end
+
+    end
+
     describe 'collection' do
       it 'has errors when not present' do
         expect{media_object.collection = nil}.to raise_error(ActiveFedora::AssociationTypeMismatch)


### PR DESCRIPTION
Not really a PR, don't approve or merge.

@cjcolvar Here is a minimal example of the broken `before_validation` callback in ActiveFedora.