### PR TITLE
Atom feed restored for media objects

### DIFF
--- a/app/views/catalog/_document_media_object.atom.builder
+++ b/app/views/catalog/_document_media_object.atom.builder
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+xml.entry do
+  xml.title index_presenter(document).label(document_show_link_field(document))
+
+  # updated is required, for now we'll just set it to now, sorry
+  xml.updated document[:system_modified_dtsi]
+
+  xml.link    "rel" => "alternate", "type" => "application/json", "href" => media_object_url(document.id, format: :json)
+  # add other doc-specific formats, atom only lets us have one per
+  # content type, so the first one in the list wins.
+  # xml << show_presenter(document).link_rel_alternates(unique: true)
+
+  xml.id media_object_url(document.id)
+
+  if document.to_semantic_values.key? :author
+    xml.author { xml.name(document.to_semantic_values[:author].first) }
+  end
+
+  with_format("html") do
+    xml.summary "type" => "html" do
+      xml.text! render_document_partial(document,
+      :index,
+      document_counter: document_counter)
+    end
+  end
+
+  #If they asked for a format, give it to them.
+  if (params["content_format"] &&
+    document.export_formats[params["content_format"].to_sym])
+
+    type = document.export_formats[params["content_format"].to_sym][:content_type]
+
+    xml.content type: type do |content_element|
+      data = document.export_as(params["content_format"])
+
+      # encode properly. See:
+      # http://tools.ietf.org/html/rfc4287#section-4.1.3.3
+      type = type.downcase
+      if (type.downcase =~ %r{\+|/xml$})
+        # xml, just put it right in
+        content_element << data
+      elsif (type.downcase =~ %r{text/})
+        # text, escape
+        content_element.text! data
+      else
+        #something else, base64 encode it
+        content_element << Base64.encode64(data)
+      end
+    end
+
+  end
+end

--- a/app/views/catalog/index.atom.builder
+++ b/app/views/catalog/index.atom.builder
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# TODO: Remove this file once we upgrade to Blacklight 7
+require 'base64'
+
+xml.instruct!(:xml, encoding: "UTF-8")
+
+xml.feed("xmlns" => "http://www.w3.org/2005/Atom",
+         "xmlns:opensearch" => "http://a9.com/-/spec/opensearch/1.1/") do
+
+  xml.title   t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name)
+  # an author is required, so we'll just use the app name
+  xml.author { xml.name application_name }
+
+  xml.link    "rel" => "self", "href" => url_for(search_state.to_h.merge(only_path: false))
+  xml.link    "rel" => "alternate", "href" => url_for(search_state.to_h.merge(only_path: false, format: "html")), "type" => "text/html"
+  xml.id      url_for(search_state.to_h.merge(:only_path => false, :format => "html", :content_format => nil, "type" => "text/html"))
+
+  # Navigational and context links
+
+  xml.link( "rel" => "next",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.next_page.to_s))
+           ) if @response.next_page
+
+  xml.link( "rel" => "previous",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.prev_page.to_s))
+           ) if @response.prev_page
+
+  xml.link( "rel" => "first",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: "1")))
+
+  xml.link( "rel" => "last",
+            "href" => url_for(search_state.to_h.merge(only_path: false, page: @response.total_pages.to_s)))
+
+  # "search" doesn't seem to actually be legal, but is very common, and
+  # used as an example in opensearch docs
+  xml.link( "rel" => "search",
+            "type" => "application/opensearchdescription+xml",
+            "href" => url_for(controller: 'catalog',action: 'opensearch', format: 'xml', only_path: false))
+
+  # opensearch response elements
+  xml.opensearch :totalResults, @response.total.to_s
+  xml.opensearch :startIndex, @response.start.to_s
+  xml.opensearch :itemsPerPage, @response.limit_value
+  xml.opensearch :Query, role: "request", searchTerms: params[:q], startPage: @response.current_page
+
+
+  # updated is required, for now we'll just set it to now, sorry
+  xml.updated Time.current.iso8601
+
+  @response.documents.each_with_index do |document, document_counter|
+    xml << Nokogiri::XML.fragment(render_document_partials(document, blacklight_config.view_config(:atom).partials, document_counter: document_counter))
+  end
+end

--- a/spec/requests/atom_feed_spec.rb
+++ b/spec/requests/atom_feed_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'atom feed', type: :request do
+  it 'returns an atom feed' do
+    get '/catalog.atom'
+    expect(response).to be_successful
+  end
+
+  describe 'entry' do
+    let!(:media_object) { FactoryBot.create(:fully_searchable_media_object) }
+    let(:updated_date) { media_object.modified_date.to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+
+    it 'returns information about a media object' do
+      get '/catalog.atom'
+      atom = Nokogiri::XML(response.body)
+      atom.remove_namespaces!
+      entry = atom.xpath('//entry[1]')
+      expect(entry.at('id/text()').to_s).to eq media_object_url(media_object)
+      expect(entry.at('updated/text()').to_s).to eq updated_date
+      expect(entry.at("link[@type='application/json']/@href").to_s).to eq media_object_url(media_object, format: :json)
+    end
+  end
+end


### PR DESCRIPTION
This might still need some small changes to what information gets displayed for each entry but for now I started with the blacklight defaults then changed urls to be media object urls instead of catalog urls and removed the additional alternate links.

In support of a local story that will be using the atom feed.