### PR TITLE
Add configurable recaptcha to comments page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git'
 gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-toggle-rails.git', tag: 'v2.2.1.0'
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
+gem 'recaptcha', require: 'recaptcha/rails'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", branch: 'rails5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,6 +636,8 @@ GEM
       rdf (~> 2.1)
     rdf-xsd (2.2.1)
       rdf (>= 2.2, < 4.0)
+    recaptcha (4.12.0)
+      json
     redis (4.0.1)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -922,6 +924,7 @@ DEPENDENCIES
   rb-readline
   rdf (~> 2.2)
   rdf-rdfxml
+  recaptcha
   redis-rails
   resque (~> 1.27.0)
   resque-scheduler (~> 4.3.0)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,17 +29,16 @@ class CommentsController < ApplicationController
     @comment.subject = params[:comment][:subject]
     @comment.comment = params[:comment][:comment]
 
-    if (@comment.valid?)
+    if @comment.valid? && (Settings.recaptcha.blank? || verify_recaptcha(model: @comment))
       begin
         CommentsMailer.contact_email(@comment.to_h).deliver_later
       rescue Errno::ECONNRESET => e
         logger.warn "The mail server does not appear to be responding \n #{e}"
-
-	flash[:notice] = "The message could not be sent in a timely fashion. Contact us at #{Settings.email.support} to report the problem."
-	render action: "index"
+        flash[:notice] = "The message could not be sent in a timely fashion. Contact us at #{Settings.email.support} to report the problem."
+        render action: "index"
       end
     else
-      flash[:error] = "There were problems submitting your comment. Please correct the errors and try again."
+      flash[:error] = "Your comment was missing required information. Please complete all fields and resubmit."
       render action: "index"
     end
   end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -26,9 +26,14 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= comment.text_field :name, label: 'Name' %>
       <%= comment.hidden_field :nickname %>
       <%= comment.email_field :email, label: 'Email address' %>
-      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %> 
-      <%= comment.select :subject, @subjects, prompt: 'Select one' %>    
+      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %>
+      <%= comment.select :subject, @subjects, prompt: 'Select one' %>
       <%= comment.text_area :comment, rows: 10 %>
+      <% if Settings.recaptcha.present?%>
+        <div class="form-group">
+          <%= recaptcha_tags %>
+        </div>
+      <% end %>
       <%= comment.primary "Submit comments" %>
     </fieldset>
   <% end %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,8 @@
+
+# config/initializers/recaptcha.rb
+if Settings.recaptcha.present?
+  Recaptcha.configure do |config|
+    config.site_key = Settings.recaptcha.site_key
+    config.secret_key = Settings.recaptcha.secret_key
+  end
+end


### PR DESCRIPTION
Forward port from 6.4-stable branch.

Looks for these configuration settings:

recaptcha:
site_key: abc
secret_key: 123

Values for key pair must be obtained from Google (https://developers.google.com/recaptcha/intro).