### PR TITLE
Fix backfill script 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,7 +891,7 @@ GEM
       rack (>= 1.0.0)
     warden (1.2.8)
       rack (>= 2.0.6)
-    wavefile (1.1.0)
+    wavefile (1.0.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -1035,7 +1035,7 @@ DEPENDENCIES
   sprockets-es6
   sqlite3
   uglifier (>= 1.3.0)
-  wavefile
+  wavefile (~> 1.0.1)
   web-console
   webdrivers (~> 3.0)
   webmock (~> 3.5.1)

--- a/app/jobs/waveform_job.rb
+++ b/app/jobs/waveform_job.rb
@@ -40,7 +40,7 @@ class WaveformJob < ActiveJob::Base
     end
 
     def playlist_url(master_file)
-      streams = master_file.stream_details[:stream_hls]
+      streams = master_file.hls_streams
       hls_url = nil
 
       # Find the lowest quality stream

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -77,6 +77,28 @@ module MasterFileBehavior
     })
   end
 
+  # Copied and extracted from stream_details for use in the waveformjob
+  # This isn't used in stream_details because it would be less efficient
+  def hls_streams
+    hls = []
+    derivatives.each do |d|
+      common = { quality: d.quality,
+                 bitrate: d.bitrate,
+                 mimetype: d.mime_type,
+                 format: d.format }
+      hls << common.merge(url: d.streaming_url(true))
+    end
+    if hls.length > 1
+      hls << { quality: 'auto',
+               mimetype: hls.first[:mimetype],
+               format: hls.first[:format],
+               url: hls_manifest_master_file_url(id: id, quality: 'auto') }
+    end
+
+    # Sorts the streams in order of quality
+    sort_streams hls
+  end
+
   def display_title
     mf_title = structuralMetadata.section_title unless structuralMetadata.blank?
     mf_title ||= title if title.present?

--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -8,6 +8,7 @@ class WaveformService
   end
 
   def get_waveform_json(uri)
+    return nil unless uri.present?
     waveform = AudioWaveform::WaveformDataFile.new(
       sample_rate: 44_100,
       samples_per_pixel: @samples_per_pixel,

--- a/script/waveform_backfill.rb
+++ b/script/waveform_backfill.rb
@@ -28,8 +28,8 @@ end
 
 if mf_ids.empty?
   Rails.logger.info "Reading ids of master files needing waveform back-fill from #{wb_path}"
-  File.readlines(wb_file).each do |id|
-    mf_ids << id
+  File.readlines(wb_path).each do |id|
+    mf_ids << id.strip
     Rails.logger.debug "to be back filled: master file #{id}"
   end
 end

--- a/script/waveform_backfill.rb
+++ b/script/waveform_backfill.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-wb_path = '/srv/avalon/scriptdata/waveform_backfill.txt'
+wb_path = File.join(Rails.root, 'scriptdata/waveform_backfill.txt')
 start_index = ARGV[0] || 1
 row_max = ARGV[1] || 1_000_000
 

--- a/script/waveform_backfill.rb
+++ b/script/waveform_backfill.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-wb_path = File.join(Rails.root, 'scriptdata/waveform_backfill.txt')
+wb_path = Rails.root.join('scriptdata', 'waveform_backfill.txt')
 start_index = ARGV[0] || 1
 row_max = ARGV[1] || 1_000_000
 

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -27,6 +27,12 @@ describe WaveformService, type: :service do
 
       expect(json).to eq(target_json)
     end
+
+    context 'when uri parameter is blank' do
+      it 'returns nil' do
+        expect(service.get_waveform_json(nil)).to eq nil
+      end
+    end
   end
 
   describe "get_wave_io" do


### PR DESCRIPTION
The fixes in the second commit come from trying to run the backfill script on spruce and having to deal with edge cases like master files without media objects and master files without derivatives.