### PR TITLE
Batch ingest post-encoding email.

### DIFF
--- a/app/jobs/ingest_batch_status_email_jobs.rb
+++ b/app/jobs/ingest_batch_status_email_jobs.rb
@@ -41,6 +41,21 @@ module IngestBatchStatusEmailJobs
         end
         br.save
       end
+
+      # Done encoding? (either successfully or with error)
+      BatchRegistries.where(processed_email_sent: false,
+                            error: false,
+                            complete: true).each do |br|
+        if br.encoding_finished?
+          BatchRegistriesMailer.batch_encoding_finished(br).deliver_now
+          br.processed_email_sent = true
+          if br.encoding_error?
+            br.error = true
+          end
+          br.save
+        end
+      end
+
     end
   end
 

--- a/app/mailers/batch_registries_mailer.rb
+++ b/app/mailers/batch_registries_mailer.rb
@@ -53,4 +53,23 @@ class BatchRegistriesMailer < ApplicationMailer
       subject: "Batch Registry #{@batch_registry.file_name} for #{collection_text} has stalled"
     )
   end
+
+  # Update the progress of finished (success or error) batch encoding
+  def batch_encoding_finished(batch_registry)
+    @batch_registry = batch_registry
+    @user = User.find(@batch_registry.user_id)
+    @email = @user.email unless @user.nil?
+    @email ||= Settings.email.notification
+    @collection_text = Admin::Collection.find(@batch_registry.collection).name if Admin::Collection.exists?(@batch_registry.collection)
+    @collection_text ||= "Collection"
+
+    @status = @batch_registry.encoding_success? ? "Success" : "Errors present"
+
+    mail(
+      to: @email,
+      from: Settings.email.notification,
+      subject: "#{@status}: Batch encoding #{@batch_registry.file_name} for #{@collection_text}"
+    )
+  end
+
 end

--- a/app/views/batch_registries_mailer/_batch_encoding_entry_row.html.erb
+++ b/app/views/batch_registries_mailer/_batch_encoding_entry_row.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <td> <%= batch_entry.position + 2 %> </td>
+  <% media_object = MediaObject.where(id: batch_entry.media_object_pid).first %>
+  <% if media_object %>
+    <% link_url = media_object.permalink %>
+    <% link_url = media_object_url(media_object) if link_url.blank? %>
+    <td> <%= link_to(batch_entry.media_object_pid, link_url) %></td>
+  <% else %>
+    <td> Item (<%= batch_entry.media_object_pid %>) was created but no longer exists </td>
+  <% end %>
+</tr>

--- a/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
+++ b/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
@@ -1,0 +1,38 @@
+Batch encoding complete!
+
+<dl>
+  <dt>Manifest:</dt>
+  <dd><%= @batch_registry.file_name %></dd>
+  <dt>Email:</dt>
+  <dd><%= @email %></dd>
+  <dt>Status:</dt>
+  <dd><%= @status %></dd>
+  <dt>Collection:</dt>
+  <dd><%= @collection_text %></dd>
+</dl>
+
+<% if @batch_registry.encoding_error? %>
+  <h2>Spreadsheet rows with encoding errors</h2>
+  <table>
+    <tr>
+      <th>Row</th>
+      <th>Media Object ID</th>
+    </tr>
+    <% @batch_registry.batch_entries_with_encoding_error.each do |batch_entry| %>
+      <%= render partial: 'batch_encoding_entry_row', locals: { batch_entry: batch_entry } %>
+    <% end %>
+  </table>
+<% end %>
+
+<% if @batch_registry.batch_entries_with_encoding_success.any? %>
+  <h2>Successfully encoded spreadsheet rows</h2>
+  <table>
+    <tr>
+      <th>Row</th>
+      <th>Media Object ID</th>
+    </tr>
+    <% @batch_registry.batch_entries_with_encoding_success.each do |batch_entry| %>
+      <%= render partial: 'batch_encoding_entry_row', locals: { batch_entry: batch_entry } %>
+    <% end %>
+  </table>
+<% end %>

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -55,7 +55,7 @@ describe IngestBatchStatusEmailJobs do
     end
 
     it 'sends an email when encoding is complete with success' do
-      FactoryGirl.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      FactoryBot.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
       allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)
       allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
 
@@ -67,7 +67,7 @@ describe IngestBatchStatusEmailJobs do
     end
 
     it 'sends an email when encoding is complete with error' do
-      FactoryGirl.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      FactoryBot.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
       allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
       allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(true)
 

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -16,8 +16,14 @@ require 'rails_helper'
 
 describe IngestBatchStatusEmailJobs do
   describe IngestBatchStatusEmailJobs::IngestFinished do
