### PR TITLE
Use ffmpeg configured in settings

### DIFF
--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -31,7 +31,7 @@ private
   def get_wave_io(uri)
     headers = "-headers $'Referer: #{Rails.application.routes.url_helpers.root_url}\r\n'" if uri.starts_with? "http"
     normalized_uri = uri.starts_with?("file") ? URI.unescape(uri) : uri
-    cmd = "ffmpeg #{headers} -i '#{normalized_uri}' -f wav - 2> /dev/null"
+    cmd = "#{Settings.ffmpeg.path} #{headers} -i '#{normalized_uri}' -f wav - 2> /dev/null"
     IO.popen(cmd)
   end
 

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -36,7 +36,7 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"ffmpeg -headers $'Referer: http://test.host/\r\n' -i '#{uri}' -f wav - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -i '#{uri}' -f wav - 2> /dev/null"}
 
       it "should call ffmpeg with headers" do
         service.send(:get_wave_io, uri)
@@ -46,7 +46,7 @@ describe WaveformService, type: :service do
 
     context "local file" do
       let(:uri) { "file:///path/to/video.mp4" }
-      let(:cmd) {"ffmpeg  -i '#{uri}' -f wav - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path}  -i '#{uri}' -f wav - 2> /dev/null"}
 
       it "should call ffmpeg without headers" do
         service.send(:get_wave_io, uri)
@@ -56,7 +56,7 @@ describe WaveformService, type: :service do
       context 'with spaces in filename' do
         let(:uri) { 'file:///path/to/special%20video%20file.mp4' }
         let(:unencoded_uri) { 'file:///path/to/special video file.mp4' }
-        let(:cmd) {"ffmpeg  -i '#{unencoded_uri}' -f wav - 2> /dev/null"}
+        let(:cmd) {"#{Settings.ffmpeg.path}  -i '#{unencoded_uri}' -f wav - 2> /dev/null"}
 
         it "should call ffmpeg without url encoding" do
           service.send(:get_wave_io, uri)


### PR DESCRIPTION
Instead of assuming ffmpeg is in the path or that the ffmpeg in the path is the one we want to use.  This makes this call a little more consistent with the [thumbnail/poster frame extraction](https://github.com/avalonmediasystem/avalon/blob/develop/app/models/master_file.rb#L602).