### PR TITLE
Batch ingest post-encoding email

### DIFF
--- a/app/jobs/ingest_batch_status_email_jobs.rb
+++ b/app/jobs/ingest_batch_status_email_jobs.rb
@@ -41,6 +41,21 @@ module IngestBatchStatusEmailJobs
         end
         br.save
       end
+
+      # Done encoding? (either successfully or with error)
+      BatchRegistries.where(processed_email_sent: false,
+                            error: false,
+                            complete: true).each do |br|
+        if br.encoding_finished?
+          BatchRegistriesMailer.batch_encoding_finished(br).deliver_now
+          br.processed_email_sent = true
+          if br.encoding_error?
+            br.error = true
+          end
+          br.save
+        end
+      end
+
     end
   end
 

--- a/app/mailers/batch_registries_mailer.rb
+++ b/app/mailers/batch_registries_mailer.rb
@@ -63,12 +63,12 @@ class BatchRegistriesMailer < ApplicationMailer
     @collection_text = Admin::Collection.find(@batch_registry.collection).name if Admin::Collection.exists?(@batch_registry.collection)
     @collection_text ||= "Collection"
 
-    @status = @batch_registry.encoding_success? ? "Success" : "Errors present"
+    @status = @batch_registry.encoding_success? ? "Success" : "Errors Present"
 
     mail(
       to: @email,
       from: Settings.email.notification,
-      subject: "#{@status}: Batch encoding #{@batch_registry.file_name} for #{@collection_text}"
+      subject: "#{@status}: Batch Registry #{@batch_registry.file_name} for #{@collection_text} has finished encoding"
     )
   end
 

--- a/app/mailers/batch_registries_mailer.rb
+++ b/app/mailers/batch_registries_mailer.rb
@@ -53,4 +53,23 @@ class BatchRegistriesMailer < ApplicationMailer
       subject: "Batch Registry #{@batch_registry.file_name} for #{collection_text} has stalled"
     )
   end
+
+  # Update the progress of finished (success or error) batch encoding
+  def batch_encoding_finished(batch_registry)
+    @batch_registry = batch_registry
+    @user = User.find(@batch_registry.user_id)
+    @email = @user.email unless @user.nil?
+    @email ||= Settings.email.notification
+    @collection_text = Admin::Collection.find(@batch_registry.collection).name if Admin::Collection.exists?(@batch_registry.collection)
+    @collection_text ||= "Collection"
+
+    @status = @batch_registry.encoding_success? ? "Success" : "Errors present"
+
+    mail(
+      to: @email,
+      from: Settings.email.notification,
+      subject: "#{@status}: Batch encoding #{@batch_registry.file_name} for #{@collection_text}"
+    )
+  end
+
 end

--- a/app/views/batch_registries_mailer/_batch_encoding_entry_row.html.erb
+++ b/app/views/batch_registries_mailer/_batch_encoding_entry_row.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <td> <%= batch_entry.position + 2 %> </td>
+  <% media_object = MediaObject.where(id: batch_entry.media_object_pid).first %>
+  <% if media_object %>
+    <% link_url = media_object.permalink %>
+    <% link_url = media_object_url(media_object) if link_url.blank? %>
+    <td> <%= link_to(batch_entry.media_object_pid, link_url) %></td>
+  <% else %>
+    <td> Item (<%= batch_entry.media_object_pid %>) was created but no longer exists </td>
+  <% end %>
+</tr>

--- a/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
+++ b/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
@@ -12,7 +12,9 @@ Batch encoding complete!
 </dl>
 
 <% if @batch_registry.encoding_error? %>
-  <h2>Spreadsheet rows with encoding errors</h2>
+  <div class="alert alert-danger">
+    The following rows of your spreadsheet had encoding errors:
+  </div>
   <table>
     <tr>
       <th>Row</th>
@@ -25,7 +27,9 @@ Batch encoding complete!
 <% end %>
 
 <% if @batch_registry.batch_entries_with_encoding_success.any? %>
-  <h2>Successfully encoded spreadsheet rows</h2>
+  <div class="alert">
+    The following rows of your spreadsheet successfully finished encoding:
+  </div>
   <table>
     <tr>
       <th>Row</th>