+<<<<<<< HEAD
     let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id) }
     let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+=======
+    let(:batch_registry) { FactoryGirl.create(:batch_registries, user_id: manager.id) }
+    let(:completed_batch_registry) { FactoryGirl.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
+    let(:manager) { FactoryGirl.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+>>>>>>> 07345153... Initial commit of 'Encoding finished' email. It uses an unused attribute
     let(:batch_mailer) { double }
 
     before do
@@ -51,6 +57,30 @@ describe IngestBatchStatusEmailJobs do
       expect(batch_registry.reload.error).to be false
       expect(batch_registry.reload.completed_email_sent).to be false
       expect(batch_registry.reload.complete).to be false
+    end
+
+    it 'sends an email when encoding is complete with success' do
+      FactoryGirl.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
+
+      expect(BatchRegistriesMailer).to receive(:batch_registration_finished_mailer).once.with(batch_registry).and_return(batch_mailer)
+      described_class.perform_now
+      completed_batch_registry.reload
+      expect(completed_batch_registry.processed_email_sent).to be true
+      expect(completed_batch_registry.error).to be false
+    end
+
+    it 'sends an email when encoding is complete with error' do
+      FactoryGirl.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(true)
+
+      expect(BatchRegistriesMailer).to receive(:batch_registration_finished_mailer).once.with(batch_registry).and_return(batch_mailer)
+      described_class.perform_now
+      completed_batch_registry.reload
+      expect(completed_batch_registry.processed_email_sent).to be true
+      expect(completed_batch_registry.error).to be true
     end
 
     context 'with locked batch' do

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -16,14 +16,9 @@ require 'rails_helper'
 
 describe IngestBatchStatusEmailJobs do
   describe IngestBatchStatusEmailJobs::IngestFinished do
-<<<<<<< HEAD
     let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id) }
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
-=======
-    let(:batch_registry) { FactoryGirl.create(:batch_registries, user_id: manager.id) }
     let(:completed_batch_registry) { FactoryGirl.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
-    let(:manager) { FactoryGirl.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
->>>>>>> 07345153... Initial commit of 'Encoding finished' email. It uses an unused attribute
+    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:batch_mailer) { double }
 
     before do

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -17,7 +17,7 @@ require 'rails_helper'
 describe IngestBatchStatusEmailJobs do
   describe IngestBatchStatusEmailJobs::IngestFinished do
     let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id) }
