### PR TITLE
Add missing stylesheet pack tag

### DIFF
--- a/app/views/timelines/timeliner.html.erb
+++ b/app/views/timelines/timeliner.html.erb
@@ -9,5 +9,6 @@
 <body class="">
    <div id="app"></div>
    <%= javascript_pack_tag 'iiif-timeliner' %>
+   <%= stylesheet_pack_tag 'iiif-timeliner' %>
 </body>
 </html>


### PR DESCRIPTION
Without this the CSS doesn't get included in production mode.

I didn't test this in development and it may or may not be necessary but I hope that it works there as well and that we'll be able to remove the CSS include at the top of the timeliner JS pack.