### PR TITLE
Wowza unnest expects a hash

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -359,7 +359,7 @@ protected
   def hls_stream(master_file, quality)
     stream_info = secure_streams(master_file.stream_details)
     hls_stream = stream_info[:stream_hls].select { |stream| stream[:quality] == quality }
-    unnest_wowza_stream(hls_stream) if Settings.streaming.server == "wowza"
+    unnest_wowza_stream(hls_stream&.first) if Settings.streaming.server == "wowza"
     hls_stream
   end
 


### PR DESCRIPTION
The select on the previous line returns an array which is expected as the result of this method but `unnest_wowza_stream` expects the first element (and only) element in the array, a hash.