### PR TITLE
Use solr document timestamp to indicate updated time instead of system_modified_dtsi

### DIFF
--- a/app/views/catalog/_document_media_object.atom.builder
+++ b/app/views/catalog/_document_media_object.atom.builder
@@ -4,7 +4,7 @@ xml.entry do
   xml.title index_presenter(document).label(document_show_link_field(document))
 
   # updated is required, for now we'll just set it to now, sorry
-  xml.updated document[:system_modified_dtsi]
+  xml.updated document[:timestamp]
 
   xml.link    "rel" => "alternate", "type" => "application/json", "href" => media_object_url(document.id, format: :json)
   # add other doc-specific formats, atom only lets us have one per

--- a/spec/requests/atom_feed_spec.rb
+++ b/spec/requests/atom_feed_spec.rb
@@ -22,7 +22,11 @@ describe 'atom feed', type: :request do
 
   describe 'entry' do
     let!(:media_object) { FactoryBot.create(:fully_searchable_media_object) }
-    let(:updated_date) { media_object.modified_date.to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+    let(:updated_date) do
+      query = ActiveFedora::SolrQueryBuilder.construct_query(ActiveFedora.id_field => media_object.id)
+      doc = ActiveFedora::SolrService.get(query)['response']['docs'].first
+      doc["timestamp"]
+    end
 
     it 'returns information about a media object' do
       get '/catalog.atom'


### PR DESCRIPTION
The system_modified_dtsi field is getting updated when the fedora object is modified.  But for media objects most of the data that would be modified lives in child nodes (e.g. descriptive metadata and access control).  When these child nodes are saved it does not change the modified date of the parent media object.  The approach taken in this PR is to think of the atom feed's updated time as the update time of the solr document (whether it had any fields change or not).