### PR TITLE
`self.file_location` may not be set when `working_file_path` is called.

### DIFF
--- a/app/jobs/cleanup_working_file_job.rb
+++ b/app/jobs/cleanup_working_file_job.rb
@@ -16,6 +16,6 @@ class CleanupWorkingFileJob < ActiveJob::Base
   def perform(masterfile_id)
     masterfile = MasterFile.find(masterfile_id)
     path = masterfile.working_file_path
-    File.delete(path) if File.exist?(path)
+    File.delete(path) if path.present? && File.exist?(path)
   end
 end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -647,9 +647,9 @@ class MasterFile < ActiveFedora::Base
         path = File.join(File.dirname(realpath), original_name)
         File.rename(realpath, path)
         realpath = path
-        self.file_location = realpath
       end
 
+      self.file_location = realpath
       newpath = working_file_path
       FileUtils.cp(realpath, newpath) unless newpath.blank?
     end


### PR DESCRIPTION
Can cause issues with the test suite, and presumably elsewhere. In particular, these two tests can fail if the matterhorn media_path setting is not blank:

https://github.com/avalonmediasystem/avalon/blob/master/spec/controllers/master_files_controller_spec.rb#L148-L170