### PR TITLE
Generate iiif manifests using iiif_manifest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-togg
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
 gem 'recaptcha', require: 'recaptcha/rails'
+gem 'iiif_manifest'
+gem 'rack-cors', require: 'rack/cors'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", branch: 'rails5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,8 @@ GEM
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     iconv (1.0.5)
+    iiif_manifest (0.5.0)
+      activesupport (>= 4)
     ims-lti (1.1.13)
       builder
       oauth (>= 0.4.5, < 0.6)
@@ -573,6 +575,7 @@ GEM
     public_suffix (3.0.2)
     raabro (1.1.6)
     rack (2.0.6)
+    rack-cors (1.0.2)
     rack-protection (2.0.3)
       rack
     rack-test (1.1.0)
@@ -900,6 +903,7 @@ DEPENDENCIES
   hooks
   hydra-head (~> 10.6)
   iconv
+  iiif_manifest
   ims-lti (~> 1.1.13)
   jbuilder (~> 2.0)
   jquery-datatables
@@ -919,6 +923,7 @@ DEPENDENCIES
   poltergeist
   pry-byebug
   pry-rails
+  rack-cors
   rails (= 5.1.6)
   rails-controller-testing
   rb-readline

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -468,7 +468,7 @@ class MediaObjectsController < ApplicationController
 
     manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
     # TODO: implement thumbnail in iiif_manifest
-    manifest["thumbnail"] = [{"id" => presenter.thumbnail, "type" => 'Image'}] if presenter.thumbnail
+    manifest["thumbnail"] = [{ "id" => presenter.thumbnail, "type" => 'Image' }] if presenter.thumbnail
 
     respond_to do |wants|
       wants.json { render json: manifest.to_json }

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -22,8 +22,8 @@ class MediaObjectsController < ApplicationController
   include ConditionalPartials
   include SecurityHelper
 
-  before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details]
-  load_and_authorize_resource except: [:create, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections]
+  before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details, :manifest]
+  load_and_authorize_resource except: [:create, :destroy, :update_status, :set_session_quality, :tree, :deliver_content, :confirm_remove, :show_stream_details, :add_to_playlist_form, :add_to_playlist, :intercom_collections, :manifest]
   authorize_resource only: [:create]
 
   before_action :inject_workflow_steps, only: [:edit, :update], unless: proc { request.format.json? }
@@ -452,6 +452,27 @@ class MediaObjectsController < ApplicationController
         end
         render :json => result
       }