-    let(:completed_batch_registry) { FactoryGirl.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
+    let(:completed_batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
     let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:batch_mailer) { double }
 

--- a/spec/mailers/batch_registries_mailer_spec.rb
+++ b/spec/mailers/batch_registries_mailer_spec.rb
@@ -85,11 +85,11 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
   end
 
   describe 'batch_encoding_finished' do
-    let(:batch_registries) { FactoryGirl.create(:batch_registries, user_id: manager.id) }
-    let(:manager) { FactoryGirl.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
-    let!(:collection) { FactoryGirl.create(:collection, id: 'k32jf0kw') }
-    let!(:batch_entries) { FactoryGirl.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
-    let(:media_object) { FactoryGirl.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }
+    let(:batch_registries) { FactoryBot.create(:batch_registries, user_id: manager.id) }
+    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let!(:collection) { FactoryBot.create(:collection, id: 'k32jf0kw') }
+    let!(:batch_entries) { FactoryBot.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
+    let(:media_object) { FactoryBot.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }
 
     it "correctly sets up the email indicating that encoding is successful" do
       allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)

--- a/spec/mailers/batch_registries_mailer_spec.rb
+++ b/spec/mailers/batch_registries_mailer_spec.rb
@@ -84,6 +84,44 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
     end
   end
 
+  describe 'batch_encoding_finished' do
+    let(:batch_registries) { FactoryGirl.create(:batch_registries, user_id: manager.id) }
+    let(:manager) { FactoryGirl.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let!(:collection) { FactoryGirl.create(:collection, id: 'k32jf0kw') }
+    let!(:batch_entries) { FactoryGirl.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
+    let(:media_object) { FactoryGirl.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }
+
+    it "correctly sets up the email indicating that encoding is successful" do
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
+      email = BatchRegistriesMailer.batch_encoding_finished(batch_registries)
+      expect(email.to).to include(manager.email)
+      expect(email.subject).to include batch_registries.file_name
+      expect(email.subject).to include collection.name
+
+      expect(email.subject).to include 'Success'
+
+      expect(email).to have_body_text(batch_registries.file_name)
+      expect(email).to have_body_text("<a href=\"#{media_object.permalink}\">")
+      expect(email).to have_body_text(media_object.id)
+    end
+
+    it "correctly sets up the email indicating that encoding has errors" do
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(true)
+      email = BatchRegistriesMailer.batch_encoding_finished(batch_registries)
+      expect(email.to).to include(manager.email)
+      expect(email.subject).to include batch_registries.file_name
+      expect(email.subject).to include collection.name
+
+      expect(email.subject).to include 'Errors present'
+
+      expect(email).to have_body_text(batch_registries.file_name)
+      expect(email).to have_body_text("<a href=\"#{media_object.permalink}\">")
+      expect(email).to have_body_text(media_object.id)
+    end
+  end
+
   describe 'batch_registration_stalled_mailer' do
     let(:batch_registries) { FactoryBot.create(:batch_registries) }
     let(:notification_email_address) { Settings.email.notification }

--- a/spec/models/batch_entries_spec.rb
+++ b/spec/models/batch_entries_spec.rb
@@ -84,4 +84,92 @@ describe BatchEntries do
       expect(subject.current_status).to eq 'Queued'
     end
   end
+
+  describe 'encoding tracking' do
+    it 'records an encoding error if the media_object_pid is blank' do
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: nil)
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_truthy
+    end
+
+    it 'records an encoding error if the MediaObject is not in Fedora' do
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: 'nope')
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_truthy
+    end
+
+    it 'records an encoding error if the MediaObject does not have enough MasterFiles' do
+      media_object = FactoryGirl.create(:media_object)
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+
+      expect(media_object.master_files.to_a.count).to eq(0)
+      expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_truthy
+    end
+
+    it 'records an encoding success if the MediaObject has MasterFiles that are complete' do
+      master_file = FactoryGirl.create(:master_file, :with_media_object,
+                                       status_code: 'COMPLETED')
+      media_object = master_file.media_object
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+
+      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_truthy
+      expect(batch_entry.encoding_error?).to be_falsey
+    end
+
+    it 'records an encoding error if the MediaObject has MasterFiles that have errored' do
+      master_file = FactoryGirl.create(:master_file, :with_media_object,
+                                       status_code: 'FAILED')
+      media_object = master_file.media_object
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+
+      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_truthy
+    end
+
+    it 'records an encoding error if the MediaObject has MasterFiles that are cancelled' do
+      master_file = FactoryGirl.create(:master_file, :with_media_object,
+                                       status_code: 'CANCELLED')
+      media_object = master_file.media_object
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+
+      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
+
+      expect(batch_entry.encoding_finished?).to be_truthy
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_truthy
+    end
+
+    it 'records neither error nor success nor finished if MediaObject has MasterFiles that are not errored or successful' do
+      master_file = FactoryGirl.create(:master_file, :with_media_object,
+                                       status_code: 'RUNNING')
+      media_object = master_file.media_object
+      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+
+      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
+
+      expect(batch_entry.encoding_finished?).to be_falsey
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_falsey
+    end
+
+  end
+
 end

--- a/spec/models/batch_entries_spec.rb
+++ b/spec/models/batch_entries_spec.rb
@@ -87,7 +87,7 @@ describe BatchEntries do
 
   describe 'encoding tracking' do
     it 'records an encoding error if the media_object_pid is blank' do
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: nil)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: nil)
 
       expect(batch_entry.encoding_finished?).to be_truthy
       expect(batch_entry.encoding_success?).to be_falsey
@@ -95,7 +95,7 @@ describe BatchEntries do
     end
 
     it 'records an encoding error if the MediaObject is not in Fedora' do
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: 'nope')
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: 'nope')
 
       expect(batch_entry.encoding_finished?).to be_truthy
       expect(batch_entry.encoding_success?).to be_falsey
@@ -103,8 +103,8 @@ describe BatchEntries do
     end
 
     it 'records an encoding error if the MediaObject does not have enough MasterFiles' do
-      media_object = FactoryGirl.create(:media_object)
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+      media_object = FactoryBot.create(:media_object)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
       expect(media_object.master_files.to_a.count).to eq(0)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
@@ -115,10 +115,10 @@ describe BatchEntries do
     end
 
     it 'records an encoding success if the MediaObject has MasterFiles that are complete' do