--- a/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
+++ b/app/views/batch_registries_mailer/batch_encoding_finished.html.erb
@@ -1,0 +1,38 @@
+Batch encoding complete!
+
+<dl>
+  <dt>Manifest:</dt>
+  <dd><%= @batch_registry.file_name %></dd>
+  <dt>Email:</dt>
+  <dd><%= @email %></dd>
+  <dt>Status:</dt>
+  <dd><%= @status %></dd>
+  <dt>Collection:</dt>
+  <dd><%= @collection_text %></dd>
+</dl>
+
+<% if @batch_registry.encoding_error? %>
+  <h2>Spreadsheet rows with encoding errors</h2>
+  <table>
+    <tr>
+      <th>Row</th>
+      <th>Media Object ID</th>
+    </tr>
+    <% @batch_registry.batch_entries_with_encoding_error.each do |batch_entry| %>
+      <%= render partial: 'batch_encoding_entry_row', locals: { batch_entry: batch_entry } %>
+    <% end %>
+  </table>
+<% end %>
+
+<% if @batch_registry.batch_entries_with_encoding_success.any? %>
+  <h2>Successfully encoded spreadsheet rows</h2>
+  <table>
+    <tr>
+      <th>Row</th>
+      <th>Media Object ID</th>
+    </tr>
+    <% @batch_registry.batch_entries_with_encoding_success.each do |batch_entry| %>
+      <%= render partial: 'batch_encoding_entry_row', locals: { batch_entry: batch_entry } %>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
+++ b/app/views/batch_registries_mailer/batch_registration_finished_mailer.html.erb
@@ -38,7 +38,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 <% unless @completed_items.empty? %>
   <div class="alert">
-    The following rows of your spreadsheet successfully completed
+    The following rows of your spreadsheet successfully completed:
   </div>
   <table>
     <tr>

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -17,6 +17,7 @@ require 'rails_helper'
 describe IngestBatchStatusEmailJobs do
   describe IngestBatchStatusEmailJobs::IngestFinished do
     let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id) }
+    let(:completed_batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
     let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:batch_mailer) { double }
 
@@ -51,6 +52,30 @@ describe IngestBatchStatusEmailJobs do
       expect(batch_registry.reload.error).to be false
       expect(batch_registry.reload.completed_email_sent).to be false
       expect(batch_registry.reload.complete).to be false
+    end
+
+    it 'sends an email when encoding is complete with success' do
+      FactoryBot.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
+
+      expect(BatchRegistriesMailer).to receive(:batch_registration_finished_mailer).once.with(batch_registry).and_return(batch_mailer)
+      described_class.perform_now
+      completed_batch_registry.reload
+      expect(completed_batch_registry.processed_email_sent).to be true
+      expect(completed_batch_registry.error).to be false
+    end
+
+    it 'sends an email when encoding is complete with error' do
+      FactoryBot.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(true)
+
+      expect(BatchRegistriesMailer).to receive(:batch_registration_finished_mailer).once.with(batch_registry).and_return(batch_mailer)
+      described_class.perform_now
+      completed_batch_registry.reload
+      expect(completed_batch_registry.processed_email_sent).to be true
+      expect(completed_batch_registry.error).to be true
     end
 
     context 'with locked batch' do

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -78,6 +78,18 @@ describe IngestBatchStatusEmailJobs do
       expect(completed_batch_registry.error).to be true
     end
 
+    it 'does not send an email when encoding is in progress' do
+      FactoryBot.create(:batch_entries, batch_registries: completed_batch_registry, complete: true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
+
+      expect(BatchRegistriesMailer).not_to receive(:batch_registration_finished_mailer)
+      described_class.perform_now
+      completed_batch_registry.reload
+      expect(completed_batch_registry.processed_email_sent).to be false
+      expect(completed_batch_registry.error).to be false
+    end
+
     context 'with locked batch' do
       let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id, locked: true) }
 

--- a/spec/mailers/batch_registries_mailer_spec.rb
+++ b/spec/mailers/batch_registries_mailer_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
       expect(email.subject).to include batch_registries.file_name
       expect(email.subject).to include collection.name
 
-      expect(email.subject).to include 'Errors present'
+      expect(email.subject).to include 'Errors Present'
 
       expect(email).to have_body_text(batch_registries.file_name)
       expect(email).to have_body_text("<a href=\"#{media_object.permalink}\">")

--- a/spec/mailers/batch_registries_mailer_spec.rb
+++ b/spec/mailers/batch_registries_mailer_spec.rb
@@ -84,6 +84,44 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
     end
   end
 
