### PR TITLE
Update locking_runner script to delete stale lock files

### DIFF
--- a/script/locking_runner
+++ b/script/locking_runner
@@ -5,6 +5,13 @@
 
 SEMAPHORE=$1
 LOCKFILE=tmp/pids/$SEMAPHORE
+
+if ( [ -e $LOCKFILE ] && ! kill -0 $(< $LOCKFILE) ) 2> /dev/null;
+then
+  echo "$0: Deleting stale lock file: $LOCKFILE"
+  rm -f "$LOCKFILE";
+fi
+
 shift
 
 if ( set -o noclobber; echo "$$" > "$LOCKFILE") 2> /dev/null; 

--- a/script/locking_runner
+++ b/script/locking_runner
@@ -6,7 +6,7 @@
 SEMAPHORE=$1
 LOCKFILE=tmp/pids/$SEMAPHORE
 
-if ( [ -e $LOCKFILE ] && ! kill -0 $(< $LOCKFILE) ) 2> /dev/null;
+if ( [ -e $LOCKFILE ] && ! ps -p $(< $LOCKFILE) ) > /dev/null 2>&1;
 then
   echo "$0: Deleting stale lock file: $LOCKFILE"
   rm -f "$LOCKFILE";


### PR DESCRIPTION
We had a power interruption which caused a stale lock file to stick around and prevent batch_ingest cron job from running. I have updated the locking runner script to delete lock file if there is no running process with the PID in the lock file.