### PR TITLE
Bump rubyzip due to security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -731,7 +731,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     rufus-scheduler (3.5.0)
       fugit (~> 1.1, >= 1.1.1)
     safe_yaml (1.0.4)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-1000544