### PR TITLE
Pin to wavefile 1.0.x for using IO.popen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'mediainfo', git: "https://github.com/avalonmediasystem/mediainfo.git", tag:
 gem 'rest-client'
 gem 'roo'
 gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git", tag: 'avalon-r6'
-gem 'wavefile'
+gem 'wavefile', '~> 1.0.1'
 
 # Data Translation & Normalization
 gem 'edtf'


### PR DESCRIPTION
`wavefile` 1.1.0 uses `IO#pos` which always returns an Invalid Seek exception (as far as I can tell) when called on a pipe.  Since switching form using pipes through `IO.popen` would be a large effort, I propose pinning to the earlier version of wavefile which doesn't have this issue.  In the long term, we should submit an issue and/or patch to restore this functionality since we depend on it.