+  describe 'batch_encoding_finished' do
+    let(:batch_registries) { FactoryBot.create(:batch_registries, user_id: manager.id) }
+    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let!(:collection) { FactoryBot.create(:collection, id: 'k32jf0kw') }
+    let!(:batch_entries) { FactoryBot.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
+    let(:media_object) { FactoryBot.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }
+
+    it "correctly sets up the email indicating that encoding is successful" do
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(true)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(false)
+      email = BatchRegistriesMailer.batch_encoding_finished(batch_registries)
+      expect(email.to).to include(manager.email)
+      expect(email.subject).to include batch_registries.file_name
+      expect(email.subject).to include collection.name
+
+      expect(email.subject).to include 'Success'
+
+      expect(email).to have_body_text(batch_registries.file_name)
+      expect(email).to have_body_text("<a href=\"#{media_object.permalink}\">")
+      expect(email).to have_body_text(media_object.id)
+    end
+
+    it "correctly sets up the email indicating that encoding has errors" do
+      allow_any_instance_of(BatchEntries).to receive(:encoding_success?).and_return(false)
+      allow_any_instance_of(BatchEntries).to receive(:encoding_error?).and_return(true)
+      email = BatchRegistriesMailer.batch_encoding_finished(batch_registries)
+      expect(email.to).to include(manager.email)
+      expect(email.subject).to include batch_registries.file_name
+      expect(email.subject).to include collection.name
+
+      expect(email.subject).to include 'Errors present'
+
+      expect(email).to have_body_text(batch_registries.file_name)
+      expect(email).to have_body_text("<a href=\"#{media_object.permalink}\">")
+      expect(email).to have_body_text(media_object.id)
+    end
+  end
+
   describe 'batch_registration_stalled_mailer' do
     let(:batch_registries) { FactoryBot.create(:batch_registries) }
     let(:notification_email_address) { Settings.email.notification }

--- a/spec/models/batch_entries_spec.rb
+++ b/spec/models/batch_entries_spec.rb
@@ -170,6 +170,23 @@ describe BatchEntries do
       expect(batch_entry.encoding_error?).to be_falsey
     end
 
-  end
+    it 'records neither error nor success nor finished if MediaObject has any MasterFiles that are not errored or successful' do
+      master_file1 = FactoryBot.create(:master_file, :with_media_object,
+                                       status_code: 'COMPLETED')
+      media_object = master_file1.media_object
+      master_file2 = FactoryBot.create(:master_file, media_object: media_object,
+                                       status_code: 'FAILED')
+      master_file3 = FactoryBot.create(:master_file, media_object: media_object,
+                                       status_code: 'RUNNING')
 
+      batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
+      files = double()
+      allow(batch_entry).to receive(:files).and_return(files)
+      allow(files).to receive(:count).and_return(3)
+
+      expect(batch_entry.encoding_finished?).to be_falsey
+      expect(batch_entry.encoding_success?).to be_falsey
+      expect(batch_entry.encoding_error?).to be_falsey
+    end
+  end
 end

--- a/spec/models/batch_registries_spec.rb
+++ b/spec/models/batch_registries_spec.rb
@@ -107,12 +107,17 @@ describe BatchRegistries do
                                        batch_registries_id: batch_registry.id)
      batch_entry2 = FactoryBot.create(:batch_entries,
                                        batch_registries_id: batch_registry.id)
+     batch_entry3 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
 
      # Cheat a little to avoid database fetch
-     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2, batch_entry3])
 
      allow(batch_entry1).to receive(:encoding_success?).and_return(true)
      allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(false)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(true)
 
      allow(batch_entry2).to receive(:encoding_success?).and_return(false)
      allow(batch_entry2).to receive(:encoding_error?).and_return(false)
@@ -121,6 +126,5 @@ describe BatchRegistries do
      expect(batch_registry.encoding_success?).to eq(false)
      expect(batch_registry.encoding_error?).to eq(false)
    end
-
  end
 end

--- a/spec/models/batch_registries_spec.rb
+++ b/spec/models/batch_registries_spec.rb
@@ -58,4 +58,69 @@ describe BatchRegistries do
       expect { subject.file_name = "file.mp4" }.not_to change { subject.replay_name }
     end
   end
+
+ describe 'encoding tracking' do
+   it 'records encoding success if all of the BatchEntries are successful' do
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(false)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     expect(batch_registry.encoding_finished?).to eq(true)
+     expect(batch_registry.encoding_success?).to eq(true)
+     expect(batch_registry.encoding_error?).to eq(false)
+   end
+
+   it 'records an encoding error if one of the BatchEntries has an encoding error' do
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(false)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(true)
+
+     expect(batch_registry.encoding_finished?).to eq(true)
+     expect(batch_registry.encoding_success?).to eq(false)
+     expect(batch_registry.encoding_error?).to eq(true)
+   end
+
+   it 'records as not finished if one of the BatchEntries is not finished' do
+     batch_registry = FactoryBot.create(:batch_registries)
+     batch_entry1 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+     batch_entry2 = FactoryBot.create(:batch_entries,
+                                       batch_registries_id: batch_registry.id)
+
+     # Cheat a little to avoid database fetch
+     allow(batch_registry).to receive(:batch_entries).and_return([batch_entry1, batch_entry2])
+
+     allow(batch_entry1).to receive(:encoding_success?).and_return(true)
+     allow(batch_entry1).to receive(:encoding_error?).and_return(false)
+
+     allow(batch_entry2).to receive(:encoding_success?).and_return(false)
+     allow(batch_entry2).to receive(:encoding_error?).and_return(false)
+
+     expect(batch_registry.encoding_finished?).to eq(false)
+     expect(batch_registry.encoding_success?).to eq(false)
+     expect(batch_registry.encoding_error?).to eq(false)
+   end
+
+ end
 end


### PR DESCRIPTION
Improves on @cwant's #3061 (squashed into a single commit).  This still needs to be manually tested and POs should review the generated email.