### PR TITLE
Timeline source links

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -128,7 +128,12 @@ class TimelinesController < ApplicationController
         if timeline_params.blank?
           # Accept raw IIIF manifest here from timeliner tool
           manifest = request.body.read
-          source = JSON.parse(manifest)["homepage"]["id"]
+          # Determine source from first content resource
+          manifest_json = JSON.parse(manifest)
+          stream_url = manifest_json["items"][0]["items"][0]["items"][0]["body"]["id"]
+          # Only handles urls like "https://spruce.dlib.indiana.edu/master_files/6108vd10d/auto.m3u8#t=0.0,3437.426"
+          _, master_file_id, media_fragment = stream_url.match(/master_files\/(.*)\/.*t=(.*)/).to_a
+          source = master_file_url(id: master_file_id) + "?t=#{media_fragment}"
           @timeline = Timeline.new(user: current_user, manifest: manifest, source: source)
         else
           @timeline = Timeline.new(timeline_params.merge(user: current_user))

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -99,7 +99,7 @@ class TimelinesController < ApplicationController
     authorize! :read, @timeline
     respond_to do |format|
       format.html do
-        url_fragment = "noHeader=true&noFooter=true&noSourceLink=true"
+        url_fragment = "noHeader=true&noFooter=true&noSourceLink=false"
         url_fragment += "&resource=#{URI.escape(manifest_timeline_url(@timeline, format: :json, token: @timeline.access_token), '://?=')}"
         # TODO: determine if need to clone timeline and provide saveback url specific to current_user
         if current_user == @timeline.user

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_15_215848) do
+ActiveRecord::Schema.define(version: 2019_08_06_193607) do
 
   create_table "annotations", force: :cascade do |t|
     t.string "uuid"

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TimelinesController, type: :controller do
   }
 
   let(:master_file) { FactoryBot.create(:master_file) }
-  let(:source_url) { master_file_url(master_file, params: { t: '30,60' }) }
+  let(:source_url) { master_file_url(master_file) + "?t=30,60" }
 
   let(:invalid_attributes) {
     { visibility: 'unknown' }
@@ -151,7 +151,7 @@ RSpec.describe TimelinesController, type: :controller do
             "http://www.w3.org/ns/anno.jsonld",
             "http://iiif.io/api/presentation/3/context.json"
           ],
-          "id": "https://example.com/timelines/1.json",
+          "id": "http://test.host/timelines/1.json",
           "type": "Manifest",
           "label": { "en": [ "Timeline 1" ] }
         }
@@ -226,8 +226,8 @@ RSpec.describe TimelinesController, type: :controller do
         post :create, params: { timeline: valid_attributes, include_structure: true }, session: valid_session
         timeline = Timeline.last
         structures = JSON.parse(timeline.manifest)['structures']
-        expect(structures.count).to eq(6)
-        expect(structures.first['label']['en'].first).to eq('Copland, Three Piano Excerpts from Our Town')
+        expect(structures.count).to eq(2)
+        expect(structures.first['label']['en'].first).to eq('Copland, Four Episodes from Rodeo')
         expect(structures.last['label']['en'].first).to eq('')
       end
     end
@@ -291,7 +291,7 @@ RSpec.describe TimelinesController, type: :controller do
       end
 
       context 'with manifest body' do
-        let(:source) { "http://example.com/media_objects/abc123/section/dce456?t=0," }
+        let(:source) { "http://test.host/master_files/#{master_file.id}?t=0," }
         let(:title) { "Cloned manifest" }
         let(:description) { 'The manifest description' }
         let(:submitted_manifest) do
@@ -300,7 +300,7 @@ RSpec.describe TimelinesController, type: :controller do
               "http://www.w3.org/ns/anno.jsonld",
               "http://iiif.io/api/presentation/3/context.json"
             ],
-            "id": "https://example.com/timelines/1.json",
+            "id": "http://test.host/timelines/1.json",
             "type": "Manifest",
             "label": {
               "en": [title]
@@ -315,7 +315,33 @@ RSpec.describe TimelinesController, type: :controller do
                 "en": ["View Source Item"]
               },
               "format": "text/html"
-            }
+            },
+            "items": [
+              {
+                "id": "http://test.host/timelines/1/manifest/canvas",
+                "type": "Canvas",
+                "duration": 3437.426,
+                "items": [
+                  {
+                    "id": "http://test.host/timelines/1/manifest/annotations",
+                    "type": "AnnotationPage",
+                    "items": [
+                      {
+                        "id": "http://test.host/timelines/1/manifest/annotations/1",
+                        "type": "Annotation",
+                        "motivation": "painting",
+                        "body": {
+                          "id": "http://test.host/master_files/#{master_file.id}/auto.m3u8#t=0,",
+                          "type": "Audio",
+                          "duration": 3437.426,
+                        },
+                        "target": "http://test.host/timelines/1/manifest/canvas"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         end
 
@@ -481,7 +507,7 @@ RSpec.describe TimelinesController, type: :controller do
           "http://www.w3.org/ns/anno.jsonld",
           "http://iiif.io/api/presentation/3/context.json"
         ],
-        "id": "https://example.com/timelines/1.json",
+        "id": "http://test.host/timelines/1.json",
         "type": "Manifest",
         "label": { "en": [ "Timeline 1" ] }
       }
@@ -511,7 +537,7 @@ RSpec.describe TimelinesController, type: :controller do
           "http://www.w3.org/ns/anno.jsonld",
           "http://iiif.io/api/presentation/3/context.json"
         ],
-        "id": "https://example.com/timelines/1.json",
+        "id": "http://test.host/timelines/1.json",
         "type": "Manifest",
         "label": { "en": [ "Timeline 1" ] }
       }
@@ -522,7 +548,7 @@ RSpec.describe TimelinesController, type: :controller do
       timeline.reload
       expect(response).to be_successful
       expect(response.body).to eq timeline.manifest
-      expect(timeline.manifest).to eq manifest.to_json
+      expect(JSON.parse(timeline.manifest).except("homepage")).to eq JSON.parse(manifest.to_json)
     end
   end
 


### PR DESCRIPTION
Fixes #3497 
This PR ensures that timeline sources are full urls instead of relative urls.  This url is displayed on the edit timeline page.  Additionally, this PR enables the source link in the timeliner displaying the IIIF manifest homepage attribute which on save is converted to the master file's permalink if available and falls back to the full master file url.
Migration should only require going through all existing timelines, marking them as dirty, and resaving them.