### PR TITLE
Monkey-patch AF to request ntriples during reindexing

### DIFF
--- a/config/initializers/active_fedora_reindexing.rb
+++ b/config/initializers/active_fedora_reindexing.rb
@@ -1,0 +1,16 @@
+ActiveFedora::Fedora.class_eval do
+    def ntriples_connection
+      authorized_connection.tap { |conn| conn.headers['Accept'] = 'application/n-triples' }
+    end
+
+    def build_ntriples_connection
+      ActiveFedora::InitializingConnection.new(ActiveFedora::CachingConnection.new(ntriples_connection, omit_ldpr_interaction_model: true), root_resource_path)
+    end
+end
+
+ActiveFedora::Indexing::DescendantFetcher.class_eval do
+  private
+    def rdf_resource
+      @rdf_resource ||= Ldp::Resource::RdfSource.new(ActiveFedora.fedora.build_ntriples_connection, uri)
+    end
+end


### PR DESCRIPTION
This can be removed when ActiveFedora releases this code and Avalon upgrades to use it.
Closes #2765