### PR TITLE
Fix working file path

### DIFF
--- a/app/jobs/cleanup_working_file_job.rb
+++ b/app/jobs/cleanup_working_file_job.rb
@@ -16,7 +16,9 @@ class CleanupWorkingFileJob < ActiveJob::Base
   def perform(masterfile_id)
     masterfile = MasterFile.find(masterfile_id)
     masterfile.working_file_path.map do |path|
+      parent_directory = File.dirname(path)
       File.delete(path) if File.exist?(path)
+      Dir.delete(parent_directory) if Dir.exist?(parent_directory)
     end
     masterfile.working_file_path = nil
     masterfile.save!

--- a/app/jobs/cleanup_working_file_job.rb
+++ b/app/jobs/cleanup_working_file_job.rb
@@ -15,7 +15,10 @@
 class CleanupWorkingFileJob < ActiveJob::Base
   def perform(masterfile_id)
     masterfile = MasterFile.find(masterfile_id)
-    path = masterfile.working_file_path
-    File.delete(path) if path.present? && File.exist?(path)
+    masterfile.working_file_path.map do |path|
+      File.delete(path) if File.exist?(path)
+    end
+    masterfile.working_file_path = nil
+    masterfile.save!
   end
 end

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -35,6 +35,7 @@ module Avalon
     class MasterFile < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/master_file#")
       property :posterOffset,        "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
       property :thumbnailOffset,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
+      property :workingFilePath,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
     end
 
     class Derivative < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/derivative#")

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -120,6 +120,9 @@ class MasterFile < ActiveFedora::Base
     index.as :stored_sortable
   end
 
+  # For working file copy when Settings.matterhorn.media_path is set
+  property :working_file_path, predicate: Avalon::RDFVocab::MasterFile.workingFilePath, multiple: true
+
   validates :workflow_name, presence: true, inclusion: { in: proc { WORKFLOWS } }
   validates_each :date_digitized do |record, attr, value|
     unless value.nil?
@@ -167,8 +170,7 @@ class MasterFile < ActiveFedora::Base
   def setContent(file)
     case file
     when Hash #Multiple files for pre-transcoded derivatives
-      saveOriginal( (file.has_key?('quality-high') && File.file?( file['quality-high'] )) ? file['quality-high'] : (file.has_key?('quality-medium') && File.file?( file['quality-medium'] )) ? file['quality-medium'] : file.values[0] )
-      file.each_value {|f| f.close unless f.closed? }
+      saveDerivativesHash(file)
     when ActionDispatch::Http::UploadedFile #Web upload
       saveOriginal(file, file.original_filename)
     when URI, Addressable::URI
@@ -180,7 +182,7 @@ class MasterFile < ActiveFedora::Base
         self.file_size = FileLocator::S3File.new(file).object.size
       end
     else #Batch
-      saveOriginal(file)
+      saveOriginal(file, File.basename(file.path))
     end
     reloadTechnicalMetadata!
   end
@@ -249,14 +251,22 @@ class MasterFile < ActiveFedora::Base
 
     #Build hash for single file skip transcoding
     if !file.is_a?(Hash) && (self.workflow_name == 'avalon-skip-transcoding' || self.workflow_name == 'avalon-skip-transcoding-audio')
-      file = {'quality-high' => FileLocator.new(file_location).attachment}
+      if working_file_path.present?
+        file = {'quality-high' => FileLocator.new(working_file_path.first).attachment}
+      else
+        file = {'quality-high' => FileLocator.new(file_location).attachment}
+      end
     end
 
     input = if file.is_a? Hash
       file_dup = file.dup
       file_dup.each_pair {|quality, f| file_dup[quality] = FileLocator.new(f.to_path).uri.to_s }
     else
-      FileLocator.new(file_location).uri.to_s
+      if working_file_path.present?
+        FileLocator.new(working_file_path.first).uri.to_s
+      else
+        FileLocator.new(file_location).uri.to_s
+      end
     end
 
     ActiveEncodeJob::Create.perform_later(self.id, input, {preset: self.workflow_name})
@@ -501,11 +511,23 @@ class MasterFile < ActiveFedora::Base
     end
   end
 
