### PR TITLE
Add homepage to manifest for link back to view page in avalon.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-togg
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
 gem 'recaptcha', require: 'recaptcha/rails'
-gem 'iiif_manifest', git: 'https://github.com/samvera-labs/iiif_manifest', branch: 'auth_service'
+gem 'iiif_manifest', git: 'https://github.com/samvera-labs/iiif_manifest'
 gem 'rack-cors', require: 'rack/cors'
 
 # Avalon Components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/iiif_manifest
-  revision: 5dc29418727d2a68b35f8e11693f968d55821bfc
-  branch: auth_service
+  revision: 8a02d10829d590f3f56e9cee4cfa89c36c8d4a5a
   specs:
     iiif_manifest (0.5.0)
       activesupport (>= 4)

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -48,6 +48,15 @@ class IiifManifestPresenter
     ]
   end
 
+  def homepage
+    {
+      id: Rails.application.routes.url_helpers.media_object_url(media_object),
+      type: "Text",
+      label: { "@none" => [I18n.t('iiif.manifest.homepageLabel')] },
+      format: "text/html"
+    }
+  end
+
   private
 
     def iiif_metadata_fields

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,3 +224,5 @@ en:
       header: "Please Log In"
       label: "Login Required"
       logoutLabel: "Log out"
+    manifest:
+      homepageLabel: "View in Repository"

--- a/spec/models/iiif_manifest_presenter_spec.rb
+++ b/spec/models/iiif_manifest_presenter_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe IiifManifestPresenter do
+  let(:media_object) { FactoryBot.build(:media_object) }
+  let(:master_file) { FactoryBot.build(:master_file, media_object: media_object) }
+  let(:presenter) { described_class.new(media_object: media_object, master_files: [master_file]) }
+
+  context 'homepage' do
+    subject { presenter.homepage }
+
+    it 'provices a homepage' do
+      expect(subject[:id]).to eq Rails.application.routes.url_helpers.media_object_url(media_object)
+      expect(subject[:type]).to eq "Text"
+      expect(subject[:format]).to eq "text/html"
+      expect(subject[:label]).to include("@none" => ["View in Repository"])
+    end
+  end
+end


### PR DESCRIPTION
Also switch to master of `iiif_manifest` gem since PRs were merged.

Closes #3191.