### PR TITLE
Add configurable recaptcha to comments page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git'
 gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-toggle-rails.git', tag: 'v2.2.1.0'
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
+gem 'recaptcha', require: 'recaptcha/rails'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,6 +633,8 @@ GEM
       rdf (~> 2.1)
     rdf-xsd (2.2.0)
       rdf (~> 2.1)
+    recaptcha (4.12.0)
+      json
     redis (3.3.5)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -920,6 +922,7 @@ DEPENDENCIES
   rb-readline
   rdf (~> 2.2)
   rdf-rdfxml
+  recaptcha
   redis-rails
   resque (~> 1.27.0)
   resque-scheduler (~> 4.3.0)

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -26,9 +26,14 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= comment.text_field :name, label: 'Name' %>
       <%= comment.hidden_field :nickname %>
       <%= comment.email_field :email, label: 'Email address' %>
-      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %> 
-      <%= comment.select :subject, @subjects, prompt: 'Select one' %>    
+      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %>
+      <%= comment.select :subject, @subjects, prompt: 'Select one' %>
       <%= comment.text_area :comment, rows: 10 %>
+      <% if Settings.recaptcha.present?%>
+        <div class="form-group">
+          <%= recaptcha_tags %>
+        </div>
+      <% end %>
       <%= comment.primary "Submit comments" %>
     </fieldset>
   <% end %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,8 @@
+
+# config/initializers/recaptcha.rb
+if Settings.recaptcha.present?
+  Recaptcha.configure do |config|
+    config.site_key = Settings.recaptcha.site_key
+    config.secret_key = Settings.recaptcha.secret_key
+  end
+end


### PR DESCRIPTION
Looks for these configuration settings: 

recaptcha:
  site_key: abc
  secret_key: 123

Values for key pair must be obtained from Google (https://developers.google.com/recaptcha/intro).