### PR TITLE
Add all descriptive metadata to media_object json show view

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -271,7 +271,7 @@ class MediaObject < ActiveFedora::Base
       published_by: avalon_publisher,
       published: published?,
       summary: abstract
-    }
+    }.merge(to_ingest_api_hash(false))
   end
 
   # Other validation to consider adding into future iterations is the ability to

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -873,6 +873,8 @@ describe MediaObjectsController, type: :controller do
         expect(json['published_by']).to eq(media_object.avalon_publisher)
         expect(json['published']).to eq(media_object.published?)
         expect(json['summary']).to eq(media_object.abstract)
+        expect(json['fields'].symbolize_keys).to eq(media_object.to_ingest_api_hash(false)[:fields])
+        expect(json['files'].collect(&:symbolize_keys)).to eq(media_object.to_ingest_api_hash(false)[:files])
       end
 
       it "should return 404 if requested media_object not present" do


### PR DESCRIPTION
Closes #3205 

Adds :fields (for media_object metadata) and :files (for master_file metadata) keys to json hash for media_object. 