+    end
+  end
+
+  def manifest
+    @media_object = MediaObject.find(params[:id])
+    authorize! :read, @media_object
+
+    master_files = master_file_presenter
+    canvas_presenters = master_files.collect do |mf|
+      stream_info = secure_streams(mf.stream_details)
+      IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info)
+    end
+    presenter = IiifManifestPresenter.new(media_object: @media_object, master_files: canvas_presenters)
+
+    manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
+    # TODO: implement thumbnail in iiif_manifest
+    manifest["thumbnail"] = [{"id" => presenter.thumbnail, "type" => 'Image'}] if presenter.thumbnail
+
+    respond_to do |wants|
+      wants.json { render json: manifest.to_json }
+      wants.html { render json: manifest.to_json }
     end
   end
 

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -1,0 +1,122 @@
+class IiifCanvasPresenter
+  attr_reader :master_file, :stream_info
+  attr_accessor :media_fragment
+
+  def initialize(master_file:, stream_info:, media_fragment: nil)
+    @master_file = master_file
+    @stream_info = stream_info
+    @media_fragment = media_fragment
+  end
+
+  delegate :derivative_ids, :id, to: :master_file
+
+  def to_s
+    master_file.display_title
+  end
+
+  def range
+    structure_ng_xml.root.blank? ? simple_iiif_range : structure_to_iiif_range
+  end
+
+  # @return [IIIFManifest::V3::DisplayContent] the display content required by the manifest builder.
+  def display_content
+    master_file.is_video? ? video_content : audio_content
+  end
+
+  private
+
+    def video_content
+      # @see https://github.com/samvera-labs/iiif_manifest
+      stream_urls.collect { |label, url| video_display_content(url, label) }
+    end
+
+    def video_display_content(url, label = '')
+      IIIFManifest::V3::DisplayContent.new(url,
+                                           label: label,
+                                           width: master_file.width.to_i,
+                                           height: master_file.height.to_i,
+                                           duration: stream_info[:duration],
+                                           type: 'Video')
+    end
+
+    def audio_content
+      stream_urls.collect { |label, url| audio_display_content(url, label) }
+    end
+
+    def audio_display_content(url, label = '')
+      IIIFManifest::V3::DisplayContent.new(url,
+                                           label: label,
+                                           duration: stream_info[:duration],
+                                           type: 'Sound')
+    end
+
+    def stream_urls
+      stream_info[:stream_hls].collect do |d|
+        [d[:quality], d[:url]]
+      end
+    end
+
+    def simple_iiif_range
+      # TODO: embed_title?
+      IiifManifestRange.new(
+        label: { '@none'.to_sym => [stream_info[:embed_title]] },
+        items: [
+          IiifCanvasPresenter.new(master_file: master_file, stream_info: stream_info, media_fragment: 't=0,')
+        ]
+      )
+    end
+
+    def structure_to_iiif_range
+      div_to_iiif_range(structure_ng_xml.root)
+    end
+
+    def div_to_iiif_range(div_node)
+      items = div_node.children.select(&:element?).collect do |node|
+        if node.name == "Div"
+          div_to_iiif_range(node)
+        elsif node.name == "Span"
+          span_to_iiif_range(node)
+        end
+      end
+
+      # if a non-leaf node has no valid "Div" or "Span" children, then it would become empty range node containing no canvas
+      # raise an exception here as this error shall have been caught and handled by the parser and shall never happen here
+      raise Nokogiri::XML::SyntaxError, "Empty root or Div node: #{div_node[:label]}" if items.empty?
+
+      IiifManifestRange.new(
+        label: { '@none' => [div_node[:label]] },
+        items: items
+      )
+    end
+
+    def span_to_iiif_range(span_node)
+      fragment = "t=#{parse_hour_min_sec(span_node[:begin])},#{parse_hour_min_sec(span_node[:end])}"
+      IiifManifestRange.new(
+        label: { '@none' => [span_node[:label]] },
+        items: [
+          IiifCanvasPresenter.new(master_file: master_file, stream_info: stream_info, media_fragment: fragment)
+        ]
+      )
+    end
+
+    FLOAT_PATTERN = Regexp.new(/^\d+([.]\d*)?$/).freeze
+
+    def parse_hour_min_sec(s)
+      return nil if s.nil?
+      smh = s.split(':').reverse
+      (0..2).each do |i|
+        # Use Regexp.match? when we drop ruby 2.3 support
+        smh[i] = smh[i] =~ FLOAT_PATTERN ? Float(smh[i]) : 0
+      end
+      smh[0] + (60 * smh[1]) + (3600 * smh[2])
+    end
+
+    # Note that the method returns empty Nokogiri Document instead of nil when structure_tesim doesn't exist or is empty.
+    def structure_ng_xml
+      # TODO: The XML parser should handle invalid XML files, for ex, if a non-leaf node has no valid "Div" or "Span" children,
+      # in which case SyntaxError shall be prompted to the user during file upload.
+      # This can be done by defining some XML schema to require that at least one Div/Span child node exists
+      # under root or each Div node, otherwise Nokogiri::XML parser will report error, and raise exception here.
+      @structure_ng_xml ||= (s = master_file.structuralMetadata.content).nil? ? Nokogiri::XML(nil) : Nokogiri::XML(s)
+    end
+end

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -1,0 +1,85 @@
+class IiifManifestPresenter
+  attr_reader :media_object, :master_files
+
+  def initialize(media_object:, master_files:)
+    @media_object = media_object
+    @master_files = master_files
+  end
+
+  def file_set_presenters
+    # Only return master files that have derivatives to avoid oddities in the manifest and failures in iiif_manifest
+    master_files.select { |mf| mf.derivative_ids.size > 0 }
+  end
+
+  def work_presenters
+    []
+  end
+
+  def manifest_url
+    Rails.application.routes.url_helpers.manifest_media_object_url(media_object)
+  end
+
+  def description
+    media_object.abstract
+  end
+
+  def to_s
+    media_object.title
+  end
+
+  def manifest_metadata
+    @manifest_metadata ||= iiif_metadata_fields.collect do |f|
+      value = media_object.send(f)
+      next if value.blank?
+      { 'label' => f.to_s.titleize, 'value' => Array(value) }
+    end.compact
+  end
+
+  def thumbnail
+    @thumbnail ||= image_for(media_object.to_solr)
+  end
+
+  def ranges
+    [
+      IiifManifestRange.new(
+        label: { '@none'.to_sym => media_object.title },
+        items: file_set_presenters.collect(&:range)
+      )
+    ]
+  end
+
+  private
+
+    def iiif_metadata_fields
+      # TODO: refine and order this list of fields
+      [:title, :creator, :date_created, :date_issued, :note, :contributor,
+       :publisher, :subject, :genre, :geographic_subject, :temporal_subject, :topical_subject]
+    end
+
+    def image_for(document)
+      master_file_id = document["section_id_ssim"].try :first
+
+      video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image'.titleize) } rescue 0
+      audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording'.titleize) } rescue 0
+
+      if master_file_id
+        if video_count > 0
+         Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
+        elsif audio_count > 0
+          ActionController::Base.helpers.asset_url('audio_icon.png')
+        else
+          nil
+        end
+      else
+        if video_count > 0 && audio_count > 0
+          ActionController::Base.helpers.asset_url('hybrid_icon.png')
+        elsif video_count > audio_count
+          ActionController::Base.helpers.asset_url('video_icon.png')
+        elsif audio_count > video_count
+          ActionController::Base.helpers.asset_url('audio_icon.png')
+        else
+          nil
+        end
+      end
+    end
+end

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -8,7 +8,7 @@ class IiifManifestPresenter
 
   def file_set_presenters
     # Only return master files that have derivatives to avoid oddities in the manifest and failures in iiif_manifest
