### PR TITLE
Fix BatchRegistries#batch_entries

### DIFF
--- a/app/jobs/ingest_batch_status_email_jobs.rb
+++ b/app/jobs/ingest_batch_status_email_jobs.rb
@@ -24,7 +24,7 @@ module IngestBatchStatusEmailJobs
         # Get the entries for the batch and see if they all complete
         complete = true
         errors = false
-        BatchEntries.where(batch_registries_id: br.id).each do |entry|
+        br.batch_entries.each do |entry|
           complete = false unless entry.complete || entry.error
           errors = true if entry.error
         end

--- a/app/models/batch_registries.rb
+++ b/app/models/batch_registries.rb
@@ -17,7 +17,7 @@
 class BatchRegistries < ActiveRecord::Base
   before_save :check_user
   validates :file_name, :user_id, :collection, presence: true
-  has_many :batch_entries, -> { order(position: :asc) }
+  has_many :batch_entries, -> { order(position: :asc) }, class_name: BatchEntries
 
   # For FactoryBot's taps, document more TODO
   def file_name=(fn)


### PR DESCRIPTION
As found by @cwant.

Before this PR, calling `BatchRegistries#batch_entries` would raise `NameError: uninitialized constant BatchRegistries::BatchEntry` due to the class names already being plural and thus different than the normal Rails conventions.