### PR TITLE
ApplicationRecord needed by Noid::Rails

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -17,6 +17,11 @@ require 'cancan/matchers'
 
 describe MediaObject do
   let(:media_object) { FactoryBot.create(:media_object) }
+  
+  it 'assigns a noid id' do
+    media_object = MediaObject.new
+    expect { media_object.assign_id! }.to change { media_object.id }.from(nil).to(String)
+  end
 
   describe 'validations' do
     # Force the validations to run by being on the resource-description workflow step


### PR DESCRIPTION
Spruce is throwing an exception when trying to save a new record because Noid::Rails is expecting ApplicationRecord to be defined.  Oddly, I'm not seeing this fail locally.