### PR TITLE
Authorization happens in the manifest action

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -15,9 +15,9 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class TimelinesController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
-  load_and_authorize_resource except: [:import_variations_timeline, :duplicate, :show, :index, :timeliner]
-  load_resource only: [:show]
+  before_action :authenticate_user!, except: [:show, :manifest]
+  load_and_authorize_resource except: [:import_variations_timeline, :duplicate, :show, :index, :timeliner, :manifest]
+  load_resource only: [:show, :manifest]
   authorize_resource only: [:index]
   before_action :user_timelines, only: [:index, :paged_index]
   before_action :all_other_timelines, only: [:edit]

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -402,6 +402,16 @@ RSpec.describe TimelinesController, type: :controller do
       expect(response).to be_successful
       expect(response.body).to eq timeline.manifest
     end
+
+    context 'when timeline is public' do
+      it 'returns the manifest without logging in' do
+        timeline = Timeline.create! valid_attributes.merge(manifest: manifest.to_json)
+        sign_out user
+        get :manifest, params: {id: timeline.to_param, format: :json}, session: valid_session
+        expect(response).to be_successful
+        expect(response.body).to eq timeline.manifest
+      end
+    end
   end
 
   describe '#manifest_update' do


### PR DESCRIPTION
Fixes public fetching of public timeline manifests.  Before this was returning 401.