### PR TITLE
Allow JSON access to public published media objects without an API token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -124,7 +124,9 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
-    if current_user
+    if request.format == :json
+      head :unauthorized
+    elsif current_user
       redirect_to root_path, flash: { notice: 'You are not authorized to perform this action.' }
     else
       session[:previous_url] = request.fullpath unless request.xhr?

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -23,8 +23,8 @@ class MediaObjectsController < ApplicationController
   include SecurityHelper
 
   before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details]
-  load_and_authorize_resource except: [:create, :json_update, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections]
-  # authorize_resource only: [:create, :update]
+  load_and_authorize_resource except: [:create, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections]
+  authorize_resource only: [:create]
 
   before_action :inject_workflow_steps, only: [:edit, :update], unless: proc { request.format.json? }
   before_action :load_player_context, only: [:show]
@@ -164,7 +164,6 @@ class MediaObjectsController < ApplicationController
 
   # PUT /media_objects/avalon:1.json
   def json_update
-    @media_object = MediaObject.find(params[:id])
     # Preset the workflow to the last workflow step to ensure validators run
     @media_object.workflow.last_completed_step = HYDRANT_STEPS.last.step
     update_media_object

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -23,7 +23,6 @@ class MediaObjectsController < ApplicationController
   include SecurityHelper
 
   before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details]
-  before_action :authenticate_api!, only: [:show, :create, :json_update], if: proc { request.format.json? }
   load_and_authorize_resource except: [:create, :json_update, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections]
   # authorize_resource only: [:create, :update]
 
@@ -46,10 +45,6 @@ class MediaObjectsController < ApplicationController
 
   def can_embed?
     params[:action] == 'show'
