### PR TITLE
Ensure the WaveformJob happens before the ActiveEncodeJob::Create job runs

### DIFF
--- a/app/jobs/active_encode_job.rb
+++ b/app/jobs/active_encode_job.rb
@@ -40,7 +40,7 @@ module ActiveEncodeJob
         WaveformJob.perform_now(job.arguments.first)
       rescue StandardError => e
         logger.warn("WaveformJob failed: #{e.message}")
-        logger.warn("#{e.backtrace}")
+        logger.warn(e.backtrace.to_s)
       end
     end
 

--- a/app/jobs/active_encode_job.rb
+++ b/app/jobs/active_encode_job.rb
@@ -35,6 +35,15 @@ module ActiveEncodeJob
     queue_as :active_encode_create
     throttle threshold: Settings.encode_throttling.create_jobs_throttle_threshold, period: Settings.encode_throttling.create_jobs_spacing, drop: false
 
+    before_perform do |job|
+      begin
+        WaveformJob.perform_now(job.arguments.first)
+      rescue StandardError => e
+        logger.warn("WaveformJob failed: #{e.message}")
+        logger.warn("#{e.backtrace}")
+      end
+    end
+
     def perform(master_file_id, input, options)
       mf = MasterFile.find(master_file_id)
       encode = mf.encoder_class.new(input, options.merge({output_key_prefix: "#{mf.id}/"}))

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -263,8 +263,8 @@ class MasterFile < ActiveFedora::Base
       FileLocator.new(file_location).uri.to_s
     end
 
+    # WaveformJob is performed in a before_perform callback on ActiveEncodeJob::Create
     ActiveEncodeJob::Create.perform_later(self.id, input, {preset: self.workflow_name})
-    WaveformJob.perform_later(self.id)
   end
 
   def finished_processing?

--- a/spec/jobs/active_encode_job_spec.rb
+++ b/spec/jobs/active_encode_job_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -16,30 +16,50 @@ require 'rails_helper'
 
 describe ActiveEncodeJob do
   describe ActiveEncodeJob::Create do
-    let(:job) { ActiveEncodeJob::Create.new }
+    let(:job) { ActiveEncodeJob::Create.new(master_file.id, nil, {}) }
+    let(:master_file) { FactoryGirl.create(:master_file) }
+
     describe "perform" do
       context "with error" do
         before do
           allow_any_instance_of(ActiveEncode::Base).to receive(:create!).and_raise(StandardError)
         end
-        let(:master_file) { FactoryGirl.create(:master_file) }
+
         it "sets the status of the master file to FAILED" do
-          job.perform(master_file.id, nil, {})
+          job.perform(*job.arguments)
           master_file.reload
           expect(master_file.status_code).to eq('FAILED')
         end
       end
+
       context "with uncreated job" do
         before do
           allow(encode_job).to receive(:id).and_return(nil)
           allow_any_instance_of(ActiveEncode::Base).to receive(:create!).and_return(encode_job)
         end
+
         let(:encode_job) { ActiveEncode::Base.new(nil) }
-        let(:master_file) { FactoryGirl.create(:master_file) }
+
         it "sets the status of the master file to FAILED" do
-          job.perform(master_file.id, nil, {})
+          job.perform(*job.arguments)
           master_file.reload
           expect(master_file.status_code).to eq('FAILED')
+        end
+      end
+    end
+
+    describe 'callbacks' do
+      context 'before_perform' do
+        it 'performs the WaveformJob' do
+          expect(WaveformJob).to receive(:perform_now).with(master_file.id)
+          expect(job).to receive(:perform).with(*job.arguments)
+          job.perform_now
+        end
+
+        it 'performs the job even when the WaveformJob fails' do
+          expect(WaveformJob).to receive(:perform_now).with(master_file.id).and_raise(RuntimeError)
+          expect(job).to receive(:perform).with(*job.arguments)
+          job.perform_now
         end
       end
     end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -122,10 +122,6 @@ describe MasterFile do
       master_file.process
       expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, "file://" + URI.escape(master_file.file_location), {preset: master_file.workflow_name})
     end
-    it 'enqueues a Waveform job' do
-      master_file.process
-      expect(WaveformJob).to have_been_enqueued.with(master_file.id)
-    end
     describe 'already processing' do
       before do
         master_file.status_code = 'RUNNING'


### PR DESCRIPTION
This fixes the race condition that existed where the WaveformJob while scheduled early might not run until the MasterFileManagement jobs were also running leaving the WaveformJob thinking it could use the file on disk and then finding it not there when it run ffmpeg or worse that the MasterFileManagement move or delete job fails because ffmpeg still has a open handle on the file.

This PR forces the WaveformJob to execute immediately before the ActiveEncodeJob::Create job runs.  I believe this is in the same thread that the ActiveEncodeJob::Create job will run in.  Since the waveform isn't critical any errors raised by the WaveformJob are logged but don't block the ActiveEncodeJob::Create job from running.

Finishes #3005.