-      master_file = FactoryGirl.create(:master_file, :with_media_object,
+      master_file = FactoryBot.create(:master_file, :with_media_object,
                                        status_code: 'COMPLETED')
       media_object = master_file.media_object
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
       expect(media_object.master_files.to_a.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
@@ -129,10 +129,10 @@ describe BatchEntries do
     end
 
     it 'records an encoding error if the MediaObject has MasterFiles that have errored' do
-      master_file = FactoryGirl.create(:master_file, :with_media_object,
+      master_file = FactoryBot.create(:master_file, :with_media_object,
                                        status_code: 'FAILED')
       media_object = master_file.media_object
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
       expect(media_object.master_files.to_a.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
@@ -143,10 +143,10 @@ describe BatchEntries do
     end
 
     it 'records an encoding error if the MediaObject has MasterFiles that are cancelled' do
-      master_file = FactoryGirl.create(:master_file, :with_media_object,
+      master_file = FactoryBot.create(:master_file, :with_media_object,
                                        status_code: 'CANCELLED')
       media_object = master_file.media_object
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
       expect(media_object.master_files.to_a.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
@@ -157,10 +157,10 @@ describe BatchEntries do
     end
 
     it 'records neither error nor success nor finished if MediaObject has MasterFiles that are not errored or successful' do
-      master_file = FactoryGirl.create(:master_file, :with_media_object,
+      master_file = FactoryBot.create(:master_file, :with_media_object,
                                        status_code: 'RUNNING')
       media_object = master_file.media_object
-      batch_entry = FactoryGirl.build(:batch_entries, media_object_pid: media_object.id)
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
       expect(media_object.master_files.to_a.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)

--- a/spec/models/batch_registries_spec.rb
+++ b/spec/models/batch_registries_spec.rb
@@ -61,10 +61,10 @@ describe BatchRegistries do
 
  describe 'encoding tracking' do
    it 'records encoding success if all of the BatchEntries are successful' do
-     batch_registry = FactoryGirl.create(:batch_registries)
-     batch_entry1 = FactoryGirl.create(:batch_entries,
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
-     batch_entry2 = FactoryGirl.create(:batch_entries,
+     batch_entry2 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
      allow(batch_entry1).to receive(:encoding_success?).and_return(true)
      allow(batch_entry1).to receive(:encoding_error?).and_return(false)
@@ -81,10 +81,10 @@ describe BatchRegistries do
    end
 
    it 'records an encoding error if one of the BatchEntries has an encoding error' do
-     batch_registry = FactoryGirl.create(:batch_registries)
-     batch_entry1 = FactoryGirl.create(:batch_entries,
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
-     batch_entry2 = FactoryGirl.create(:batch_entries,
+     batch_entry2 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
 
      # Cheat a little to avoid database fetch
@@ -102,10 +102,10 @@ describe BatchRegistries do
    end
 
    it 'records as not finished if one of the BatchEntries is not finished' do
-     batch_registry = FactoryGirl.create(:batch_registries)
-     batch_entry1 = FactoryGirl.create(:batch_entries,
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
-     batch_entry2 = FactoryGirl.create(:batch_entries,
+     batch_entry2 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
 
      # Cheat a little to avoid database fetch

--- a/spec/models/batch_registries_spec.rb
+++ b/spec/models/batch_registries_spec.rb
@@ -58,4 +58,69 @@ describe BatchRegistries do
       expect { subject.file_name = "file.mp4" }.not_to change { subject.replay_name }
     end
   end
+
+ describe 'encoding tracking' do
+   it 'records encoding success if all of the BatchEntries are successful' do
+     batch_registry = FactoryGirl.create(:batch_registries)
+     batch_entry1 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(false)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     expect(batch_registry.encoding_finished?).to eq(true)
+     expect(batch_registry.encoding_success?).to eq(true)
+     expect(batch_registry.encoding_error?).to eq(false)
+   end
+
+   it 'records an encoding error if one of the BatchEntries has an encoding error' do
+     batch_registry = FactoryGirl.create(:batch_registries)
+     batch_entry1 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(false)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(true)
+
+     expect(batch_registry.encoding_finished?).to eq(true)
+     expect(batch_registry.encoding_success?).to eq(false)
+     expect(batch_registry.encoding_error?).to eq(true)
+   end
+
+   it 'records as not finished if one of the BatchEntries is not finished' do
+     batch_registry = FactoryGirl.create(:batch_registries)
+     batch_entry1 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryGirl.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(false)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(false)
+
+     expect(batch_registry.encoding_finished?).to eq(false)
+     expect(batch_registry.encoding_success?).to eq(false)
+     expect(batch_registry.encoding_error?).to eq(false)
+   end
+
+ end
 end


### PR DESCRIPTION
It uses an unused attribute called `processed_email_sent` in the `BatchRegistries` class
to flag whether an email was sent already about this. Added some behaviour to the
`BatchEntries` and `BatchRegistries` classes to track encoding status.

Initiated via the rake task `avalon:batch:ingest_status_check` that is run via cron.
See app/jobs/ingest_batch_status_email_jobs.rb for mail entry point.