### PR TITLE
Default to using the test ActiveJob adapter to avoid running background jobs

### DIFF
--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -16,7 +16,14 @@ require 'rails_helper'
 require 'avalon/intercom'
 
 describe BookmarksController, type: :controller do
+  include ActiveJob::TestHelper
+
   render_views
+
+  around(:example) do |example|
+    # In Rails 5.1+ this can be restricted to whitelist jobs allowed to be performed
+    perform_enqueued_jobs { example.run }
+  end
 
   let!(:collection) { FactoryGirl.create(:collection) }
   let!(:media_objects) { [] }

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -259,7 +259,7 @@ describe Admin::CollectionsController, type: :controller do
       # allow(mock_email).to receive(:deliver_later)
       # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
       # FIXME: This delivers two instead of one for some reason
-      expect {post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}}.to change { ActionMailer::Base.deliveries.count }
+      expect {post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}}.to have_enqueued_job(ActionMailer::DeliveryJob).twice
       # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
     end
     it "should create a new collection" do
@@ -285,9 +285,7 @@ describe Admin::CollectionsController, type: :controller do
       # expect(mock_delay).to receive(:update_collection)
       @collection = FactoryGirl.create(:collection)
       # put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}
-      # FIXME: This delivers two instead of one for some reason
-      expect {put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}}.to change { ActionMailer::Base.deliveries.count }
-
+      expect {put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}}.to have_enqueued_job(ActionMailer::DeliveryJob).once
     end
 
     context "update REST API" do

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -15,13 +15,6 @@
 require 'rails_helper'
 
 describe MasterFilesController do
-  before do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
-  after do
-    ActiveJob::Base.queue_adapter = :inline
-  end
 
   describe "#create" do
     let(:media_object) { FactoryGirl.create(:media_object) }

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -430,13 +430,11 @@ describe MediaObjectsController, type: :controller do
           expect(media_object.master_files.to_a.size).to eq 2
         end
         it "should update the poster and thumbnail for its masterfile" do
-          ActiveJob::Base.queue_adapter = :test
           media_object = FactoryGirl.create(:media_object)
           put 'json_update', format: 'json', id: media_object.id, files: [master_file], collection_id: media_object.collection_id
           media_object.reload
           expect(media_object.master_files.to_a.size).to eq 1
           expect(ExtractStillJob).to have_been_enqueued.with(media_object.master_files.first.id,{type:'both',offset:2000})
-          ActiveJob::Base.queue_adapter = :inline
         end
         it "should delete existing master_files and add a new master_file to a media_object" do
           put 'json_update', format: 'json', id: media_object.id, files: [master_file], collection_id: media_object.collection_id, replace_masterfiles: true

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -15,6 +15,8 @@
 require 'rails_helper'
 
 describe MediaObjectsController, type: :controller do
+  include ActiveJob::TestHelper
+
   render_views
 
   before(:each) do
@@ -866,6 +868,11 @@ describe MediaObjectsController, type: :controller do
     let!(:collection) { FactoryGirl.create(:collection) }
     before(:each) do
       login_user collection.managers.first
+    end
+
+    around(:example) do |example|
+      # In Rails 5.1+ this can be restricted to whitelist jobs allowed to be performed
+      perform_enqueued_jobs { example.run }
     end
 
     it "should remove a MediaObject with a single MasterFiles" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -500,7 +500,6 @@ describe Admin::Collection do
   describe "reindex_members" do
     before do
       @collection = FactoryGirl.create(:collection, items: 3)
-      ActiveJob::Base.queue_adapter = :test
     end
     it 'should queue a reindex job for all member objects' do
       @collection.reindex_members {}

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -115,7 +115,6 @@ describe MasterFile do
     let!(:master_file) { FactoryGirl.create(:master_file) }
     # let(:encode_job) { ActiveEncodeJob::Create.new(master_file.id, nil, {}) }
     before do
-      ActiveJob::Base.queue_adapter = :test
       # allow(ActiveEncodeJob::Create).to receive(:new).and_return(encode_job)
       # allow(encode_job).to receive(:perform)
     end
@@ -194,11 +193,9 @@ describe MasterFile do
 
     describe "update images" do
       before do
-        ActiveJob::Base.queue_adapter = :test
         MasterFile.set_callback(:save, :after, :update_stills_from_offset!)
       end
       after do
-        ActiveJob::Base.queue_adapter = :inline
         MasterFile.skip_callback(:save, :after, :update_stills_from_offset!)
       end
       it "should update on save" do
@@ -488,7 +485,6 @@ describe MasterFile do
     subject(:master_file) { FactoryGirl.create(:master_file) }
     let(:working_dir) {'/path/to/working_dir/'}
     before do
-      ActiveJob::Base.queue_adapter = :test
       Settings.matterhorn.media_path = working_dir
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,7 +53,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-ActiveJob::Base.queue_adapter = :inline
+ActiveJob::Base.queue_adapter = :test
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|


### PR DESCRIPTION
This PR is to force a travis build to see how many tests rely on background jobs running.  My hope is that all that do can be fixed so we can switch to the `:test` adapter.

My other hope in this is to fix the failing test in the `feature/waveform-service` branch.