### PR TITLE
Revert to bootstrap-sass 3.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'react-rails'
 gem 'sass-rails', '~> 5.0'
+# Pin to version of bootstrap-sass which still uses sass instead of sassc
+gem 'bootstrap-sass', '~> 3.3.7'
 # Use the last known good version of sass
 gem 'sass', '3.4.22'
 gem 'sprockets-es6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.4.10.1)
+    autoprefixer-rails (9.4.10.2)
       execjs
     aws-sdk (2.11.89)
       aws-sdk-resources (= 2.11.89)
@@ -243,9 +243,9 @@ GEM
       deprecation (~> 1.0)
     bootsnap (1.3.1)
       msgpack (~> 1.0)
-    bootstrap-sass (3.4.1)
+    bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+      sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     browse-everything (0.13.1)
       addressable (~> 2.5)
@@ -776,9 +776,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
-      ffi (~> 1.9)
-      rake
     scrub_rb (1.0.1)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
@@ -913,6 +910,7 @@ DEPENDENCIES
   bixby
   blacklight (< 7.0)
   bootsnap
+  bootstrap-sass (~> 3.3.7)
   bootstrap-toggle-rails!
   bootstrap_form
   browse-everything (~> 0.13.0)

--- a/app/assets/javascripts/button_confirmation.js.coffee
+++ b/app/assets/javascripts/button_confirmation.js.coffee
@@ -26,7 +26,6 @@ $ ->
   $('.btn-confirmation').popover(
     trigger: 'manual'
     html: true
-    sanitize: false
     content: ->
       button = undefined
       if typeof $(this).attr('form') == "undefined"


### PR DESCRIPTION
Due to issues compiling libsass on CentOS 6.x.