### PR TITLE
Bypass cancan authorization for structure post temporarily

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -295,7 +295,8 @@ class MasterFilesController < ApplicationController
 
   def set_structure
     @master_file = MasterFile.find(params[:id])
-    authorize! :edit, @master_file, message: "You do not have sufficient privileges"
+    # Bypass authorization check for now
+    # authorize! :edit, @master_file, message: "You do not have sufficient privileges"
     @master_file.structuralMetadata.content = StructuralMetadata.from_json(params[:json])
     @master_file.save
   end


### PR DESCRIPTION
We'll need a story to determine how to handle the authentication/authorization for the structure metadata editor.  If this structure endpoint is going to be an API for content owners to use then we should have a more robust Authentication mechanism than what exists for the ingest API.  If we don't plan on giving the users access to the api but instead rely on the SME living within the rails app then I don't think we need to handle authentication yet.