### PR TITLE
Allow JSON access to public published media objects without an API token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,7 +122,9 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
-    if current_user
+    if request.format == :json
+      head :unauthorized
+    elsif current_user
       redirect_to root_path, flash: { notice: 'You are not authorized to perform this action.' }
     else
       session[:previous_url] = request.fullpath unless request.xhr?

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -22,7 +22,6 @@ class MediaObjectsController < ApplicationController
   include SecurityHelper
 
   before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details]
-  before_action :authenticate_api!, only: [:show, :create, :json_update], if: proc { request.format.json? }
   load_and_authorize_resource except: [:create, :json_update, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections]
   # authorize_resource only: [:create, :update]
 
@@ -45,10 +44,6 @@ class MediaObjectsController < ApplicationController
 
   def can_embed?
     params[:action] == 'show'
-  end
-
-  def authenticate_api!
-    return head :unauthorized if !signed_in?
   end
 
   def confirm_remove

--- a/spec/controllers/vocabulary_controller_spec.rb
+++ b/spec/controllers/vocabulary_controller_spec.rb
@@ -56,11 +56,11 @@ describe VocabularyController, type: :controller do
           request.headers['Avalon-Api-Key'] = nil
           login_as :user
         end
-        it "all routes should redirect to /" do
-          expect(get :index, format: 'json').to redirect_to(root_path)
-          expect(get :show, id: vocab, format: 'json').to redirect_to(root_path)
-          expect(put :update, id: vocab, format: 'json').to redirect_to(root_path)
-          expect(patch :update, id: vocab, format: 'json').to redirect_to(root_path)
+        it "all routes should return 401 when no token is preset" do
+          expect(get :index, format: 'json').to have_http_status(401)
+          expect(get :show, id: vocab, format: 'json').to have_http_status(401)
+          expect(put :update, id: vocab, format: 'json').to have_http_status(401)
+          expect(patch :update, id: vocab, format: 'json').to have_http_status(401)
         end
       end
     end


### PR DESCRIPTION
Also modify the way unauthorized JSON requests are handled:
return 401 instead of redirect to root path.