-  def working_file_path
-    path = nil
+  def create_working_file!(full_path)
+    working_path = MasterFile.calculate_working_file_path(full_path)
+    return unless working_path.present?
+
+    self.working_file_path = [working_path]
+    FileUtils.mkdir(File.dirname(working_path))
+    FileUtils.cp(full_path, working_path)
+    working_path
+  end
+
+  def self.calculate_working_file_path(old_path)
     config_path = Settings.matterhorn.media_path
-    path = File.join(config_path, File.basename(self.file_location)) if config_path.present? && File.directory?(config_path)
-    path
+    if config_path.present? && File.directory?(config_path)
+      File.join(config_path, SecureRandom.uuid, File.basename(old_path))
+    else
+      nil
+    end
   end
 
   protected
@@ -649,14 +671,26 @@ class MasterFile < ActiveFedora::Base
         realpath = path
       end
 
-      self.file_location = realpath
-      newpath = working_file_path
-      FileUtils.cp(realpath, newpath) unless newpath.blank?
+      create_working_file!(realpath)
     end
     self.file_location = realpath
     self.file_size = file.size.to_s
   ensure
     file.close
+  end
+
+  def saveDerivativesHash(derivative_hash)
+    usable_files = derivative_hash.select { |quality, file| File.file?(file) }
+    self.working_file_path = usable_files.values.collect { |file| create_working_file!(File.realpath(file)) }.compact
+
+    %w(quality-high quality-medium quality-low).each do |quality|
+      next unless usable_files.has_key?(quality)
+      self.file_location = File.realpath(usable_files[quality])
+      self.file_size = usable_files[quality].size.to_s
+      break
+    end
+  ensure
+    derivative_hash.values.map { |file| file.close }
   end
 
   def reloadTechnicalMetadata!

--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -201,6 +201,15 @@ module Avalon
           files = self.class.gatherFiles(file_spec[:file])
           self.class.attach_datastreams_to_master_file(master_file, file_spec[:file])
           master_file.setContent(files)
+
+          # Overwrite files hash with working file paths to pass to matterhorn
+          if files.is_a?(Hash) && master_file.working_file_path.present?
+            files.each do |quality, file|
+              working_path = master_file.working_file_path.find { |path| File.basename(file) == File.basename(path) }
+              files[quality] = File.new(working_path)
+            end
+          end
+
           master_file.absolute_location = file_spec[:absolute_location] if file_spec[:absolute_location].present?
           master_file.title = file_spec[:label] if file_spec[:label].present?
           master_file.poster_offset = file_spec[:offset] if file_spec[:offset].present?