-    master_files.select { |mf| mf.derivative_ids.size > 0 }
+    master_files.select { |mf| !mf.derivative_ids.empty? }
   end
 
   def work_presenters
@@ -59,27 +59,21 @@ class IiifManifestPresenter
     def image_for(document)
       master_file_id = document["section_id_ssim"].try :first
 
-      video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image'.titleize) } rescue 0
-      audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording'.titleize) } rescue 0
+      video_count = document["avalon_resource_type_ssim"].count { |m| m.start_with?('moving image'.titleize) } rescue 0
+      audio_count = document["avalon_resource_type_ssim"].count { |m| m.start_with?('sound recording'.titleize) } rescue 0
 
       if master_file_id
         if video_count > 0
-         Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
+          Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
         elsif audio_count > 0
           ActionController::Base.helpers.asset_url('audio_icon.png')
-        else
-          nil
         end
-      else
-        if video_count > 0 && audio_count > 0
-          ActionController::Base.helpers.asset_url('hybrid_icon.png')
-        elsif video_count > audio_count
-          ActionController::Base.helpers.asset_url('video_icon.png')
-        elsif audio_count > video_count
-          ActionController::Base.helpers.asset_url('audio_icon.png')
-        else
-          nil
-        end
+      elsif video_count > 0 && audio_count > 0
+        ActionController::Base.helpers.asset_url('hybrid_icon.png')
+      elsif video_count > audio_count
+        ActionController::Base.helpers.asset_url('video_icon.png')
+      elsif audio_count > video_count
+        ActionController::Base.helpers.asset_url('audio_icon.png')
       end
     end
 end

--- a/app/models/iiif_manifest_range.rb
+++ b/app/models/iiif_manifest_range.rb
@@ -1,0 +1,8 @@
+class IiifManifestRange
+  attr_reader :label, :items
+
+  def initialize(label:, items: [])
+    @label = label
+    @items = items
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,13 @@ module Avalon
     config.active_job.queue_adapter = :resque
 
     config.action_dispatch.default_headers = { 'X-Frame-Options' => 'ALLOWALL' }
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/media_objects/*/manifest', headers: :any, methods: [:get]
+        resource '/master_files/*/thumbnail', headers: :any, methods: [:get]
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
       get :add_to_playlist_form
       post :add_to_playlist
       patch :intercom_push
+      get :manifest
     end
     collection do
       post :create, action: :create, constraints: { format: 'json' }


### PR DESCRIPTION
This PR generates IIIF presentation 3.0 manifests using the `iiif_manifest` gem and code copied from `hyrax-iiif_av` into new presenter objects.  This is a first pass which should mostly be right but the manifests have not been validated (no validator currently exists) and currently don't work in the timeliner (could be any reason) and don't playback in the UV examples page (probably due to HLS).  These manifests require authorization that is tied to the media object so if you can read the media object then you can view the iiif manifest.  Also included is `rack-cors` to provide a better way to configure and handle CORS headers.

Fixes #3113.

### Future work
- Refine and reorder the descriptive metadata included in the manifest
- Implement IIIF Auth
- Add thumbnails to individual canvases (probably requires changes to `iiif_manifest`)
- Performance improvements (ensure that `speedy_af` is used and nothing requires reifying)