### PR TITLE
Workaround for hlsError bufferFullError: Set max buffer length to 2 minutes

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -326,6 +326,9 @@ class MEJSPlayer {
    * @return {void}
    */
   handleSuccess(mediaElement, originalNode, instance) {
+    // Workaround for hlsError bufferFullError: Set max buffer length to 2 minutes
+    mediaElement.hlsPlayer.config.maxMaxBufferLength = 120;
+
     this.mediaElement = mediaElement;
 
     // Grab instance of player


### PR DESCRIPTION
At IU we were seeing behavior where playback would randomly stop.  The browser console reports an `hlsError` of `bufferFullError`, but the audio should be able to buffer the default 600s within the default 60MB buffer of hls.js.  We think that there is a bug in hls.js where it thinks it can fetch more hls segments than it can (maybe due to the bandwidth reported in the HLS manifest not matching the actual bitrate of the stream) OR it has an off by one error.  To workaround this issue, we decided to set the `maxMaxBufferLength` (the maximum time amount that will be buffered) lower to 120s to make sure that it always fits inside the buffer.  This means that it will keep 12  ten second segments in its buffer instead of the observed 20 segments for high video, 30 or 60 segments for high audio.

See: https://github.com/video-dev/hls.js/blob/master/docs/API.md#maxmaxbufferlength