### PR TITLE
Protect workaround from undefined errors.

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -333,7 +333,7 @@ class MEJSPlayer {
       this.player = this.mediaElement;
     }
 
-    if (this.player && this.player.media && this.player.media.hlsPlayer) {
+    if (this.player && this.player.media && this.player.media.hlsPlayer && this.player.media.hlsPlayer.config) {
       // Workaround for hlsError bufferFullError: Set max buffer length to 2 minutes
       this.player.media.hlsPlayer.config.maxMaxBufferLength = 120;
     }

--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -326,14 +326,16 @@ class MEJSPlayer {
    * @return {void}
    */
   handleSuccess(mediaElement, originalNode, instance) {
-    // Workaround for hlsError bufferFullError: Set max buffer length to 2 minutes
-    mediaElement.hlsPlayer.config.maxMaxBufferLength = 120;
-
     this.mediaElement = mediaElement;
 
     // Grab instance of player
     if (!this.player) {
       this.player = this.mediaElement;
+    }
+
+    if (this.player && this.player.media && this.player.media.hlsPlayer) {
+      // Workaround for hlsError bufferFullError: Set max buffer length to 2 minutes
+      this.player.media.hlsPlayer.config.maxMaxBufferLength = 120;
     }
 
     // Toggle captions on if toggleable and previously on


### PR DESCRIPTION
This is tested as working in Chrome and Safari and android.