--- a/spec/integration/working_file_path_spec.rb
+++ b/spec/integration/working_file_path_spec.rb
@@ -1,0 +1,298 @@
+require 'rails_helper'
+
+# MasterFile#working_file_path has been a source of problems since it was introduced in 6.4.3
+# This spec file is meant to thoroughly test it in order to find any remaining bugs and to
+# ensure the intended functionality doesn't get broken accidentally in the future.
+#
+# Need to test all of the possiblilites:
+# batch ingest with single file
+# batch ingest with single file skip transcoding
+# batch ingest with pre-transcoded derivatives
+# web upload
+# web upload skip transcoding
+# BE dropbox upload
+# BE dropbox skip transcoding
+# Repeat all of these with and without media path set.
+# Also with dropbox mounted on matterhorn and not.?
+#
+# Pre-existing tests that are related (or duplicative)
+# spec/models/master_file_spec.rb:262
+# spec/models/master_file_spec.rb:500
+# spec/lib/avalon/batch/entry_spec.rb:80
+#
+describe "MasterFile#working_file_path" do
+  let(:master_file) { FactoryGirl.build(:master_file) }
+  let(:media_object) { FactoryGirl.create(:media_object) }
+  let(:workflow) { 'avalon' }
+
+  context "with Settings.matterhorn.media_path set" do
+    let(:media_path) { Dir.mktmpdir }
+
+    around(:example) do |example|
+      begin
+        old_media_path = Settings.matterhorn.media_path
+        Settings.matterhorn.media_path = media_path
+
+        example.run
+
+        Settings.matterhorn.media_path = old_media_path
+      ensure
+        FileUtils.remove_entry media_path
+      end
+    end
+
+    describe '#calculate_working_file_path' do
+      let(:path1) { MasterFile.calculate_working_file_path('/dropbox/coll1/video.mp4') }
+      let(:path2) { MasterFile.calculate_working_file_path('/dropbox/coll2/video.mp4') }
+
+      it 'returns a working file path' do
+        expect(File.fnmatch("#{File.absolute_path(media_path)}/*/video.mp4", path1)).to be true
+      end
+
+      it 'creates a unique working_file_path for each file' do
+        expect(path1).not_to eq path2
+      end
+    end
+
+    it 'can recompute the working_file_path' do
+      file = fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4')
+      master_file.setContent(file)
+      original_path = master_file.working_file_path
+      master_file.save!
+      new_path = MasterFile.find(master_file.id).working_file_path
+      expect(original_path).to eq new_path
+    end
+
+    context "using web upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:params) { { Filedata: [file], original: nil, workflow: workflow } }
+
+      it 'sends the working_file_path to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the working_file_path to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using dropbox upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:url) { Addressable::URI.convert_path(File.absolute_path(file.to_path)) }
+      let(:params) { { selected_files: { "0" => { url: url, file_name: 'videoshort.mp4' } }, workflow: workflow } }
+
+      it 'sends the working_file_path to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the working_file_path to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using batch ingest" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:collection) { FactoryGirl.build(:collection) }
+      let(:entry_fields) { { title: Faker::Lorem.sentence, date_issued: "#{DateTime.now.strftime('%F')}" } }
+      let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: false }] }
+      let(:entry_opts) { {user_key: 'archivist1@example.org', collection: collection} }
+      let(:entry) { Avalon::Batch::Entry.new(entry_fields, entry_files, entry_opts, nil, nil) }
+
+      before do
+        allow(entry).to receive(:media_object).and_return(media_object)
+      end
+
+      it 'sends the working_file_path to matterhorn' do
+        entry.process!
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context 'with skip transcoding' do
+        let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: true }] }
+
+        it 'sends the working_file_path to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+
+      context 'with pre-transcoded derivatives' do
+        let(:filename) {File.join(Rails.root, "spec/fixtures/videoshort.mp4")}
+        %w(low medium high).each do |quality|
+          let("filename_#{quality}".to_sym) {File.join(Rails.root, "spec/fixtures/videoshort.#{quality}.mp4")}
+        end
+        let(:derivative_paths) {[filename_low, filename_medium, filename_high]}
+        let(:derivative_hash) {{'quality-low' => File.new(filename_low), 'quality-medium' => File.new(filename_medium), 'quality-high' => File.new(filename_high)}}
+
+        let(:entry_files) { [{ file: filename, skip_transcoding: true }] }
+
+        let(:original_file_locator) { instance_double("FileLocator") }
+        before do
+          allow(FileLocator).to receive(:new).and_call_original
+          allow(FileLocator).to receive(:new).with(filename).and_return(original_file_locator)
+          allow(original_file_locator).to receive(:exist?).and_return(false)
+        end
+
+        # All derivatives are copied to a working path
+        # TODO: Ensure all working file copies are cleaned up by the background job
+        it 'sends the working_file_path to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          working_file_path_high = master_file.working_file_path.find { |file| file.include? "high" }
+          working_file_path_medium = master_file.working_file_path.find { |file| file.include? "medium" }
+          working_file_path_low = master_file.working_file_path.find { |file| file.include? "low" }
+
+          [working_file_path_high, working_file_path_medium, working_file_path_low].each do |file|
+            expect(File.exists? file).to be true
+          end
+          input = { "quality-high" => FileLocator.new(working_file_path_high).uri.to_s,
+                    "quality-medium" => FileLocator.new(working_file_path_medium).uri.to_s,
+                    "quality-low" => FileLocator.new(working_file_path_low).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+  end
+
+  context "without Settings.matterhorn.media_path set" do
+    it 'returns blank' do
+      expect(master_file.working_file_path).to be_blank
+    end
+
+    context "using web upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:params) { { Filedata: [file], original: nil, workflow: workflow } }
+
+      it 'sends the file_location to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the file_location to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using dropbox upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:url) { Addressable::URI.convert_path(File.absolute_path(file.to_path)) }
+      let(:params) { { selected_files: { "0" => { url: url, file_name: 'videoshort.mp4' } }, workflow: workflow } }
+
+      it 'sends the file_location to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the file_location to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using batch ingest" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:collection) { FactoryGirl.build(:collection) }
+      let(:entry_fields) { { title: Faker::Lorem.sentence, date_issued: "#{DateTime.now.strftime('%F')}" } }
+      let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: false }] }
+      let(:entry_opts) { {user_key: 'archivist1@example.org', collection: collection} }
+      let(:entry) { Avalon::Batch::Entry.new(entry_fields, entry_files, entry_opts, nil, nil) }
+
+      before do
+        allow(entry).to receive(:media_object).and_return(media_object)
+      end
+
+      it 'sends the file_location to matterhorn' do
+        entry.process!
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context 'with skip transcoding' do
+        let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: true }] }
+
+        it 'sends the file_location to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+
+      context 'with pre-transcoded derivatives' do
+        let(:filename) {File.join(Rails.root, "spec/fixtures/videoshort.mp4")}
+        %w(low medium high).each do |quality|
+          let("filename_#{quality}".to_sym) {File.join(Rails.root, "spec/fixtures/videoshort.#{quality}.mp4")}
+        end
+        let(:derivative_paths) {[filename_low, filename_medium, filename_high]}
+        let(:derivative_hash) {{'quality-low' => File.new(filename_low), 'quality-medium' => File.new(filename_medium), 'quality-high' => File.new(filename_high)}}
+
+        let(:entry_files) { [{ file: filename, skip_transcoding: true }] }
+
+        let(:original_file_locator) { instance_double("FileLocator") }
+        before do
+          allow(FileLocator).to receive(:new).and_call_original
+          allow(FileLocator).to receive(:new).with(filename).and_return(original_file_locator)
+          allow(original_file_locator).to receive(:exist?).and_return(false)
+        end
+
+        it 'sends the derivative locations to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          input = {'quality-low' => Addressable::URI.convert_path(File.absolute_path(filename_low)).to_s,
+                   'quality-medium' => Addressable::URI.convert_path(File.absolute_path(filename_medium)).to_s,
+                   'quality-high' => Addressable::URI.convert_path(File.absolute_path(filename_high)).to_s
+                  }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/working_file_path_spec.rb
+++ b/spec/integration/working_file_path_spec.rb
@@ -10,10 +10,9 @@ require 'rails_helper'
 # batch ingest with pre-transcoded derivatives
 # web upload
 # web upload skip transcoding
