### PR TITLE
Ensure the user is redirected to original page if required to login first

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -199,7 +199,7 @@ class Admin::CollectionsController < ApplicationController
   # GET /collections/1/remove
   def remove
     @collection = Admin::Collection.find(params['id'])
-    raise CanCan::AccessDenied unless current_ability.can? :destroy, @collection
+    authorize! :destroy, @collection
     @objects    = @collection.media_objects
     @candidates = get_user_collections.reject { |c| c == @collection }
   end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -18,15 +18,10 @@ class Admin::GroupsController < ApplicationController
   before_action :auth
 
   # Currently assumes that to do anything you have to be able to manage Group
-  # TODO: finer controls
   def auth
-    if current_user.nil?
-      flash[:notice] = "You need to login to manage groups"
-      redirect_to new_user_session_path
-    elsif cannot? :manage, Admin::Group
-      flash[:notice] = "You do not have permission to manage groups"
-      redirect_to root_path
-    elsif params['id'].present?
+    authorize! :manage, Admin::Group
+    if params['id'].present?
+      # Replace this with authorize! ?
       g = Admin::Group.find(params['id'])
       if cannot? :manage, g
         flash[:error] = "You must be an administrator to manage the '#{g.name}' group"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -160,4 +160,14 @@ class ApplicationController < ActionController::Base
       user_params.permit(:login, :password)
     end
   end
+
+  def authenticate_user!
+    return if user_signed_in?
+    if request.format == :json
+      head :unauthorized
+    else
+      session[:previous_url] = request.fullpath unless request.xhr?
+      redirect_to new_user_session_path(url: request.url), flash: { notice: 'You need to login to perform this action.' }
+    end
+  end
 end

--- a/app/controllers/dropbox_controller.rb
+++ b/app/controllers/dropbox_controller.rb
@@ -17,9 +17,7 @@ class DropboxController < ApplicationController
 
   def bulk_delete
     @collection = Admin::Collection.find(params[:collection_id])
-    unless can? :destroy, @collection
-      raise CanCan::AccessDenied
-    end
+    authorize! :destroy, @collection
 
     # failsafe for spaces that might be attached to string
     filenames = params[:filenames].map(&:strip)
@@ -30,7 +28,7 @@ class DropboxController < ApplicationController
 
     filenames.each do |filename|
       if dropbox_filenames.include?( filename )
-        if dropbox.delete( filename ) 
+        if dropbox.delete( filename )
           deleted_filenames << filename
           logger.info "The user #{current_user.username} deleted #{filename} from the dropbox."
         end
@@ -38,8 +36,7 @@ class DropboxController < ApplicationController
         logger.warn "The user #{current_user.username} attempted to delete #{filename} from the dropbox. File does not exist."
       end
     end
-    
+
     render :json => { deleted_filenames: deleted_filenames }
   end
-  
 end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -343,7 +343,7 @@ class MediaObjectsController < ApplicationController
 
   def show_stream_details
     load_current_stream
-    raise CanCan::AccessDenied unless current_ability.can? :read, @currentStream
+    authorize! :read, @currentStream
     render json: @currentStreamInfo
   end
 

--- a/app/controllers/migration_status_controller.rb
+++ b/app/controllers/migration_status_controller.rb
@@ -62,13 +62,7 @@ class MigrationStatusController < ApplicationController
   end
 
   def auth
-    if current_user.nil?
-      flash[:notice] = "You need to login to view migration reports"
-      redirect_to new_user_session_path
-    elsif cannot? :read, MigrationStatus
-      flash[:notice] = "You do not have permission to view migration reports"
-      redirect_to root_path
-    end
+    authorize! :read, MigrationStatus
   end
 
   def without_layout_if_xhr

--- a/spec/controllers/avalon_marker_controller_spec.rb
+++ b/spec/controllers/avalon_marker_controller_spec.rb
@@ -29,8 +29,8 @@ describe AvalonMarkerController, type: :controller do
     let(:playlist_item) { FactoryBot.create(:playlist_item, playlist: playlist) }
     context 'with unauthenticated user' do
       it "all routes should redirect to sign in" do
