### PR TITLE
Avoid link overflow of button

### DIFF
--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -53,12 +53,9 @@ Unless required by applicable law or agreed to in writing, software distributed
         <div> </div>
       <% end %>
       <div>
-        <%= link_to(new_playlist_path) do %>
-          <span class="btn btn-primary outline_on">
-            Create New Playlist
-          </span>
-        <% end %>
-	      <% if Settings['variations'].present? %>
+	<%# pass body to link_to to avoid block form of link_to which creates an odd underline that overflows the button %>
+        <%= link_to('<span class="btn btn-primary outline_on">Create New Playlist</span>', new_playlist_path) %>
+        <% if Settings['variations'].present? %>
           <%= form_tag(import_variations_playlist_playlists_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
             <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
             <input type="button" class="btn btn-primary outline_on" id="variations_import" onclick="$(this).closest('form').find('.filedata').click();" value="Import Variations Playlist" />

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -54,7 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <% end %>
       <div>
 	<%# pass body to link_to to avoid block form of link_to which creates an odd underline that overflows the button %>
-        <%= link_to('<span class="btn btn-primary outline_on">Create New Playlist</span>', new_playlist_path) %>
+        <%= link_to('<span class="btn btn-primary outline_on">Create New Playlist</span>'.html_safe, new_playlist_path) %>
         <% if Settings['variations'].present? %>
           <%= form_tag(import_variations_playlist_playlists_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
             <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />


### PR DESCRIPTION
See the little underline on the right of the create playlist button:
<img width="208" alt="Screen Shot 2019-05-09 at 8 52 39 AM" src="https://user-images.githubusercontent.com/1053603/57454869-d7c09100-7237-11e9-9cfd-08b320fa3e97.png">

This underline is due to the newline whitespace after the span and before the end of the closing a tag.
This needs to be tested before merging.