-# BE dropbox upload
-# BE dropbox skip transcoding
+# web dropbox upload
+# web dropbox skip transcoding
 # Repeat all of these with and without media path set.
-# Also with dropbox mounted on matterhorn and not.?
 #
 # Pre-existing tests that are related (or duplicative)
 # spec/models/master_file_spec.rb:262

--- a/spec/jobs/cleanup_working_files_spec.rb
+++ b/spec/jobs/cleanup_working_files_spec.rb
@@ -15,13 +15,16 @@
 require 'rails_helper'
 
 describe CleanupWorkingFileJob do
-  let(:working_file) {'/temp/working_file.mp4'}
-  let(:master_file) {instance_double('MasterFile')}
+  let(:working_file) { '/temp/working_file.mp4' }
+  let(:master_file) { FactoryGirl.build(:master_file, working_file_path: [working_file]) }
+
+  before do
+    allow(MasterFile).to receive(:find).and_return(master_file)
+    allow(File).to receive(:exist?).and_return(true)
+  end
+
   describe "perform" do
     it 'calls file delete when there is file to cleanup' do
-      allow(MasterFile).to receive(:find).and_return(master_file)
-      allow(master_file).to receive(:working_file_path).and_return(working_file)
-      allow(File).to receive(:exist?).and_return(true)
       expect(File).to receive(:delete).with(working_file).once
       CleanupWorkingFileJob.perform_now('abc123')
     end

