### PR TITLE
Test with ruby 2.6 and drop 2.3

### DIFF
--- a/.rubocop.cc.yml
+++ b/.rubocop.cc.yml
@@ -5,6 +5,8 @@ inherit_from:
   - bixby_default.yml
 
 AllCops:
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.1
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'

--- a/.rubocop.cc.yml
+++ b/.rubocop.cc.yml
@@ -5,7 +5,7 @@ inherit_from:
   - bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   TargetRailsVersion: 5.1
   DisplayCopNames: true
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   bixby: bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   TargetRailsVersion: 5.1
   DisplayCopNames: true
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,8 @@ inherit_gem:
   bixby: bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
-  TargetRailsVersion: 5.0
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.1
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.3
   - 2.4
   - 2.5
+  - 2.6
 dist: trusty
 sudo: required

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'media_element_add_to_playlist', git: 'https://github.com/avalonmediasystem/
 
 # Data Translation & Normalization
 gem 'edtf'
-gem 'iconv'
+gem 'iconv', '~> 1.0.6'
 gem 'marc'
 
 # Jobs

--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ group :test do
   gem 'rspec-retry'
   gem 'shoulda-matchers'
   gem 'simplecov'
-  gem 'webmock'
+  gem 'webmock', '~> 3.5.1'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,7 +832,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.4.2)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -951,7 +951,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   wavefile
   web-console
-  webmock
+  webmock (~> 3.5.1)
   whenever!
   with_locking
   xray-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
       rails (>= 3.2.6)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
-    iconv (1.0.5)
+    iconv (1.0.6)
     iiif_manifest (0.5.0)
       activesupport (>= 4)
     ims-lti (1.1.13)
@@ -902,7 +902,7 @@ DEPENDENCIES
   hashdiff
   hooks
   hydra-head (~> 10.6)
-  iconv
+  iconv (~> 1.0.6)
   iiif_manifest
   ims-lti (~> 1.1.13)
   jbuilder (~> 2.0)
@@ -959,4 +959,4 @@ DEPENDENCIES
   zoom
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
Ruby 2.6 was released on 12/25/2018 and Ruby 2.3 is EOL on 3/31/2019.