### PR TITLE
Create new timeline from media_object show page

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
@@ -185,4 +185,50 @@ class MEJSUtility {
       player.startControlsTimer();
     }
   }
+
+  /**
+   * Get new timeline scopes for active section playing
+   * @function timelineScopes
+   * @param  {player} player - reference to currentPlayer
+   * @return {[{string, int, string}]} [{label, tracks, t}] = scope label, number of tracks, mediafragment
+   */
+  timelineScopes(player) {
+    let duration = player.duration;
+    let scopes = new Array();
+    let trackCount = 1
+    const currentStream = $('#accordion li a.current-stream');
+
+    if (currentStream.length > 0 && !currentStream.closest('div').hasClass('panel-heading')) {
+      let $firstCurrentStream = $(currentStream[0]);
+      let re1 = /^\s*\d\.\s*/; // index number in front of section title '1. '
+      let re2 = /\s*\(.*\)$/; // duration notation at end of section title ' (2:00)'
+      let label = $firstCurrentStream
+        .text()
+        .replace(re1, '')
+        .replace(re2, '')
+        .trim();
+      let begin = parseFloat($firstCurrentStream[0].dataset["fragmentbegin"]) || 0
+      let end = parseFloat($firstCurrentStream[0].dataset["fragmentend"]) || duration
+
+      scopes.push({'label': label, 'tracks': trackCount, 't': 't='+begin+','+end})
+
+      let parent = $firstCurrentStream
+        .closest('ul')
+        .closest('li');
+
+      while (parent.length > 0) {
+        let tracks = parent.find('li a');
+        trackCount = tracks.length;
+        begin = parseFloat(tracks[0].dataset["fragmentbegin"]) || 0;
+        end = parseFloat(tracks[trackCount-1].dataset["fragmentend"]) || duration;
+        scopes.push({'label': parent.prev().text().trim(), 'tracks': trackCount, 't': 't='+begin+','+end})
+        parent = parent
+          .closest('ul')
+          .closest('li')
+      }
+    }
+    trackCount = currentStream.closest('div').find('li a').length
+    scopes.push({'label': player.avalonWrapper.currentStreamInfo.embed_title, 'tracks': trackCount, 't': 't=0,'})
+    return scopes.reverse()
+  }
 }

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -29,6 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%# Partial view for MEJS4 Add To Playlist plugin %>
     <%= render partial: 'mejs4_add_to_playlist' if current_user.present? && is_mejs_4? %>
     <%= render 'workflow_progress' %>
+    <%= render partial: 'timeline' if current_ability.can? :create, Timeline %>
     <%= render 'share' if will_partial_list_render? :share %>
 
     <!-- Sections -->

--- a/app/views/media_objects/_share.html.erb
+++ b/app/views/media_objects/_share.html.erb
@@ -14,15 +14,15 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<div id="share-button">
-  <a data-toggle="collapse" href="#share-list" aria-expanded="false" aria-controls="collapseExample">
+<div id="share-button" class="btn btn-default">
+   <a data-toggle="collapse" href="#share-list" aria-expanded="false" aria-controls="collapseExample">
     <i class="fa fa-share-alt"></i>
     Share
   </a>
   <br class="clear"/>
 </div>
 
-<div id="share-list" class="collapse">
+<div id="share-list" class="collapse" style="margin-top: 10px">
   <ul class="nav nav-tabs share-tabs">
     <%= render_conditional_partials :share, section:'share-tabs' %>
   </ul>

--- a/app/views/media_objects/_timeline.html.erb
+++ b/app/views/media_objects/_timeline.html.erb
@@ -1,0 +1,100 @@
+<%#
+Copyright 2011-2018, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<div id="timeline-button" style="display: inline-block;">
+  <button type="button" class="btn btn-default" data-toggle="modal" data-target="#timelineModal" style="margin-top: 10px;">
+    Create Timeline
+  </button>
+</div>
+
+<div class="modal fade" id="timelineModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true" style="display: none;">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="timelineModalLabel">Create Timeline</h5>
+      </div>
+      <div class="modal-body">
+        <div id="new-timeline-inputs">
+        </div>
+        <%= form_tag(timelines_path, id: 'new-timeline-form') do %>
+          <input type='hidden' name='timeline[title]' id='new-timeline-title'/>
+          <input type='hidden' name='timeline[source]' id='new-timeline-source'/>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="timelineModalSave">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% content_for :page_scripts do %>
+
+<script>
+$(document).ready(function() {
+  $('#timelineModal').on('show.bs.modal', function (e) {
+    console.log('in modal builder')
+    let $modalBody = $('#timelineModal').find('div#new-timeline-inputs')[0]
+    let bodyText = "<p>Choose scope for new timeline:</p>";
+    scopes = currentPlayer.avalonWrapper.mejsUtility.timelineScopes(currentPlayer)
+    for (let index = 0; index < scopes.length; index++) {
+      scope = scopes[index];
+      label = scope.label
+      if (scope.tracks > 1) {
+        label += " ("+scope.tracks+" tracks)"
+      }
+      bodyText += "<div class=\"form-check\">"
+      bodyText += "<input class=\"form-check-input\" type=\"radio\" name=\"scope\" id=\"timelinescope"+index+"\">"
+      bodyText += "<label class=\"form-check-label\" for=\"timelinescope"+index+"\"> "+label+"</label>"
+      bodyText += "</div>"
+    }
+    bodyText += "<div class=\"form-check\">"
+    bodyText += "<input class=\"form-check-input\" type=\"radio\" name=\"scope\" id=\"timelinescope_custom\">"
+    bodyText += "<label class=\"form-check-label\" for=\"timelinescope_custom\"> Custom</label>"
+    bodyText += "<input type=\"number\" name=\"custombegin\" id=\"custombegin\" size=\"10\" value=\""+currentPlayer.currentTime.toFixed(2)+"\" \> to "
+    bodyText += "<input type=\"number\" name=\"customend\" id=\"customend\" size=\"10\" value=\""+currentPlayer.duration.toFixed(2)+"\" \>"
+    bodyText += "</div>"
+    $modalBody.innerHTML = bodyText;
+  })
+
+  $('#timelineModalSave').on('click', function (e) {
+    let label, t;
+    if ($('#timelinescope_custom')[0].checked) {
+      label = 'custom scope';
+      t = 't='+$('#custombegin')[0].value+','+$('#customend')[0].value
+    } else {
+      scopes = currentPlayer.avalonWrapper.mejsUtility.timelineScopes(currentPlayer)
+      let selectedIndex = -1;
+      for (let index = 0; index < scopes.length; index++) {
+        if ($('#timelinescope'+index)[0].checked) {
+          selectedIndex = index;
+          break;
+        }
+      }
+      if (selectedIndex === -1) return;
+      scope = scopes[selectedIndex];
+      label = scope.label;
+      t = scope.t
+    }
+    $('#new-timeline-title')[0].value = label;
+    $('#new-timeline-source')[0].value = currentPlayer.avalonWrapper.currentStreamInfo.link_back_url+'?'+t;
+    $('#new-timeline-form')[0].submit();
+  })
+})
+</script>
+
+<% end %>


### PR DESCRIPTION
Closes #3214 

If timeliner is configured, adds a Create New Timeline button to Media_object show page.
Provides a choice of timeline 'scopes' based on the currently playing track, including a customizeable scope.

This PR includes only the client-side generation of the create timeline request.