### PR TITLE
Fix section playthrough by ensuring section ids that look like intege…

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -183,7 +183,7 @@ class MEJSPlayer {
 
     const $sections = $('#accordion').find('.panel-heading[data-section-id]');
     const sectionsIdArray = $sections.map((index, item) =>
-      $(item).data('sectionId')
+      $(item).data('sectionId').toString()
     );
     const currentIdIndex = [...sectionsIdArray].indexOf(t.currentStreamInfo.id);
 


### PR DESCRIPTION
…rs remain strings

jQuery's .data() function tries to convert values to their native types. So, if a section's fedora id happens to be all numeric, jquery will convert it into an integer.  Then it won't match when being compared to the same id represented as a string.  This happens two lines down and prevents playthrough from succeeding.