-  end
-
-  def authenticate_api!
-    return head :unauthorized if !signed_in?
   end
 
   def confirm_remove

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -35,16 +35,17 @@ describe MediaObjectsController, type: :controller do
         expect(get :index, format: 'json').to have_http_status(401)
         expect(post :create, format: 'json').to have_http_status(401)
         expect(put :update, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
+        expect(put :json_update, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
       end
       describe '#show' do
         it "returns 401 when no token is present, and unpublished" do
-          expect(get :show, id: media_object.id, format: 'json').to have_http_status(401)
+          expect(get :show, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
         end
         it "returns 401 for published private items when no token is present" do
-          expect(get :show, id: private_media_object.id, format: 'json').to have_http_status(401)
+          expect(get :show, params: { id: private_media_object.id, format: 'json' }).to have_http_status(401)
         end
         it "permits published public items when no token is present" do
-          expect(get :show, id: published_media_object.id, format: 'json').to have_http_status(200)
+          expect(get :show, params: { id: published_media_object.id, format: 'json' }).to have_http_status(200)
         end
       end
       it "all routes should return 403 when a bad token in present" do
@@ -53,6 +54,7 @@ describe MediaObjectsController, type: :controller do
         expect(get :show, params: { id: media_object.id, format: 'json' }).to have_http_status(403)
         expect(post :create, format: 'json').to have_http_status(403)
         expect(put :update, params: { id: media_object.id, format: 'json' }).to have_http_status(403)
+        expect(put :json_update, params: { id: media_object.id, format: 'json' }).to have_http_status(403)
       end
     end
     describe 'normal auth' do
@@ -63,10 +65,8 @@ describe MediaObjectsController, type: :controller do
         end
         it "all routes should redirect to sign in" do
           expect(get :show, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(get :show_progress, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
           expect(get :edit, params: { id: media_object.id }).to redirect_to(new_user_session_path)
           expect(get :confirm_remove, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          #expect(post :create).to redirect_to(new_user_session_path) # route accessible by json only
           expect(put :update, params: { id: media_object.id }).to redirect_to(new_user_session_path)
           expect(put :update_status, params: { id: media_object.id }).to redirect_to(new_user_session_path)
           expect(get :tree, params: { id: media_object.id }).to redirect_to(new_user_session_path)
@@ -74,6 +74,11 @@ describe MediaObjectsController, type: :controller do
           expect(delete :destroy, params: { id: media_object.id }).to redirect_to(new_user_session_path)
           expect(get :add_to_playlist_form, params: { id: media_object.id }).to redirect_to(new_user_session_path)
           expect(post :add_to_playlist, params: { id: media_object.id }).to redirect_to(new_user_session_path)
+        end
+        it "json routes should return 401" do
+          expect(post :create, format: 'json').to have_http_status(401)
+          expect(put :json_update, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
+          expect(get :show_progress, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
         end
       end
       context 'with end-user' do
@@ -88,7 +93,6 @@ describe MediaObjectsController, type: :controller do
           expect(get :show, params: { id: media_object.id }).to redirect_to(root_path)
           expect(get :edit, params: { id: media_object.id }).to redirect_to(root_path)
           expect(get :confirm_remove, params: { id: media_object.id }).to redirect_to(root_path)
-          #expect(post :create).to redirect_to(root_path) # route accessible by json only
           expect(put :update, params: { id: media_object.id }).to redirect_to(root_path)
           expect(put :update_status, params: { id: media_object.id }).to redirect_to(root_path)
           expect(get :tree, params: { id: media_object.id }).to redirect_to(root_path)
@@ -97,8 +101,10 @@ describe MediaObjectsController, type: :controller do
           expect(get :add_to_playlist_form, params: { id: media_object.id }).to redirect_to(root_path)
           expect(post :add_to_playlist, params: { id: media_object.id }).to redirect_to(root_path)
         end
-        it "show progress should return 401" do
-          expect(get :show_progress, id: media_object.id, format: 'json').to have_http_status(401)
+        it "json routes should return 401" do
+          expect(post :create, format: 'json').to have_http_status(401)
+          expect(put :json_update, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
+          expect(get :show_progress, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
         end
       end
     end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -25,15 +25,27 @@ describe MediaObjectsController, type: :controller do
 
   describe 'security' do
     let(:media_object) { FactoryBot.create(:media_object) }
+    let(:published_media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let(:private_media_object) { FactoryBot.create(:published_media_object, visibility: 'private') }
     describe 'ingest api' do
       before do
         ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
       end
-      it "all routes should return 401 when no token is present" do
+      it "most routes should return 401 when no token is present" do
         expect(get :index, format: 'json').to have_http_status(401)
-        expect(get :show, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
         expect(post :create, format: 'json').to have_http_status(401)
         expect(put :update, params: { id: media_object.id, format: 'json' }).to have_http_status(401)
+      end
+      describe '#show' do
+        it "returns 401 when no token is present, and unpublished" do
+          expect(get :show, id: media_object.id, format: 'json').to have_http_status(401)
+        end
+        it "returns 401 for published private items when no token is present" do
+          expect(get :show, id: private_media_object.id, format: 'json').to have_http_status(401)
+        end
+        it "permits published public items when no token is present" do
+          expect(get :show, id: published_media_object.id, format: 'json').to have_http_status(200)
+        end
       end
       it "all routes should return 403 when a bad token in present" do
         request.headers['Avalon-Api-Key'] = 'badtoken'
@@ -74,7 +86,6 @@ describe MediaObjectsController, type: :controller do
         end
         it "all routes should redirect to /" do
           expect(get :show, params: { id: media_object.id }).to redirect_to(root_path)
-          expect(get :show_progress, params: { id: media_object.id, format: 'json' }).to redirect_to(root_path)
           expect(get :edit, params: { id: media_object.id }).to redirect_to(root_path)
           expect(get :confirm_remove, params: { id: media_object.id }).to redirect_to(root_path)
           #expect(post :create).to redirect_to(root_path) # route accessible by json only
@@ -85,6 +96,9 @@ describe MediaObjectsController, type: :controller do
           expect(delete :destroy, params: { id: media_object.id }).to redirect_to(root_path)
           expect(get :add_to_playlist_form, params: { id: media_object.id }).to redirect_to(root_path)
           expect(post :add_to_playlist, params: { id: media_object.id }).to redirect_to(root_path)
+        end
+        it "show progress should return 401" do
+          expect(get :show_progress, id: media_object.id, format: 'json').to have_http_status(401)
         end
       end
     end

--- a/spec/controllers/vocabulary_controller_spec.rb
+++ b/spec/controllers/vocabulary_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -57,10 +57,10 @@ describe VocabularyController, type: :controller do
           login_as :user
         end
         it "all routes should redirect to /" do
-          expect(get :index, format: 'json').to redirect_to(root_path)
-          expect(get :show, params: { id: vocab, format: 'json' }).to redirect_to(root_path)
-          expect(put :update, params: { id: vocab, format: 'json' }).to redirect_to(root_path)
-          expect(patch :update, params: { id: vocab, format: 'json' }).to redirect_to(root_path)
+          expect(get :index, format: 'json').to have_http_status(401)
+          expect(get :show, params: { id: vocab, format: 'json' }).to have_http_status(401)
+          expect(put :update, params: { id: vocab, format: 'json' }).to have_http_status(401)
+          expect(patch :update, params: { id: vocab, format: 'json' }).to have_http_status(401)
         end
       end
     end


### PR DESCRIPTION
This PR is based on https://github.com/avalonmediasystem/avalon/pull/3004.
Changes to that PR: 
- Merge with Rails 5.1 changes in develop
- Add additional tests for `create` and `json_update`
- Fix case where a logged-in user without api token was not getting 401 for `create` and `json_update`