-        expect(post :create, params: { marker: { playlist_item_id: playlist_item.id, master_file_id: master_file.id, title: Faker::Lorem.word, start_time: 0.0 } }).to redirect_to(new_user_session_path)
-        expect(put :update, params: { id: avalon_marker.id, marker: { title: Faker::Lorem.word } }).to redirect_to(new_user_session_path)
+        expect(post :create, params: { marker: { playlist_item_id: playlist_item.id, master_file_id: master_file.id, title: Faker::Lorem.word, start_time: 0.0 } }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(put :update, params: { id: avalon_marker.id, marker: { title: Faker::Lorem.word } }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
     end
     context 'with end-user' do

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -20,21 +20,50 @@ describe Admin::GroupsController do
   test_group = "rspec_test_group"
   test_group_new = "rspec_test_group_new"
 
+  describe 'index' do
+    it "index should redirect to sign in page with a notice when unauthenticated" do
+      get 'index'
+      expect(flash[:notice]).not_to be_nil
+      expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+    end
+
+    it "index new should redirect to home page with a notice when authenticated but unauthorized" do
+      login_as('student')
+      get 'index'
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).not_to be_nil
+    end
+  end
+
   describe "creating a new group" do
-  	it "should redirect to sign in page with a notice when unauthenticated" do
+    it "new should redirect to sign in page with a notice when unauthenticated" do
   	  expect { get 'new' }.not_to change { Admin::Group.all.count }
   	  expect(flash[:notice]).not_to be_nil
-  	  expect(response).to redirect_to(new_user_session_path)
+  	  expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
   	end
 
-    it "should redirect to home page with a notice when authenticated but unauthorized" do
+    it "new should redirect to home page with a notice when authenticated but unauthorized" do
       login_as('student')
       expect { get 'new' }.not_to change {Admin::Group.all.count}
       expect(response).to redirect_to(root_path)
       expect(flash[:notice]).not_to be_nil
     end
 
-    it "should redirect to group index page with a notice when group name is already taken" do
+    it "create should redirect to sign in page with a notice on when unauthenticated" do
+      expect { post 'create', params: { admin_group: test_group } }.not_to change {Admin::Group.all.count }
+      expect(flash[:notice]).not_to be_nil
+      expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+    end
+
+    it "create should redirect to home page with a notice when authenticated but unauthorized" do
+      login_as('student')
+
+      expect { post 'create', params: { admin_group: test_group } }.not_to change {Admin::Group.all.count }
+      expect(flash[:notice]).not_to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "create should redirect to group index page with a notice when group name is already taken" do
       group = FactoryBot.create(:group)
       login_as('group_manager')
       expect { post 'create', params: { admin_group: group.name } }.not_to change {Admin::Group.all.count }
@@ -62,16 +91,32 @@ describe Admin::GroupsController do
     let!(:group) {Admin::Group.find(FactoryBot.create(:group).name)}
 
     context "editing a group" do
-      it "should redirect to sign in page with a notice on when unauthenticated" do
+      it "edit should redirect to sign in page with a notice on when unauthenticated" do
         get 'edit', params: { id: group.name }
         expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
 
-      it "should redirect to home page with a notice when authenticated but unauthorized" do
+      it "edit should redirect to home page with a notice when authenticated but unauthorized" do
         login_as('student')
 
         get 'edit', params: { id: group.name }
+        expect(flash[:notice]).not_to be_nil
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "update should redirect to sign in page with a notice on when unauthenticated" do
+        new_user = FactoryBot.build(:user).user_key
+        put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
+        expect(flash[:notice]).not_to be_nil
+        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      end
+
+      it "update should redirect to home page with a notice when authenticated but unauthorized" do
+        login_as('student')
+        new_user = FactoryBot.build(:user).user_key
+
+        put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
         expect(flash[:notice]).not_to be_nil
         expect(response).to redirect_to(root_path)
       end
@@ -162,7 +207,7 @@ describe Admin::GroupsController do
 
         expect { put 'update_multiple', params: { group_ids: [group.name] } }.not_to change { Avalon::RoleControls.users(group.name) }
         expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
 
       it "should redirect to home page with a notice when authenticated but unauthorized" do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -61,19 +61,19 @@ describe MediaObjectsController, type: :controller do
       context 'with unauthenticated user' do
         #New is isolated here due to issues caused by the controller instance not being regenerated
         it "should redirect to sign in" do
-          expect(get :new).to redirect_to(new_user_session_path)
+          expect(get :new).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         end
         it "all routes should redirect to sign in" do
           expect(get :show, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-          expect(get :edit, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(get :confirm_remove, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(put :update, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(put :update_status, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(get :tree, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(get :deliver_content, params: { id: media_object.id, file: 'descMetadata' }).to redirect_to(new_user_session_path)
-          expect(delete :destroy, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(get :add_to_playlist_form, params: { id: media_object.id }).to redirect_to(new_user_session_path)
-          expect(post :add_to_playlist, params: { id: media_object.id }).to redirect_to(new_user_session_path)
+          expect(get :edit, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :confirm_remove, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(put :update, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(put :update_status, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :tree, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :deliver_content, params: { id: media_object.id, file: 'descMetadata' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(delete :destroy, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :add_to_playlist_form, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(post :add_to_playlist, params: { id: media_object.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         end
         it "json routes should return 401" do
           expect(post :create, format: 'json').to have_http_status(401)

--- a/spec/controllers/migration_status_controller_spec.rb
+++ b/spec/controllers/migration_status_controller_spec.rb
@@ -19,18 +19,43 @@ describe MigrationStatusController do
   let(:fedora3_pid) { 'avalon:12345' }
   let(:avalon_noid) { obj.id }
 
-  before do
-    login_as :administrator
-    MigrationStatus.create!(f3_pid: fedora3_pid, f4_pid: avalon_noid, source_class: obj.class)
+  describe 'security' do
+    context 'not logged in' do
+      it "all routes should redirect to sign in" do
+        expect(get :index).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :show, params: { class: 'MediaObject' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :detail, params: { id: 'avalon:12345' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :report, params: { id: 'avalon:12345' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      end
+    end
+
+    context 'with end-user' do
+      before do
+        login_as :user
+      end
+
+      it "all routes should redirect to /" do
+        expect(get :index).to redirect_to(root_path)
+        expect(get :show, params: { class: 'MediaObject' }).to redirect_to(root_path)
+        expect(get :detail, params: { id: 'avalon:12345' }).to redirect_to(root_path)
+        expect(get :report, params: { id: 'avalon:12345' }).to redirect_to(root_path)
+      end
+    end
   end
 
   describe '#detail' do
+    before do
+      login_as :administrator
+      MigrationStatus.create!(f3_pid: fedora3_pid, f4_pid: avalon_noid, source_class: obj.class)
+    end
+
     context 'with a Fedora 3 pid' do
       it 'returns the details' do
         get :detail, params: { id: fedora3_pid }
         expect(response).to have_http_status(:ok)
       end
     end
+
     context 'with an Avalon noid' do
       it 'returns the details' do
         get :detail, params: { id: avalon_noid }

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -61,15 +61,15 @@ RSpec.describe PlaylistsController, type: :controller do
     context 'with unauthenticated user' do
       # New is isolated here due to issues caused by the controller instance not being regenerated
       it "should redirect to sign in" do
-        expect(get :new).to redirect_to(new_user_session_path)
+        expect(get :new).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
       it "all routes should redirect to sign in" do
-        expect(get :index).to redirect_to(new_user_session_path)
-        expect(get :edit, params: { id: playlist.id }).to redirect_to(new_user_session_path)
-        expect(post :create).to redirect_to(new_user_session_path)
-        expect(put :update, params: { id: playlist.id }).to redirect_to(new_user_session_path)
-        expect(put :update_multiple, params: { id: playlist.id }).to redirect_to(new_user_session_path)
-        expect(delete :destroy, params: { id: playlist.id }).to redirect_to(new_user_session_path)
+        expect(get :index).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :edit, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(post :create).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(put :update, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(put :update_multiple, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(delete :destroy, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
       context 'with a public playlist' do

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe TimelinesController, type: :controller do
     context 'with unauthenticated user' do
       # New is isolated here due to issues caused by the controller instance not being regenerated
       it "should redirect to sign in" do
-        expect(get :new).to redirect_to(new_user_session_path)
+        expect(get :new).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
       it "all routes should redirect to sign in" do
-        expect(get :index).to redirect_to(new_user_session_path)
-        expect(get :edit, params: { id: timeline.id }).to redirect_to(new_user_session_path)
-        expect(post :create).to redirect_to(new_user_session_path)
-        expect(put :update, params: { id: timeline.id }).to redirect_to(new_user_session_path)
-        expect(delete :destroy, params: { id: timeline.id }).to redirect_to(new_user_session_path)
+        expect(get :index).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :edit, params: { id: timeline.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(post :create).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(put :update, params: { id: timeline.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(delete :destroy, params: { id: timeline.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
       context 'with a public timeline' do
         let(:timeline) { FactoryBot.create(:timeline, visibility: Timeline::PUBLIC) }

--- a/spec/requests/redirect_spec.rb
+++ b/spec/requests/redirect_spec.rb
@@ -1,0 +1,29 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe 'redirect', type: :request do
+  it 'stores url to redirect to when unauthorized and needing to authenticate (#authorize!)' do
+    get '/admin/migration_report'
+    expect(request.env['rack.session']['previous_url']).to eq '/admin/migration_report'
+    expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+  end
+
+  it 'stores url to redirect to when needing to authenticate (#authenticate_user!)' do
+    get '/bookmarks'
+    expect(request.env['rack.session']['previous_url']).to eq '/bookmarks'
+    expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+  end
+end


### PR DESCRIPTION
This PR fixes post-login redirection in two cases:
1. MigrationStatusController
2. Controllers that sent users to the login page via `#authenticate_user!`

This PR also cleans up and standardizes the use of `#authorize!`. It also adds tests for redirecting to login for more controllers and some basic request tests to ensure that the `previous_url` session variable is set.