--- a/spec/jobs/cleanup_working_files_spec.rb
+++ b/spec/jobs/cleanup_working_files_spec.rb
@@ -21,11 +21,13 @@ describe CleanupWorkingFileJob do
   before do
     allow(MasterFile).to receive(:find).and_return(master_file)
     allow(File).to receive(:exist?).and_return(true)
+    allow(Dir).to receive(:exist?).and_return(true)
   end
 
   describe "perform" do
     it 'calls file delete when there is file to cleanup' do
       expect(File).to receive(:delete).with(working_file).once
+      expect(Dir).to receive(:delete).with(File.dirname(working_file)).once
       CleanupWorkingFileJob.perform_now('abc123')
     end
   end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -317,7 +317,7 @@ describe MasterFile do
 
         it "should copy an uploaded file to the media path" do
           Settings.matterhorn.media_path = media_path
-          expect(subject.working_file_path).to eq(File.join(media_path,original))
+          expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
         end
       end
     end
@@ -483,7 +483,7 @@ describe MasterFile do
 
   context 'with a working directory' do
     subject(:master_file) { FactoryGirl.create(:master_file) }
-    let(:working_dir) {'/path/to/working_dir/'}
+    let(:working_dir) { Dir.mktmpdir }
     before do
       Settings.matterhorn.media_path = working_dir
     end
@@ -498,13 +498,16 @@ describe MasterFile do
       end
     end
     describe '#working_file_path' do
-      it 'returns nil when the working directory is invalid' do
-        expect(master_file.working_file_path).to be_nil
+      it 'returns blank when the working directory is invalid' do
+        expect(master_file.working_file_path).to be_blank
       end
 
       it 'returns a path when the working directory is valid' do
-        allow(File).to receive(:directory?).and_return(true)
-        expect(master_file.working_file_path).to include(working_dir)
+        # allow(File).to receive(:directory?).and_call_original
+        # allow(File).to receive(:directory?).with(Settings.matterhorn.media_path).and_return(true)
+        file = File.new(Rails.root.join('spec', 'fixtures', 'videoshort.mp4'))
+        master_file.setContent(file)
+        expect(master_file.working_file_path.first).to include(Settings.matterhorn.media_path)
       end
     end
   end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -503,8 +503,6 @@ describe MasterFile do
       end
 
       it 'returns a path when the working directory is valid' do
-        # allow(File).to receive(:directory?).and_call_original
-        # allow(File).to receive(:directory?).with(Settings.matterhorn.media_path).and_return(true)
         file = File.new(Rails.root.join('spec', 'fixtures', 'videoshort.mp4'))
         master_file.setContent(file)
         expect(master_file.working_file_path.first).to include(Settings.matterhorn.media_path)


### PR DESCRIPTION
The working file path is only used when Settings.matterhorn.media_path is configured.  The code changes in prior commits did not take into account all of the ways ingest happens: web upload, web upload skip transcoding, web dropbox, web dropbox skip transcoding, batch ingest, batch ingest skip transcoding, and batch ingest pre-transcoded derivatives.  The approach to this commit was to write tests for each of these scenarios with both the Settings.matterhorn.media_path configuration set and not set then make all of the tests pass.  The underlying use case for the working file path is when Matterhorn is running on a different server than Avalon and they don't share the same filesystem (and filesystem paths) for both the Rails web upload directory and dropbox.  The working_file_path is a copy of the originally uploaded file to where Matterhorn has access and at a path shared by both servers.  For example, if Matterhorn is running on a different server and Matterhorn's ingest directory is '/srv/matterhorn/ingest' and mounted on the Avalon server at the same location and Avalon's dropbox directory is '/srv/avalon/dropbox' then Settings.matterhorn.media_path should be configured to be '/srv/matterhorn/ingest'.  Note that Matterhorn's ingset directory needs to be mounted at the same location on both the Avalon and Matterhorn servers for Avalon to be able to ingest due to the use of absolute paths and not relative paths.

Changes in this PR:
- Pass `working_file_path` to Matterhorn if present
- Change `working_file_path` to be a stored value on `MasterFile`
- Thoroughly test all cases  (AWS not tested because it shouldn't have `Settings.matterhorn.media_path` set.)