### PR TITLE
Make sure objects exist when trying to send them messages

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -328,20 +328,20 @@ class MEJSPlayer {
   handleSuccess(mediaElement, originalNode, instance) {
     this.mediaElement = mediaElement;
 
+    // Grab instance of player
+    if (!this.player) {
+      this.player = this.mediaElement;
+    }
+
     // Toggle captions on if toggleable and previously on
     if (this.mediaType==="video" && this.player.options.toggleCaptionsButtonWhenOnlyOne) {
-      if (this.localStorage.getItem('captions') !== '' && this.player.tracks.length===1) {
+      if (this.localStorage.getItem('captions') !== '' && this.player.tracks && this.player.tracks.length===1) {
         this.player.setTrack(this.player.tracks[0].trackId, (typeof keyboard !== 'undefined'));
       }
     }
 
     // Make the player visible
     this.revealPlayer(instance);
-
-    // Grab instance of player
-    if (!this.player) {
-      this.player = this.mediaElement;
-    }
 
     this.emitSuccessEvent();
 


### PR DESCRIPTION
The player variable is set earlier so it is defined for when it is called for turning on captions.  Also player.tracks is tested first before trying to check its length.

This PR allows the player to load and play on Safari on OS X and iOS as well as Chrome on Android and IE11.  Also the captions button is not sticky on Safari on OSX (this might also be the case for iOS and Android).