### PR TITLE
Add access info to media_object json and restrict to admins

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -334,7 +334,9 @@ class MediaObjectsController < ApplicationController
         end
       end
       format.json do
-        render json: @media_object.to_json
+        response_json = @media_object.as_json
+        response_json.except!(:files, :visibility, :read_groups) unless current_ability.is_administrator?
+        render json: response_json.to_json
       end
     end
   end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -266,11 +266,14 @@ class MediaObject < ActiveFedora::Base
       id: id,
       title: title,
       collection: collection.name,
+      unit: collection.unit,
       main_contributors: creator,
       publication_date: date_created,
       published_by: avalon_publisher,
       published: published?,
-      summary: abstract
+      summary: abstract,
+      visibility: visibility,
+      read_groups: read_groups
     }.merge(to_ingest_api_hash(false))
   end
 


### PR DESCRIPTION
Enhance json view of MediaObject.
Restrict access control and file data to admins.