### PR TITLE
Strip html tags from structure labels in master_file#set_structure

### DIFF
--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -24,6 +24,12 @@ class StructuralMetadata < ActiveFedora::File
     Nokogiri::XML::Schema(File.read('public/avalon_structure.xsd'))
   end
 
+  @sanitizer = Rails::Html::FullSanitizer.new
+
+  def self.sanitize(s)
+    @sanitizer.sanitize(s)
+  end
+
   delegate :xpath, to: :ng_xml
 
   def self.content_valid?(content)
@@ -46,7 +52,7 @@ class StructuralMetadata < ActiveFedora::File
   def self.from_json(js)
     document = Nokogiri::XML::Document.new
     root_node = Nokogiri::XML::Node.new('Item', document)
-    root_node.set_attribute('label', js[:label])
+    root_node.set_attribute('label', sanitize(js[:label]))
     js[:items].each { |item| node_json_to_xml(item, root_node, document) }
     document.add_child(root_node)
     document.root.to_s
@@ -55,12 +61,12 @@ class StructuralMetadata < ActiveFedora::File
   def self.node_json_to_xml(item, node, document)
     if item[:type].casecmp('div').zero?
       new_node = Nokogiri::XML::Node.new('Div', document)
-      new_node.set_attribute('label', item[:label])
+      new_node.set_attribute('label', sanitize(item[:label]))
       item[:items].each { |i| node_json_to_xml(i, new_node, document) } if item[:items].present?
       node.add_child(new_node)
     elsif item[:type].casecmp('span').zero?
       new_node = Nokogiri::XML::Node.new('Span', document)
-      new_node.set_attribute('label', item[:label])
+      new_node.set_attribute('label', sanitize(item[:label]))
       new_node.set_attribute('begin', item[:begin])
       new_node.set_attribute('end', item[:end])
       node.add_child(new_node)

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -393,7 +393,7 @@ describe MasterFilesController do
 
   describe "#set_structure" do
     let(:master_file) { FactoryBot.create(:master_file, :with_media_object) }
-    let(:structure_json) { JSON.parse(File.read('spec/fixtures/structure.json')) }
+    let(:structure_json) { JSON.parse(File.read('spec/fixtures/structure_with_html.json')) }
     let(:structure_xml) { File.read('spec/fixtures/structure.xml') }
 
     before do
@@ -405,6 +405,11 @@ describe MasterFilesController do
 
     it "populates structuralMetadata datastream with xml translated from JSON" do
       expect(Nokogiri::XML(master_file.structuralMetadata.content).root).to be_equivalent_to(Nokogiri::XML(structure_xml).root)
+    end
+
+    it "strips html tags from JSON labels" do
+      expect(master_file.structuralMetadata.content).not_to include('<b>')
+      expect(master_file.structuralMetadata.content).not_to include('<i>')
     end
   end
 

--- a/spec/fixtures/structure_with_html.json
+++ b/spec/fixtures/structure_with_html.json
@@ -1,0 +1,102 @@
+{
+  "type": "div",
+  "label": "<b>CD 1</b>",
+  "items": [
+    {
+      "type": "div",
+      "label": "Copland, Three Piano Excerpts from Our Town",
+      "items": [
+        {
+          "type": "span",
+          "label": "Track 1. <i>Story of Our Town</i>",
+          "begin": "0",
+          "end": "0:09.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 2. Conversation at the Soda Fountain",
+          "begin": "0:10",
+          "end": "0:19.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 3. The Resting Place on the Hill",
+          "begin": "0:20",
+          "end": "0:29.99"
+        }
+      ]
+    },
+    {
+      "type": "div",
+      "label": "Copland, Four Episodes from Rodeo",
+      "items": [
+        {
+          "type": "span",
+          "label": "Track 4. Buckaroo Holiday",
+          "begin": "0:30",
+          "end": "0:39.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 5. Corral Nocturne",
+          "begin": "0:40",
+          "end": "0:49.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 6. Saturday Night Waltz",
+          "begin": "0:50",
+          "end": "0:59.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 7. Hoe-Down",
+          "begin": "1:00",
+          "end": "1:09.99"
+        }
+      ]
+    },
+    {
+      "type": "span",
+      "label": "Track 8. Copland, Piano Variations ",
+      "begin": "1:10",
+      "end": "1:19.99"
+    },
+    {
+      "type": "div",
+      "label": "Copland, Four Piano Blues",
+      "items": [
+        {
+          "type": "span",
+          "label": "Track 9. For Leo Smit: Freely poetic",
+          "begin": "1:20",
+          "end": "1:29.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 10. For Andor Foldes: Soft and languid",
+          "begin": "1:30",
+          "end": "1:39.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 11. For Willian Kapell: Muted and sensuous",
+          "begin": "1:40",
+          "end": "1:49.99"
+        },
+        {
+          "type": "span",
+          "label": "Track 12. For John Kirkpatrick: WIth bounce",
+          "begin": "1:50",
+          "end": "1:59.99"
+        }
+      ]
+    },
+    {
+      "type": "span",
+      "label": "Track 13. Copland, Danzon Cubano",
+      "begin": "2:00",
+      "end": "2:30"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3158 

Strips html tags from structural metadata labels as they are submitted through the master_files#set_structure endpoint.