### PR TITLE
Public items shouldn't require iiif auth workflow

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -286,7 +286,7 @@ class MasterFilesController < ApplicationController
     quality = params[:quality]
     if request.head?
       auth_token = request.headers['Authorization']&.sub('Bearer ', '')
-      if StreamToken.valid_token?(auth_token, master_file.id)
+      if StreamToken.valid_token?(auth_token, master_file.id) || can?(:read, master_file)
         return head :ok
       else
         return head :unauthorized

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -523,6 +523,8 @@ describe MasterFilesController do
   describe '#hls_manifest' do
     let(:media_object) { FactoryBot.create(:published_media_object) }
     let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
+    let(:public_media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let(:public_master_file) { FactoryBot.create(:master_file, media_object: public_media_object) }
 
     context 'with head request' do
       it 'returns unauthorized (401) with invalid auth token' do
@@ -534,6 +536,10 @@ describe MasterFilesController do
         token = StreamToken.find_or_create_session_token(session, master_file.id)
         request.headers['Authorization'] = "Bearer #{token.to_s}"
         expect(head('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:ok)
+      end
+
+      it 'returns ok (200) if public' do
+        expect(head('hls_manifest', params: { id: public_master_file.id, quality: 'auto' })).to have_http_status(:ok)
       end
     end
 
@@ -551,6 +557,10 @@ describe MasterFilesController do
       login_as :administrator
       expect(get('hls_manifest', params: { id: master_file.id, quality: 'high' })).to have_http_status(:ok)
       expect(response.content_type).to eq 'application/x-mpegURL'
+    end
+
+    it 'returns a manifest if public' do
+      expect(get('hls_manifest', params: { id: public_master_file.id, quality: 'auto' })).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
Without this change a public item would require a non-logged in user to go through the auth flow and login (or cancel out of login) before being able to access a public stream.