### PR TITLE
Avoid calling fedora to only check existence

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -219,7 +219,7 @@ class Ability
   end
 
   def is_member_of_any_collection?
-    @user.id.present? && Admin::Collection.where("inheritable_edit_access_person_ssim" => @user.user_key).first.present?
+    @user.id.present? && Admin::Collection.exists?("inheritable_edit_access_person_ssim" => @user.user_key)
   end
 
   def full_login?


### PR DESCRIPTION
Found when production fedora was down.  This blocked me from even accessing `/about` or `/about/health.yaml`.

We should aim to have all read-only operations only hit solr so that the site will still be mostly useable by end-users even if fedora goes down.