### PR TITLE
Rough draft of collection index and landing page

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 7.1.0
+version: 7.7.2
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -41,16 +41,20 @@
 
 a:not(.btn) {
   color: $linkColor;
+
   &:hover {
     color: $linkColor;
   }
+
   &:active {
     color: $linkColor;
   }
+
   &:visited {
     color: $linkColor;
   }
 }
+
 @mixin hidden-disabled-link {
   text-decoration: none !important;
   color: $black !important;
@@ -83,10 +87,12 @@ tr.active-false td {
     a:hover {
       background: transparent;
     }
+
     span {
       display: block;
       padding: 10px 15px;
     }
+
     p {
       margin-left: 1em;
       margin-right: 1em;
@@ -98,6 +104,7 @@ tr.active-false td {
     border-color: $state-success-border;
     color: $state-success-text;
   }
+
   li.nav-success a {
     text-shadow: rgba(255, 255, 255, 0.2) 0px 1px 0px;
   }
@@ -147,6 +154,7 @@ tr.active-false td {
     }
   }
 }
+
 .navbar-inverse .navbar-nav {
   li {
     a:hover {
@@ -155,19 +163,24 @@ tr.active-false td {
     }
   }
 }
+
 .navbar-right {
   padding: 4px 0;
   margin-right: 0;
 }
-.container > .navbar-header {
+
+.container>.navbar-header {
   height: auto;
 }
+
 .navbar-inverse .navbar-toggle .icon-bar {
   background-color: #888888;
 }
+
 .navbar-toggle {
   margin: 4px;
 }
+
 #user-util-collapse {
   border-top: 0;
 }
@@ -185,6 +198,7 @@ tr.active-false td {
 .uneditable-input-exists {
   //@extend .uneditable-input;
   width: 45%;
+
   i {
     padding-left: 0.5em;
   }
@@ -194,9 +208,11 @@ tr.active-false td {
 .tooltip-block {
   cursor: help;
 }
+
 .tooltip-label * {
   cursor: pointer;
 }
+
 .tooltip-block .close {
   font-size: 14px;
 }
@@ -204,39 +220,48 @@ tr.active-false td {
 // Form-group input fields
 .form-group .input-group {
   width: 100%;
+
   .form-control {
     border-radius: 0;
+
     &:first-child {
       border-top-left-radius: $border-radius-base;
       border-bottom-left-radius: $border-radius-base;
     }
+
     &:last-child {
       border-top-right-radius: $border-radius-base;
       border-bottom-right-radius: $border-radius-base;
     }
   }
+
   .input-group-btn {
     vertical-align: top;
   }
+
   .add-dynamic-field {
     cursor: pointer;
   }
 }
+
 .form-group .input-group.typed-textarea {
   .input-group-btn:first-of-type {
     width: 100%;
+
     button {
       width: 100%;
       text-align: left;
       border-bottom-left-radius: 0;
     }
   }
+
   .input-group-btn:last-of-type {
     button {
       border-bottom-right-radius: 0;
     }
   }
 }
+
 .form-group textarea.typed-textarea {
   border-top: none;
   border-top-right-radius: 0;
@@ -266,16 +291,20 @@ label {
   .row {
     margin-right: 0;
   }
+
   .remove:hover,
   .remove:active {
     @extend .btn-danger;
   }
+
   td.access_list_label {
     width: 55%;
   }
+
   td.access_list_dates {
     width: 35%;
   }
+
   td.access_list_remove {
     width: 10%;
   }
@@ -307,6 +336,7 @@ input[type='text']#admin_group {
   margin-bottom: 0em;
   font-size: 0.8em;
   @extend .mobile-hidden;
+
   .row {
     margin: 0;
   }
@@ -321,6 +351,7 @@ header div {
   color: #2a5459;
   background-color: #fbb040;
   padding: 0.8em;
+
   &:after {
     content: '\003e \003e';
   }
@@ -354,6 +385,7 @@ header div {
 /* Sidebar */
 
 .sidenav {
+
   /* Browse By Header */
   h2 {
     margin: 0px;
@@ -363,6 +395,7 @@ header div {
     font-weight: bold;
     font-size: 18px;
   }
+
   /* Facet Group Header */
   h3 {
     font-weight: bold;
@@ -381,18 +414,23 @@ header div {
   @media (min-width: $screen-sm-min) {
     max-width: 220px;
   }
+
   padding-bottom: 10px;
+
   .panel {
     border-radius: 0px;
   }
+
   .panel-group {
     margin-bottom: 0px;
     padding-right: 0px;
     padding-left: 0px;
   }
+
   ul {
     margin-bottom: 0px;
   }
+
   .top-panel-heading {
     margin-bottom: 0em;
   }
@@ -410,9 +448,11 @@ div[id*='facet-panel-'] {
 .facets-toggle {
   margin-top: -6px;
   background-color: $white;
+
   .icon-bar {
     background-color: #888888;
   }
+
   margin: 3px;
 }
 
@@ -455,6 +495,7 @@ footer a {
 footer ul {
   float: left;
   margin-left: -40px;
+
   @media all and (max-width: 475px) {
     float: none;
   }
@@ -462,6 +503,7 @@ footer ul {
 
 footer .release {
   float: right;
+
   @media all and (max-width: 475px) {
     float: none;
   }
@@ -475,8 +517,10 @@ footer .release {
 
 .alert-success {
   text-shadow: rgba(0, 0, 0, 0.1) 0px 1px 0px;
+
   a {
     color: $successLink;
+
     &:hover {
       color: scale-color($successLink, $lightness: -20%);
     }
@@ -486,10 +530,12 @@ footer .release {
 #featured_content_header {
   margin-top: 0;
 }
+
 #featured_content {
   h5 {
     font-weight: bold;
   }
+
   img {
     @extend .img-thumbnail;
   }
@@ -507,6 +553,7 @@ span.constraints-label {
 }
 
 #creation_metadata {
+
   // Make <pre> formatted text look like normal output instead of
   // bounded in gray
   pre {
@@ -552,10 +599,12 @@ button.close {
       border-color: $state-danger-text;
     }
   }
+
   .field_with_errors input {
     border-color: $state-danger-border;
     background-color: $state-danger-bg;
   }
+
   input,
   textarea {
     width: 90%;
@@ -563,6 +612,7 @@ button.close {
     margin-bottom: 10px;
     padding: 3px;
   }
+
   label {
     display: block;
   }
@@ -574,6 +624,7 @@ button.close {
 
 .mejs-poster {
   overflow: hidden;
+
   img {
     width: 100%;
     height: 100%;
@@ -586,17 +637,18 @@ button.close {
 }
 
 .role-popover-help {
-  & + .popover .arrow {
+  &+.popover .arrow {
     left: 10%;
   }
 }
 
-.btn-confirmation + .popover .popover-content {
+.btn-confirmation+.popover .popover-content {
   white-space: nowrap;
 }
 
 .fileinput {
   max-width: 500px;
+
   .form-control {
     max-width: 500px;
     white-space: nowrap;
@@ -656,10 +708,12 @@ a[data-trigger='submit'] {
 .facets .panel-group .panel {
   margin-top: 0px;
 }
-.facet_limit-active > .panel-heading {
+
+.facet_limit-active>.panel-heading {
   background-color: $lightgray;
 }
-:not(.facet_limit-active).facet_limit > .panel-heading {
+
+:not(.facet_limit-active).facet_limit>.panel-heading {
   background-color: $white;
 }
 
@@ -668,6 +722,7 @@ a[data-trigger='submit'] {
     width: auto;
     margin-right: 1em;
   }
+
   dd {
     margin-left: 0;
   }
@@ -688,7 +743,7 @@ a[data-trigger='submit'] {
   color: $black;
 }
 
-.tab-content > .tab-pane {
+.tab-content>.tab-pane {
   padding: 10px;
   border-bottom: 1px solid $gray;
   border-left: 1px solid $gray;
@@ -706,6 +761,7 @@ a[data-trigger='submit'] {
 
 #documents .document {
   padding-bottom: $padding-base-vertical;
+
   &:last-child {
     border-bottom: none;
   }
@@ -718,6 +774,7 @@ a[data-trigger='submit'] {
 .fileinput-submit {
   background-color: $blue !important;
   border-color: $blue !important;
+
   &:hover {
     background-color: darken($blue, 15%) !important;
   }
@@ -731,6 +788,7 @@ a[data-trigger='submit'] {
     border-color: $green;
     font-size: $font-size-base;
   }
+
   .constraint-value:hover {
     background-color: $greenBG;
     border-color: $green;
@@ -757,8 +815,9 @@ a[data-trigger='submit'] {
   color: $white;
 }
 
-.nav-pills > li > a {
+.nav-pills>li>a {
   padding: 4px 15px;
+
   /* override bootstrap .nav overrides of button colors */
   &.btn-danger {
     @extend .btn-danger;
@@ -770,29 +829,36 @@ a[data-trigger='submit'] {
     legend {
       margin: 10px 0 5px 0;
     }
+
     &:first-of-type {
       legend {
         margin-top: -10px;
       }
     }
   }
+
   .help-block {
     z-index: 1045;
   }
+
   .control-label {
     text-align: left;
   }
+
   .special-access label {
     display: block;
+
     input,
     select {
       display: inline;
       width: auto;
       min-width: 300px;
     }
+
     p {
       margin: 10px 0 5px 0;
     }
+
     .twitter-typeahead {
       width: auto;
     }
@@ -807,6 +873,7 @@ a[data-trigger='submit'] {
   text-align: right;
   margin-top: 10px;
   margin-bottom: 0;
+
   a:link,
   a:visited,
   a:hover,
@@ -814,11 +881,13 @@ a[data-trigger='submit'] {
     text-decoration: none;
   }
 }
+
 #share-list .tab-content {
   margin-bottom: 20px;
 }
 
 $accordionPadding: 20px;
+
 @function accordion-indent($n) {
   @return -1 * $n * $accordionPadding;
 }
@@ -830,6 +899,7 @@ $accordionPadding: 20px;
   a {
     display: inline-block;
     cursor: pointer;
+
     &:link,
     &:visited,
     &:hover,
@@ -837,7 +907,9 @@ $accordionPadding: 20px;
       text-decoration: none;
     }
   }
+
   .panel-title {
+
     .fa-plus-square,
     .fa-minus-square {
       font-size: 0.9em;
@@ -847,49 +919,61 @@ $accordionPadding: 20px;
       background-color: $lightgray;
     }
   }
+
   ul,
   li {
     list-style: none;
   }
+
   li.stream-li {
     position: relative;
   }
+
   i.now-playing {
     position: absolute;
     color: $linkColor;
     left: accordion-indent(1);
   }
+
   .panel-heading {
     border-bottom: 1px solid #dddddd;
     padding: 7px 10px;
+
     ul {
       padding-left: $accordionPadding;
       margin-bottom: 0;
       display: inline-block;
     }
+
     #expand_button,
     #collapse_button {
       float: right;
       margin-top: -2px;
     }
   }
+
   .panel-body {
     border-top: none;
     position: relative;
+
     ul {
       padding-left: $accordionPadding;
+
       i.now-playing {
         top: 3px;
         left: accordion-indent(1);
       }
+
       ul {
         i.now-playing {
           left: accordion-indent(2);
         }
+
         ul {
           i.now-playing {
             left: accordion-indent(3);
           }
+
           ul {
             i.now-playing {
               left: accordion-indent(4);
@@ -932,12 +1016,15 @@ $accordionPadding: 20px;
   &:link {
     @hidden-disabled-link;
   }
+
   &:hover {
     @hidden-disabled-link;
   }
+
   &:active {
     @hidden-disabled-link;
   }
+
   &:visited {
     @hidden-disabled-link;
   }
@@ -960,50 +1047,62 @@ div.status-detail {
 }
 
 #mediaobject_structure {
+
   a.structure_toggle,
   a.captions_toggle {
     cursor: pointer;
   }
+
   ul {
     list-style: none;
     padding: 0;
     margin: 0;
     min-width: 920px;
   }
+
   ul.header {
     background-color: $lightgray;
     font-weight: bold;
   }
+
   li.section {
     &:nth-of-type(2n) {
       background-color: $lightgray;
     }
   }
+
   ul.fileinfo,
   ul.header {
     border-top: 1px solid $gray;
+
     li {
       display: inline-block;
       padding: 8px;
       vertical-align: top;
+
       &:nth-of-type(1) {
         width: 50px;
         text-align: center;
       }
+
       &:nth-of-type(2) {
         width: 30%;
       }
+
       &:nth-of-type(3) {
         width: 40%;
       }
+
       &:nth-of-type(4) {
         width: 75px;
         text-align: left;
       }
+
       &:nth-of-type(5) {
         width: 75px;
         text-align: center;
       }
+
       &:nth-of-type(6) {
         width: 75px;
         text-align: center;
@@ -1011,66 +1110,83 @@ div.status-detail {
       }
     }
   }
+
   div.structure_tool {
     padding: 10px 20px;
     border-top: 1px dotted $gray;
     min-height: 40px;
+
     div.structure_view {
       margin-left: 20px;
+
       ul {
         padding-left: 20px;
+
         li {
           display: block;
           width: 100%;
         }
       }
     }
+
     div.tool_actions {
       width: 100%;
+
       form {
         display: inline;
         float: right;
       }
     }
+
     span.tool_label {
       font-weight: bold;
     }
   }
 }
+
 div.structure_edit {
   .modal-dialog {
     min-width: 900px;
   }
+
   ul {
     list-style: none;
     padding: 0;
   }
+
   ul.element_header {
     .top_actions {
       margin-top: 1px;
     }
+
     .element_name {
       margin-left: 6px;
     }
   }
+
   .xml_tab_area {
     .gui_content {
       background-color: inherit;
     }
+
     .xml_problems_panel {
       background-color: $state-danger-bg;
     }
-    .attribute_container > textarea {
+
+    .attribute_container>textarea {
       resize: both;
     }
-    .attribute_container > a,
-    .attribute_container > label {
+
+    .attribute_container>a,
+    .attribute_container>label {
       vertical-align: top;
     }
   }
+
   .xml_textarea {
     padding: 0;
   }
+
   .section_edit_submit {
     margin-bottom: 10px;
     margin-top: 4px;
@@ -1167,45 +1283,56 @@ div.structure_edit {
 /* Playlist show page */
 .queue {
   opacity: 0.8;
+
   &:hover {
     opacity: 1;
   }
 }
+
 h5.panel-title {
   font-size: 1.15em;
   padding-left: 0.4em;
   min-height: 1em;
 }
+
 .panel-heading {
   border-top: 1px solid $gray;
 }
+
 .panel-heading .accordion-toggle:before {
   font-family: 'FontAwesome';
   content: '\f078';
 }
+
 .panel-heading .accordion-toggle.collapsed:before {
   content: '\f054';
 }
+
 #metadata_header h3 {
   font-size: 18px;
 }
+
 .indicator {
   font-size: 18px;
   padding-right: 4px;
 }
+
 .now-playing-title {
   width: 80%;
   float: left;
 }
+
 .side-playlist {
   border-top: 1px solid $gray;
   padding-top: 0.6em;
   padding-left: 2rem;
+
   li {
     margin-top: 0.2em;
     margin-left: 21px;
     float: left;
     width: 100%;
+
     &.now_playing:before {
       @include current-stream-indicator(-16px, -24px);
     }
@@ -1214,29 +1341,36 @@ h5.panel-title {
       margin-right: 3px;
     }
   }
+
   a {
     cursor: pointer;
   }
+
   .pull-right {
     text-align: right;
     margin-right: 21px;
   }
 }
+
 #section-label {
   float: left;
 }
+
 #edit-playlist-button {
   margin-left: 5px;
   margin-top: 1px;
 }
+
 .copy-playlist-button {
   margin-top: 2px;
   padding-top: 1px;
   padding-bottom: 1px;
+
   @media (max-width: $screen-xs-max) {
     margin-top: 1px;
   }
 }
+
 .playlist-title {
   margin: 0;
   padding: 0;
@@ -1244,18 +1378,22 @@ h5.panel-title {
   width: 100%;
   border-bottom: 1px solid $gray;
   line-height: 2em;
+
   .fa {
     font-size: 0.7em;
   }
 }
+
 .position-input {
   width: 4em;
 }
+
 .playlist_actions {
   textarea {
     resize: vertical;
   }
 }
+
 .playlist_item_edit {
   border: 2pt solid $gray;
   border-top: 1pt solid $gray;
@@ -1266,29 +1404,35 @@ h5.panel-title {
   padding: 10pt;
   margin-top: 2pt;
   margin-bottom: 10pt;
+
   label {
     text-align: right;
     margin-top: 2pt;
   }
+
   input,
   textarea {
     margin-bottom: 4pt;
   }
+
   textarea {
     resize: vertical;
   }
 }
+
 #related_items {
   .clip_title {
     font-weight: bold;
   }
-  .clip_start_time {
-  }
-  .clip_end_time {
-  }
+
+  .clip_start_time {}
+
+  .clip_end_time {}
+
   .clip_position {
     text-align: center;
   }
+
   tr {
     height: 2em;
   }
@@ -1303,9 +1447,11 @@ h5.panel-title {
     float: right;
     padding-right: 5px;
   }
+
   #delete_selected_playlist_items {
     margin-right: 5px;
   }
+
   label {
     padding-left: 20px;
     float: right;
@@ -1324,6 +1470,7 @@ h5.panel-title {
   height: 14px !important;
   top: -3px !important;
 }
+
 .mejs__container {
   z-index: 1000;
 }
@@ -1395,9 +1542,10 @@ h5.panel-title {
     font-size: 18px;
     padding-bottom: 10px;
 
-    > span {
+    >span {
       padding: 0 5px;
     }
+
     .delete {
       margin-left: auto;
       padding: 0;
@@ -1435,6 +1583,11 @@ h5.panel-title {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #b24b47;
 }
 
+/**
+ * Collections
+ */
+.collections-list-wrapper {}
+
 .well-vertical-spacer {
   margin-bottom:10px;
 }
@@ -1443,7 +1596,7 @@ h5.panel-title {
   white-space:pre-wrap;
 }
 
-// Collection list page
+// Admin Collection list page
 .row.display-flex {
   display: flex;
 	flex-direction: row;

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,30 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# frozen_string_literal: true
+class CollectionsController < CatalogController
+  skip_before_action :enforce_show_permissions, only: :show
+
+  def index
+    response = repository.search(CollectionSearchBuilder.new(self))
+    @doc_presenters = response.documents.collect { |doc| CollectionPresenter.new(doc) }
+  end
+
+  def show
+    response = repository.search(CollectionSearchBuilder.new(self))
+    document = response.documents.find { |doc| doc.id == params[:id] }
+    # Only go on if params[:id] is in @document_list
+    raise CanCan::AccessDenied unless document
+    @doc_presenter = CollectionPresenter.new(document)
+  end
+end

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -26,7 +26,14 @@ module Blacklight::LocalBlacklightHelper
   end
 
   def url_for_document doc, options = {}
-    media_object_path(doc[:id])
+    case doc["has_model_ssim"].first
+    when "MediaObject"
+      media_object_path(doc[:id])
+    when "Admin::Collection"
+      collection_path(doc[:id])
+    else
+      object_path(doc[:id])
+    end
   end
 
   def contributor_index_display args

--- a/app/models/collection_search_builder.rb
+++ b/app/models/collection_search_builder.rb
@@ -1,0 +1,41 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# frozen_string_literal: true
+class CollectionSearchBuilder < Blacklight::SearchBuilder
+  include Blacklight::Solr::SearchBuilderBehavior
+  include Hydra::AccessControlsEnforcement
+  include Hydra::MultiplePolicyAwareAccessControlsEnforcement
+
+  self.default_processor_chain -= [:add_access_controls_to_solr_params]
+  # self.default_processor_chain += [:add_access_controls_to_solr_params_if_not_admin, :only_wanted_models, :gated_discovery_join]
+  self.default_processor_chain += [:gated_discovery_join, :only_wanted_models]
+
+  def only_wanted_models(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << 'has_model_ssim:"Admin::Collection"'
+  end
+
+  def add_access_controls_to_solr_params_if_not_admin(solr_parameters)
+    add_access_controls_to_solr_params(solr_parameters) if current_ability.cannot? :discover_everything, Admin::Collection
+  end
+
+  def gated_discovery_join(solr_parameters)
+    temp_solr_parameters = {}
+    add_access_controls_to_solr_params_if_not_admin(temp_solr_parameters)
+    query =  "{!join from=isMemberOfCollection_ssim to=id}*:*"
+    query += " AND (#{temp_solr_parameters[:fq].first})" if temp_solr_parameters[:fq].present?
+    solr_parameters[:q] = query
+    solr_parameters[:defType] = "lucene"
+  end
+end

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,0 +1,39 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# frozen_string_literal: true
+class CollectionPresenter
+  attr_reader :document
+
+  def initialize(solr_doc)
+    @document = solr_doc
+  end
+
+  delegate :id, to: :document
+
+  def name
+    document["name_ssi"]
+  end
+
+  def unit
+    document["unit_ssi"]
+  end
+
+  def description
+    document["description_tesim"]&.first
+  end
+
+  def thumbnail
+    'hybrid_icon.png'
+  end
+end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -16,6 +16,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div class="navbar-left">
   <ul class="nav navbar-nav">
     <li><%= link_to 'Browse', main_app.search_catalog_path(search_field: 'all_fields', utf8: '✓', q: '') %></li>
+    <li><%= link_to 'Collections', main_app.collections_path %></li>
+
     <% if can? :read, Admin::Collection %>
     <li class=<%= active_for_controller('admin/collections') %>><%= link_to 'Manage Content', main_app.admin_collections_path %></li>
     <% end %>
@@ -46,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
     <% if current_ability.can? :create, Timeline %>
     <li class=<%= active_for_controller('timelines') %>>
-      <%= link_to 'Timelines', main_app.timelines_path, id:'timelines_nav' %> 
+      <%= link_to 'Timelines', main_app.timelines_path, id:'timelines_nav' %>
     </li>
     <% end %>
     <li class="divider desktop-hidden" />

--- a/app/views/collections/_index_collection.html.erb
+++ b/app/views/collections/_index_collection.html.erb
@@ -1,0 +1,32 @@
+<%#
+Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<li class="media">
+  <div class="media-left">
+    <div class="document-thumbnail"><%= image_tag doc_presenter.thumbnail, alt: "Collection thumbnail" %></div>
+  </div>
+  <div class="media-body">
+    <h4 class="media-heading"><%= link_to(doc_presenter.name, collection_path(doc_presenter.id)) %></h4>
+    <dl>
+      <dt>Unit</dt>
+      <dd><%= doc_presenter.unit %></dd>
+      <% if doc_presenter.description.present? %>
+      <dt>Description</dt>
+      <dd><%= doc_presenter.description.truncate(100, separator: ' ') %></dd>
+      <% end %>
+    </dl>
+  </div>
+</li>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -1,0 +1,26 @@
+<%#
+Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+<% @page_title = t('collections.title', :application_name => application_name) %>
+
+<div class='container-fluid collections-list-wrapper'>
+  <h2><%= @page_title %></h2>
+
+  <ul class="list-unstyled">
+    <% @doc_presenters.each do |doc_presenter| %>
+      <%= render 'index_collection', doc_presenter: doc_presenter %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,0 +1,30 @@
+<%#
+Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<% @page_title = t('collections.show.title', :collection_name => @doc_presenter.name, :application_name => application_name) %>
+
+<div class='container-fluid'>
+  <h3 class="col-md-12">
+    <div class="document-thumbnail">
+      <%= image_tag @doc_presenter.thumbnail, class: 'img-responsive' %>
+    </div>
+    <%= link_to(@doc_presenter.name, collection_path(@doc_presenter.id)) %>
+  </h3>
+  <p><strong>Unit:</strong></p>
+  <p><%= @doc_presenter.unit %></p>
+  <p><strong>Description:</strong></p>
+  <p style="white-space:pre-wrap"><%= @doc_presenter.description %></p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,8 @@ Rails.application.routes.draw do
 
   resources :vocabulary, except: [:create, :destroy, :new, :edit]
 
+  resources :collections, only: [:index, :show]
+
   resources :media_objects, except: [:create, :update] do
     member do
       put :update, action: :update, defaults: { format: 'html' }, constraints: { format: 'html' }

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -1,0 +1,400 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe Admin::CollectionsController, type: :controller do
+  render_views
+
+  describe 'security' do
+    let(:collection) { FactoryBot.create(:collection) }
+    before do
+      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+    end
+    describe 'ingest api' do
+      it "all routes should return 401 when no token is present" do
+        expect(get :index, params: { format: 'json' }).to have_http_status(401)
+        expect(get :show, params: { id: collection.id, format: 'json' }).to have_http_status(401)
+        expect(get :items, params: { id: collection.id, format: 'json' }).to have_http_status(401)
+        expect(post :create, params: { format: 'json' }).to have_http_status(401)
+        expect(put :update, params: { id: collection.id, format: 'json' }).to have_http_status(401)
+      end
+      it "all routes should return 403 when a bad token in present" do
+        request.headers['Avalon-Api-Key'] = 'badtoken'
+        expect(get :index, params: { format: 'json' }).to have_http_status(403)
+        expect(get :show, params: { id: collection.id, format: 'json' }).to have_http_status(403)
+        expect(get :items, params: { id: collection.id, format: 'json' }).to have_http_status(403)
+        expect(post :create, params: { format: 'json' }).to have_http_status(403)
+        expect(put :update, params: { id: collection.id, format: 'json' }).to have_http_status(403)
+      end
+    end
+    describe 'normal auth' do
+      context 'with end-user' do
+        before do
+          login_as :user
+        end
+        #New is isolated here due to issues caused by the controller instance not being regenerated
+        it "should redirect to /" do
+          expect(get :new).to redirect_to(root_path)
+        end
+        it "all routes should redirect to /" do
+          expect(get :index).to redirect_to(root_path)
+          expect(get :show, params: { id: collection.id }).to redirect_to(root_path)
+          expect(get :edit, params: { id: collection.id }).to redirect_to(root_path)
+          expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
+          expect(post :create).to redirect_to(root_path)
+          expect(put :update, params: { id: collection.id }).to redirect_to(root_path)
+          expect(patch :update, params: { id: collection.id }).to redirect_to(root_path)
+          expect(delete :destroy, params: { id: collection.id }).to redirect_to(root_path)
+          expect(post :attach_poster, params: { id: collection.id }).to redirect_to(root_path)
+          expect(get :poster, params: { id: collection.id }).to redirect_to(root_path)
+        end
+      end
+    end
+  end
+
+  describe "#manage" do
+    let!(:collection) { FactoryBot.create(:collection) }
+    before(:each) do
+      request.env["HTTP_REFERER"] = '/'
+      login_as(:administrator)
+    end
+
+    it "should add users to manager role" do
+      manager = FactoryBot.create(:manager)
+      put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: manager.user_key }
+      collection.reload
+      expect(manager).to be_in(collection.managers)
+    end
+
+    it "should not add users to manager role" do
+      user = FactoryBot.create(:user)
+      put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: user.user_key }
+      collection.reload
+      expect(user).not_to be_in(collection.managers)
+      expect(flash[:error]).not_to be_empty
+    end
+
+    it "should remove users from manager role" do
+      #initial_manager = FactoryBot.create(:manager).user_key
+      collection.managers += [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+      collection.save!
+      manager = User.where(Devise.authentication_keys.first => collection.managers.first).first
+      put 'update', params: { id: collection.id, remove_manager: manager.user_key }
+      collection.reload
+      expect(manager).not_to be_in(collection.managers)
+    end
+  end
+
+  describe "#edit" do
+    let!(:collection) { FactoryBot.create(:collection) }
+    before(:each) do
+      request.env["HTTP_REFERER"] = '/'
+    end
+
+    it "should add users to editor role" do
+      login_as(:administrator)
+      editor = FactoryBot.build(:user)
+      put 'update', params: { id: collection.id, submit_add_editor: 'Add', add_editor: editor.user_key }
+      collection.reload
+      expect(editor).to be_in(collection.editors)
+    end
+
+    it "should remove users from editor role" do
+      login_as(:administrator)
+      editor = User.where(Devise.authentication_keys.first => collection.editors.first).first
+      put 'update', params: { id: collection.id, remove_editor: editor.user_key }
+      collection.reload
+      expect(editor).not_to be_in(collection.editors)
+    end
+  end
+
+  describe "#deposit" do
+    let!(:collection) { FactoryBot.create(:collection) }
+    before(:each) do
+      request.env["HTTP_REFERER"] = '/'
+    end
+
+    it "should add users to depositor role" do
+      login_as(:administrator)
+      depositor = FactoryBot.build(:user)
+      put 'update', params: { id: collection.id, submit_add_depositor: 'Add', add_depositor: depositor.user_key }
+      collection.reload
+      expect(depositor).to be_in(collection.depositors)
+    end
+
+    it "should remove users from depositor role" do
+      login_as(:administrator)
+      depositor = User.where(Devise.authentication_keys.first => collection.depositors.first).first
+      put 'update', params: { id: collection.id, remove_depositor: depositor.user_key }
+      collection.reload
+      expect(depositor).not_to be_in(collection.depositors)
+    end
+  end
+
+  describe "#index" do
+    let!(:collection) { FactoryBot.create(:collection) }
+    subject(:json) { JSON.parse(response.body) }
+    before do
+      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+      request.headers['Avalon-Api-Key'] = 'secret_token'
+    end
+    it "should return list of collections" do
+      get 'index', params: { format:'json' }
+      expect(json.count).to eq(1)
+      expect(json.first['id']).to eq(collection.id)
+      expect(json.first['name']).to eq(collection.name)
+      expect(json.first['unit']).to eq(collection.unit)
+      expect(json.first['description']).to eq(collection.description)
+      expect(json.first['object_count']['total']).to eq(collection.media_objects.count)
+      expect(json.first['object_count']['published']).to eq(collection.media_objects.reject{|mo| !mo.published?}.count)
+      expect(json.first['object_count']['unpublished']).to eq(collection.media_objects.reject{|mo| mo.published?}.count)
+      expect(json.first['roles']['managers']).to eq(collection.managers)
+      expect(json.first['roles']['editors']).to eq(collection.editors)
+      expect(json.first['roles']['depositors']).to eq(collection.depositors)
+    end
+    it "should return list of collections for good user" do
+      get 'index', params: { user: collection.managers.first, format:'json' }
+      expect(json.count).to eq(1)
+    end
+    it "should return no collections for bad user" do
+      get 'index', params: { user: 'foobar', format:'json' }
+      expect(json.count).to eq(0)
+    end
+  end
+
+  describe 'pagination' do
+    subject(:json) { JSON.parse(response.body) }
+    before do
+      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+      request.headers['Avalon-Api-Key'] = 'secret_token'
+    end
+    it 'should paginate index' do
+      5.times { FactoryBot.create(:collection) }
+      get 'index', params: { format:'json', per_page: '2' }
+      expect(json.count).to eq(2)
+      expect(response.headers['Per-Page']).to eq('2')
+      expect(response.headers['Total']).to eq('5')
+    end
+    it 'should paginate collection/items' do
+      collection = FactoryBot.create(:collection, items: 5)
+      get 'items', params: { id: collection.id, format: 'json', per_page: '2' }
+      expect(json.count).to eq(2)
+      expect(response.headers['Per-Page']).to eq('2')
+      expect(response.headers['Total']).to eq('5')
+    end
+  end
+
+  describe "#show" do
+    let!(:collection) { FactoryBot.create(:collection) }
+
+    it "should allow access to managers" do
+      login_user(collection.managers.first)
+      get 'show', params: { id: collection.id }
+      expect(response).to be_ok
+    end
+
+    context "with json format" do
+      subject(:json) { JSON.parse(response.body) }
+
+      it "should return json for specific collection" do
+        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        request.headers['Avalon-Api-Key'] = 'secret_token'
+        get 'show', params: { id: collection.id, format:'json' }
+        expect(json['id']).to eq(collection.id)
+        expect(json['name']).to eq(collection.name)
+        expect(json['unit']).to eq(collection.unit)
+        expect(json['description']).to eq(collection.description)
+        expect(json['object_count']['total']).to eq(collection.media_objects.count)
+        expect(json['object_count']['published']).to eq(collection.media_objects.reject{|mo| !mo.published?}.count)
+        expect(json['object_count']['unpublished']).to eq(collection.media_objects.reject{|mo| mo.published?}.count)
+        expect(json['roles']['managers']).to eq(collection.managers)
+        expect(json['roles']['editors']).to eq(collection.editors)
+        expect(json['roles']['depositors']).to eq(collection.depositors)
+      end
+
+      it "should return 404 if requested collection not present" do
+        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        request.headers['Avalon-Api-Key'] = 'secret_token'
+        get 'show', params: { id: 'doesnt_exist', format: 'json' }
+        expect(response.status).to eq(404)
+        expect(JSON.parse(response.body)["errors"].class).to eq Array
+        expect(JSON.parse(response.body)["errors"].first.class).to eq String
+      end
+    end
+  end
+
+  describe "#items" do
+    let!(:collection) { FactoryBot.create(:collection, items: 2) }
+
+    it "should return json for specific collection's media objects" do
+      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+      request.headers['Avalon-Api-Key'] = 'secret_token'
+      get 'items', params: { id: collection.id, format: 'json' }
+      expect(JSON.parse(response.body)).to include(collection.media_objects[0].id,collection.media_objects[1].id)
+      #TODO add check that mediaobject is serialized to json properly
+    end
+
+  end
+
+  describe "#create" do
+    let!(:collection) { FactoryBot.build(:collection) }
+    before do
+      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+      request.headers['Avalon-Api-Key'] = 'secret_token'
+    end
+
+    it "should notify administrators" do
+      login_as(:administrator) #otherwise, there are no administrators to mail
+      # mock_email = double('email')
+      # allow(mock_email).to receive(:deliver_later)
+      # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
+      # FIXME: This delivers two instead of one for some reason
+      expect {post 'create', params: { format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers} }}.to have_enqueued_job(ActionMailer::DeliveryJob).twice
+      # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
+    end
+    it "should create a new collection" do
+      post 'create', params: { format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers} }
+      expect(JSON.parse(response.body)['id'].class).to eq String
+      expect(JSON.parse(response.body)).not_to include('errors')
+    end
+    it "should create a new collection with default manager list containing current API user" do
+      post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description, unit: collection.unit } }
+      expect(JSON.parse(response.body)['id'].class).to eq String
+      collection = Admin::Collection.find(JSON.parse(response.body)['id'])
+      expect(collection.managers).to eq(['archivist1@example.com'])
+    end
+    it "should return 422 if collection creation failed" do
+      post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description } }
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)).to include('errors')
+      expect(JSON.parse(response.body)["errors"].class).to eq Array
+      expect(JSON.parse(response.body)["errors"].first.class).to eq String
+    end
+
+  end
+
+  describe "#update" do
+    it "should notify administrators if name changed" do
+      login_as(:administrator) #otherwise, there are no administrators to mail
+      # mock_delay = double('mock_delay').as_null_object
+      # allow(NotificationsMailer).to receive(:deliver_later).and_return(mock_delay)
+      # expect(mock_delay).to receive(:update_collection)
+      @collection = FactoryBot.create(:collection)
+      # put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}
+      expect {put 'update', params: { id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit} }}.to have_enqueued_job(ActionMailer::DeliveryJob).once
+    end
+
+    context "update REST API" do
+      let!(:collection) { FactoryBot.create(:collection)}
+      before do
+        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        request.headers['Avalon-Api-Key'] = 'secret_token'
+      end
+
+      it "should update a collection via API" do
+        old_description = collection.description
+        put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
+        expect(JSON.parse(response.body)['id'].class).to eq String
+        expect(JSON.parse(response.body)).not_to include('errors')
+        collection.reload
+        expect(collection.description).to eq old_description+'new'
+      end
+      it "should return 422 if collection update via API failed" do
+        allow_any_instance_of(Admin::Collection).to receive(:save).and_return false
+        put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
+        expect(response.status).to eq(422)
+        expect(JSON.parse(response.body)).to include('errors')
+        expect(JSON.parse(response.body)["errors"].class).to eq Array
+        expect(JSON.parse(response.body)["errors"].first.class).to eq String
+      end
+    end
+
+    context "access controls" do
+      let!(:collection) { FactoryBot.create(:collection)}
+
+      it "should not allow empty user" do
+        expect{ put 'update', params: { id: collection.id, submit_add_user: "Add", add_user: "", add_user_display: "" }}.not_to change{ collection.reload.default_read_users.size }
+      end
+
+      it "should not allow empty class" do
+        expect{ put 'update', params: { id: collection.id, submit_add_class: "Add", add_class: "", add_class_display: "" }}.not_to change{ collection.reload.default_read_groups.size }
+      end
+
+    end
+  end
+
+  describe "#remove" do
+    let!(:collection) { FactoryBot.create(:collection) }
+
+    it "redirects with message when user does not have ability to delete collection" do
+      login_as :user
+      expect(controller.current_ability.can? :destroy, collection).to be_falsey
+      expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
+      expect(flash[:notice]).not_to be_empty
+    end
+    it "displays confirmation form for managers" do
+      login_user collection.managers.first
+      expect(controller.current_ability.can? :destroy, collection).to be_truthy
+      expect(get :remove, params: { id: collection.id }).to render_template(:remove)
+    end
+  end
+
+  describe '#attach_poster' do
+    context 'adding a poster' do
+      let(:collection) { FactoryBot.create(:collection) }
+
+      before do
+        login_user collection.managers.first
+      end
+
+      it 'adds the poster' do
+        file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
+        expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.to change { collection.poster.present? }.from(false).to(true)
+        expect(collection.poster.mime_type).to eq 'image/jpeg'
+        expect(collection.poster.original_name).to eq 'collection_poster.jpg'
+        expect(collection.poster.content).not_to be_blank
+        expect(response).to redirect_to(admin_collection_path(collection))
+      end
+    end
+
+    context 'removing a poster' do
+      let(:collection) { FactoryBot.create(:collection, :with_poster) }
+
+      before do
+        login_user collection.managers.first
+      end
+
+      it 'removes the poster' do
+        expect { post :attach_poster, params: { id: collection.id } }.to change { collection.poster.present? }.from(true).to(false)
+        expect(response).to redirect_to(admin_collection_path(collection))
+      end
+    end
+  end
+
+  describe '#poster' do
+    let(:collection) { FactoryBot.create(:collection, :with_poster) }
+
+    before do
+      login_user collection.managers.first
+    end
+
+    it 'returns the poster' do
+      get :poster, params: { id: collection.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq "image/jpeg"
+      expect(response.body).not_to be_blank
+    end
+  end
+end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -14,387 +14,64 @@
 
 require 'rails_helper'
 
-describe Admin::CollectionsController, type: :controller do
-  render_views
+describe CollectionsController, type: :controller do
+  # TODO: replace the fedora creates with solr mocking?
+  let!(:collection) { FactoryBot.create(:collection, items: 1) }
 
   describe 'security' do
-    let(:collection) { FactoryBot.create(:collection) }
-    before do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-    end
-    describe 'ingest api' do
-      it "all routes should return 401 when no token is present" do
-        expect(get :index, params: { format: 'json' }).to have_http_status(401)
-        expect(get :show, params: { id: collection.id, format: 'json' }).to have_http_status(401)
-        expect(get :items, params: { id: collection.id, format: 'json' }).to have_http_status(401)
-        expect(post :create, params: { format: 'json' }).to have_http_status(401)
-        expect(put :update, params: { id: collection.id, format: 'json' }).to have_http_status(401)
+    context 'with end-user' do
+      before do
+        login_as :user
       end
-      it "all routes should return 403 when a bad token in present" do
-        request.headers['Avalon-Api-Key'] = 'badtoken'
-        expect(get :index, params: { format: 'json' }).to have_http_status(403)
-        expect(get :show, params: { id: collection.id, format: 'json' }).to have_http_status(403)
-        expect(get :items, params: { id: collection.id, format: 'json' }).to have_http_status(403)
-        expect(post :create, params: { format: 'json' }).to have_http_status(403)
-        expect(put :update, params: { id: collection.id, format: 'json' }).to have_http_status(403)
+      it "all routes should redirect to /" do
+        expect(get :show, params: { id: collection.id }).to redirect_to(root_path)
       end
     end
-    describe 'normal auth' do
-      context 'with end-user' do
-        before do
-          login_as :user
-        end
-        #New is isolated here due to issues caused by the controller instance not being regenerated
-        it "should redirect to /" do
-          expect(get :new).to redirect_to(root_path)
-        end
-        it "all routes should redirect to /" do
-          expect(get :index).to redirect_to(root_path)
-          expect(get :show, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :edit, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
-          expect(post :create).to redirect_to(root_path)
-          expect(put :update, params: { id: collection.id }).to redirect_to(root_path)
-          expect(patch :update, params: { id: collection.id }).to redirect_to(root_path)
-          expect(delete :destroy, params: { id: collection.id }).to redirect_to(root_path)
-          expect(post :attach_poster, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :poster, params: { id: collection.id }).to redirect_to(root_path)
-        end
+
+    context 'with unauthenticated user' do
+      it "all routes should redirect to sign in" do
+        expect(get :show, params: { id: collection.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
-    end
-  end
-
-  describe "#manage" do
-    let!(:collection) { FactoryBot.create(:collection) }
-    before(:each) do
-      request.env["HTTP_REFERER"] = '/'
-      login_as(:administrator)
-    end
-
-    it "should add users to manager role" do
-      manager = FactoryBot.create(:manager)
-      put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: manager.user_key }
-      collection.reload
-      expect(manager).to be_in(collection.managers)
-    end
-
-    it "should not add users to manager role" do
-      user = FactoryBot.create(:user)
-      put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: user.user_key }
-      collection.reload
-      expect(user).not_to be_in(collection.managers)
-      expect(flash[:error]).not_to be_empty
-    end
-
-    it "should remove users from manager role" do
-      #initial_manager = FactoryBot.create(:manager).user_key
-      collection.managers += [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
-      collection.save!
-      manager = User.where(Devise.authentication_keys.first => collection.managers.first).first
-      put 'update', params: { id: collection.id, remove_manager: manager.user_key }
-      collection.reload
-      expect(manager).not_to be_in(collection.managers)
-    end
-  end
-
-  describe "#edit" do
-    let!(:collection) { FactoryBot.create(:collection) }
-    before(:each) do
-      request.env["HTTP_REFERER"] = '/'
-    end
-
-    it "should add users to editor role" do
-      login_as(:administrator)
-      editor = FactoryBot.build(:user)
-      put 'update', params: { id: collection.id, submit_add_editor: 'Add', add_editor: editor.user_key }
-      collection.reload
-      expect(editor).to be_in(collection.editors)
-    end
-
-    it "should remove users from editor role" do
-      login_as(:administrator)
-      editor = User.where(Devise.authentication_keys.first => collection.editors.first).first
-      put 'update', params: { id: collection.id, remove_editor: editor.user_key }
-      collection.reload
-      expect(editor).not_to be_in(collection.editors)
-    end
-  end
-
-  describe "#deposit" do
-    let!(:collection) { FactoryBot.create(:collection) }
-    before(:each) do
-      request.env["HTTP_REFERER"] = '/'
-    end
-
-    it "should add users to depositor role" do
-      login_as(:administrator)
-      depositor = FactoryBot.build(:user)
-      put 'update', params: { id: collection.id, submit_add_depositor: 'Add', add_depositor: depositor.user_key }
-      collection.reload
-      expect(depositor).to be_in(collection.depositors)
-    end
-
-    it "should remove users from depositor role" do
-      login_as(:administrator)
-      depositor = User.where(Devise.authentication_keys.first => collection.depositors.first).first
-      put 'update', params: { id: collection.id, remove_depositor: depositor.user_key }
-      collection.reload
-      expect(depositor).not_to be_in(collection.depositors)
     end
   end
 
   describe "#index" do
-    let!(:collection) { FactoryBot.create(:collection) }
-    subject(:json) { JSON.parse(response.body) }
-    before do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-      request.headers['Avalon-Api-Key'] = 'secret_token'
-    end
-    it "should return list of collections" do
-      get 'index', params: { format:'json' }
-      expect(json.count).to eq(1)
-      expect(json.first['id']).to eq(collection.id)
-      expect(json.first['name']).to eq(collection.name)
-      expect(json.first['unit']).to eq(collection.unit)
-      expect(json.first['description']).to eq(collection.description)
-      expect(json.first['object_count']['total']).to eq(collection.media_objects.count)
-      expect(json.first['object_count']['published']).to eq(collection.media_objects.reject{|mo| !mo.published?}.count)
-      expect(json.first['object_count']['unpublished']).to eq(collection.media_objects.reject{|mo| mo.published?}.count)
-      expect(json.first['roles']['managers']).to eq(collection.managers)
-      expect(json.first['roles']['editors']).to eq(collection.editors)
-      expect(json.first['roles']['depositors']).to eq(collection.depositors)
-    end
-    it "should return list of collections for good user" do
-      get 'index', params: { user: collection.managers.first, format:'json' }
-      expect(json.count).to eq(1)
-    end
-    it "should return no collections for bad user" do
-      get 'index', params: { user: 'foobar', format:'json' }
-      expect(json.count).to eq(0)
-    end
-  end
+    let!(:collection2) { FactoryBot.create(:collection, items: 1) }
+    let!(:collection3) { FactoryBot.create(:collection) }
+    let!(:public_media_object) { FactoryBot.create(:fully_searchable_media_object, collection: collection3) }
 
-  describe 'pagination' do
-    subject(:json) { JSON.parse(response.body) }
-    before do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-      request.headers['Avalon-Api-Key'] = 'secret_token'
+    it "admin should see all collections" do
+      login_as :administrator
+      get 'index'
+      expect(response).to be_ok
+      expect(assigns(:doc_presenters).count).to eql(3)
+      expect(assigns(:doc_presenters).map(&:id)).to match_array([collection.id, collection2.id, collection3.id])
     end
-    it 'should paginate index' do
-      5.times { FactoryBot.create(:collection) }
-      get 'index', params: { format:'json', per_page: '2' }
-      expect(json.count).to eq(2)
-      expect(response.headers['Per-Page']).to eq('2')
-      expect(response.headers['Total']).to eq('5')
+
+    it "managers should see their collections and collections with public items" do
+      login_user(collection.managers.first)
+      get 'index'
+      expect(response).to be_ok
+      expect(assigns(:doc_presenters).count).to eql(2)
+      expect(assigns(:doc_presenters).map(&:id)).to match_array([collection.id, collection3.id])
     end
-    it 'should paginate collection/items' do
-      collection = FactoryBot.create(:collection, items: 5)
-      get 'items', params: { id: collection.id, format: 'json', per_page: '2' }
-      expect(json.count).to eq(2)
-      expect(response.headers['Per-Page']).to eq('2')
-      expect(response.headers['Total']).to eq('5')
+
+    it "end users should see collections with public items" do
+      login_as :user
+      get 'index'
+      expect(response).to be_ok
+      expect(assigns(:doc_presenters).count).to eql(1)
+      expect(assigns(:doc_presenters).map(&:id)).to match_array([collection3.id])
     end
   end
 
   describe "#show" do
-    let!(:collection) { FactoryBot.create(:collection) }
-
     it "should allow access to managers" do
       login_user(collection.managers.first)
       get 'show', params: { id: collection.id }
       expect(response).to be_ok
-    end
-
-    context "with json format" do
-      subject(:json) { JSON.parse(response.body) }
-
-      it "should return json for specific collection" do
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-        request.headers['Avalon-Api-Key'] = 'secret_token'
-        get 'show', params: { id: collection.id, format:'json' }
-        expect(json['id']).to eq(collection.id)
-        expect(json['name']).to eq(collection.name)
-        expect(json['unit']).to eq(collection.unit)
-        expect(json['description']).to eq(collection.description)
-        expect(json['object_count']['total']).to eq(collection.media_objects.count)
-        expect(json['object_count']['published']).to eq(collection.media_objects.reject{|mo| !mo.published?}.count)
-        expect(json['object_count']['unpublished']).to eq(collection.media_objects.reject{|mo| mo.published?}.count)
-        expect(json['roles']['managers']).to eq(collection.managers)
-        expect(json['roles']['editors']).to eq(collection.editors)
-        expect(json['roles']['depositors']).to eq(collection.depositors)
-      end
-
-      it "should return 404 if requested collection not present" do
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-        request.headers['Avalon-Api-Key'] = 'secret_token'
-        get 'show', params: { id: 'doesnt_exist', format: 'json' }
-        expect(response.status).to eq(404)
-        expect(JSON.parse(response.body)["errors"].class).to eq Array
-        expect(JSON.parse(response.body)["errors"].first.class).to eq String
-      end
-    end
-  end
-
-  describe "#items" do
-    let!(:collection) { FactoryBot.create(:collection, items: 2) }
-
-    it "should return json for specific collection's media objects" do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-      request.headers['Avalon-Api-Key'] = 'secret_token'
-      get 'items', params: { id: collection.id, format: 'json' }
-      expect(JSON.parse(response.body)).to include(collection.media_objects[0].id,collection.media_objects[1].id)
-      #TODO add check that mediaobject is serialized to json properly
-    end
-
-  end
-
-  describe "#create" do
-    let!(:collection) { FactoryBot.build(:collection) }
-    before do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-      request.headers['Avalon-Api-Key'] = 'secret_token'
-    end
-
-    it "should notify administrators" do
-      login_as(:administrator) #otherwise, there are no administrators to mail
-      # mock_email = double('email')
-      # allow(mock_email).to receive(:deliver_later)
-      # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
-      # FIXME: This delivers two instead of one for some reason
-      expect {post 'create', params: { format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers} }}.to have_enqueued_job(ActionMailer::DeliveryJob).twice
-      # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
-    end
-    it "should create a new collection" do
-      post 'create', params: { format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers} }
-      expect(JSON.parse(response.body)['id'].class).to eq String
-      expect(JSON.parse(response.body)).not_to include('errors')
-    end
-    it "should create a new collection with default manager list containing current API user" do
-      post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description, unit: collection.unit } }
-      expect(JSON.parse(response.body)['id'].class).to eq String
-      collection = Admin::Collection.find(JSON.parse(response.body)['id'])
-      expect(collection.managers).to eq(['archivist1@example.com'])
-    end
-    it "should return 422 if collection creation failed" do
-      post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description } }
-      expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)).to include('errors')
-      expect(JSON.parse(response.body)["errors"].class).to eq Array
-      expect(JSON.parse(response.body)["errors"].first.class).to eq String
-    end
-
-  end
-
-  describe "#update" do
-    it "should notify administrators if name changed" do
-      login_as(:administrator) #otherwise, there are no administrators to mail
-      # mock_delay = double('mock_delay').as_null_object
-      # allow(NotificationsMailer).to receive(:deliver_later).and_return(mock_delay)
-      # expect(mock_delay).to receive(:update_collection)
-      @collection = FactoryBot.create(:collection)
-      # put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}
-      expect {put 'update', params: { id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit} }}.to have_enqueued_job(ActionMailer::DeliveryJob).once
-    end
-
-    context "update REST API" do
-      let!(:collection) { FactoryBot.create(:collection)}
-      before do
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-        request.headers['Avalon-Api-Key'] = 'secret_token'
-      end
-
-      it "should update a collection via API" do
-        old_description = collection.description
-        put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
-        expect(JSON.parse(response.body)['id'].class).to eq String
-        expect(JSON.parse(response.body)).not_to include('errors')
-        collection.reload
-        expect(collection.description).to eq old_description+'new'
-      end
-      it "should return 422 if collection update via API failed" do
-        allow_any_instance_of(Admin::Collection).to receive(:save).and_return false
-        put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
-        expect(response.status).to eq(422)
-        expect(JSON.parse(response.body)).to include('errors')
-        expect(JSON.parse(response.body)["errors"].class).to eq Array
-        expect(JSON.parse(response.body)["errors"].first.class).to eq String
-      end
-    end
-
-    context "access controls" do
-      let!(:collection) { FactoryBot.create(:collection)}
-
-      it "should not allow empty user" do
-        expect{ put 'update', params: { id: collection.id, submit_add_user: "Add", add_user: "", add_user_display: "" }}.not_to change{ collection.reload.default_read_users.size }
-      end
-
-      it "should not allow empty class" do
-        expect{ put 'update', params: { id: collection.id, submit_add_class: "Add", add_class: "", add_class_display: "" }}.not_to change{ collection.reload.default_read_groups.size }
-      end
-
-    end
-  end
-
-  describe "#remove" do
-    let!(:collection) { FactoryBot.create(:collection) }
-
-    it "redirects with message when user does not have ability to delete collection" do
-      login_as :user
-      expect(controller.current_ability.can? :destroy, collection).to be_falsey
-      expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
-      expect(flash[:notice]).not_to be_empty
-    end
-    it "displays confirmation form for managers" do
-      login_user collection.managers.first
-      expect(controller.current_ability.can? :destroy, collection).to be_truthy
-      expect(get :remove, params: { id: collection.id }).to render_template(:remove)
-    end
-  end
-
-  describe '#attach_poster' do
-    context 'adding a poster' do
-      let(:collection) { FactoryBot.create(:collection) }
-
-      before do
-        login_user collection.managers.first
-      end
-
-      it 'adds the poster' do
-        file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
-        expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.to change { collection.poster.present? }.from(false).to(true)
-        expect(collection.poster.mime_type).to eq 'image/jpeg'
-        expect(collection.poster.original_name).to eq 'collection_poster.jpg'
-        expect(collection.poster.content).not_to be_blank
-        expect(response).to redirect_to(admin_collection_path(collection))
-      end
-    end
-
-    context 'removing a poster' do
-      let(:collection) { FactoryBot.create(:collection, :with_poster) }
-
-      before do
-        login_user collection.managers.first
-      end
-
-      it 'removes the poster' do
-        expect { post :attach_poster, params: { id: collection.id } }.to change { collection.poster.present? }.from(true).to(false)
-        expect(response).to redirect_to(admin_collection_path(collection))
-      end
-    end
-  end
-
-  describe '#poster' do
-    let(:collection) { FactoryBot.create(:collection, :with_poster) }
-
-    before do
-      login_user collection.managers.first
-    end
-
-    it 'returns the poster' do
-      get :poster, params: { id: collection.id }
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to eq "image/jpeg"
-      expect(response.body).not_to be_blank
+      expect(response).to render_template(:show)
+      expect(assigns(:doc_presenter).id).to eq collection.id
     end
   end
 end

--- a/spec/routing/collections_routing_spec.rb
+++ b/spec/routing/collections_routing_spec.rb
@@ -1,0 +1,28 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require "rails_helper"
+
+RSpec.describe CollectionsController, type: :routing do
+  describe "routing" do
+
+    it "routes to #index" do
+      expect(:get => "/collections").to route_to("collections#index")
+    end
+
+    it "routes to #show" do
+      expect(:get => "/collections/1").to route_to("collections#show", :id => "1")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds routes and controller actions for the end-user focused collection index and view pages.  Gated discovery is applied through media objects: if you can discover at least one item in a collection then you can see the collection.  Conversely though if you can't discover at least one item in a collection then it doesn't show up in the index nor are you allowed to see the landing page.  Alternatively (or in addition) we could give collections themselves visibility and special exceptions which would explicitly allow the ability to discover/read a collection.