### PR TITLE
Upgrade resque-scheduler to move off of fork.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'chromedriver-helper'
   gem 'codeclimate-test-reporter'
   gem 'database_cleaner'
   gem 'email_spec'
@@ -132,6 +131,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov'
+  gem 'webdrivers', '~> 3.0'
   gem 'webmock', '~> 3.5.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'marc'
 gem 'activejob-traffic_control'
 gem 'redis-rails'
 gem 'resque', '~> 2.0'
-gem 'resque-scheduler', git: 'https://github.com/resque/resque-scheduler.git', ref: 'bbf4930'
+gem 'resque-scheduler', '~> 4.4'
 
 # Coding Patterns
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,17 +85,6 @@ GIT
       chronic (>= 0.6.3)
 
 GIT
-  remote: https://github.com/resque/resque-scheduler.git
-  revision: bbf4930c28020a395b02fca49c57fba68ac6f544
-  ref: bbf4930
-  specs:
-    resque-scheduler (4.3.1)
-      mono_logger (~> 1.0)
-      redis (>= 3.3)
-      resque (>= 1.26)
-      rufus-scheduler (~> 3.2)
-
-GIT
   remote: https://github.com/rkallensee/bootstrap-toggle-rails.git
   revision: b85df8ea25ab71628fcec1504c7182dd5d7d3606
   tag: v2.2.1.0
@@ -382,7 +371,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.8.0)
-    et-orbi (1.1.7)
+    et-orbi (1.2.1)
       tzinfo
     execjs (2.7.0)
     factory_bot (4.10.0)
@@ -402,8 +391,8 @@ GEM
     ffi (1.10.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
-    fugit (1.1.8)
-      et-orbi (~> 1.1, >= 1.1.7)
+    fugit (1.2.0)
+      et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -601,7 +590,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     raabro (1.1.6)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-cors (1.0.2)
     rack-protection (2.0.5)
       rack
@@ -711,6 +700,11 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-scheduler (4.4.0)
+      mono_logger (~> 1.0)
+      redis (>= 3.3)
+      resque (>= 1.26)
+      rufus-scheduler (~> 3.2)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -768,8 +762,8 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.2.2)
-    rufus-scheduler (3.5.2)
-      fugit (~> 1.1, >= 1.1.5)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.7)
@@ -975,7 +969,7 @@ DEPENDENCIES
   recaptcha
   redis-rails
   resque (~> 2.0)
-  resque-scheduler!
+  resque-scheduler (~> 4.4)
   rest-client
   roo
   rsolr (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,8 +188,6 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     api-pagination (4.8.1)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.4.10.2)
@@ -284,9 +282,6 @@ GEM
       xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic (0.10.2)
     cloudfront-signer (3.0.2)
     codeclimate-test-reporter (1.0.8)
@@ -456,7 +451,6 @@ GEM
     ims-lti (1.1.13)
       builder
       oauth (>= 0.4.5, < 0.6)
-    io-like (0.3.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -862,6 +856,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -918,7 +916,6 @@ DEPENDENCIES
   capistrano-rvm
   capistrano-yarn
   capybara
-  chromedriver-helper
   cloudfront-signer
   codeclimate-test-reporter
   coffee-rails (~> 4.2.0)
@@ -990,6 +987,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   wavefile
   web-console
+  webdrivers (~> 3.0)
   webmock (~> 3.5.1)
   webpacker
   whenever!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ require 'webmock/rspec'
 require 'noid/rails/rspec'
 require "email_spec"
 require "email_spec/rspec"
+require 'webdrivers'
 # require 'equivalent-xml/rspec_matchers'
 # require 'fakefs/safe'
 # require 'fileutils'
@@ -89,7 +90,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
-    WebMock.disable_net_connect!(allow: ['localhost', '127.0.0.1', 'fedora', 'solr', 'matterhorn'])
+    WebMock.disable_net_connect!(allow: ['localhost', '127.0.0.1', 'fedora', 'solr', 'matterhorn', 'https://chromedriver.storage.googleapis.com'])
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
     disable_production_minter!


### PR DESCRIPTION
We have temporarily been using a fork I made of `resque-scheduler` in order to use a newer version of `resque`.  Now that `resque-scheduler` 4.4.0 has been released, we can use it instead of the fork.