### PR TITLE
Poorly configured role_map.yml can grant non-logged in users administrator role

### DIFF
--- a/app/models/role_map.rb
+++ b/app/models/role_map.rb
@@ -44,6 +44,7 @@ class RoleMap < ActiveRecord::Base
   end
 
   def set_entries new_entries
+    new_entries.reject! &:nil?
     existing = entries.collect &:entry
     add = new_entries - existing
     delete = existing - new_entries

--- a/config/initializers/hydra_config.rb
+++ b/config/initializers/hydra_config.rb
@@ -49,7 +49,7 @@ module Hydra::RoleMapperBehavior::ClassMethods
 
   def byname
     @byname = map.each_with_object(Hash.new{ |h,k| h[k] = [] }) do |(role, usernames), memo|
-      Array(usernames).each { |x| memo[x] << role}
+      Array(usernames).each { |x| memo[x] << role unless x.nil? }
     end
   end
 end

--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -9,10 +9,13 @@ development:
 test:
   administrator:
     - archivist1@example.com
+    -
   manager:
     - archivist1@example.com
+    -
   group_manager:
     - archivist1@example.com
+    -
 
 production:
   # Add roles for users here.

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,23 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe Ability, type: :model do
+  describe 'non-logged in users' do
+    it 'only belongs to the public group' do
+      expect(Ability.new(nil).user_groups).to eq ["public"]
+    end
+  end
+end

--- a/spec/models/role_map_spec.rb
+++ b/spec/models/role_map_spec.rb
@@ -24,8 +24,10 @@ describe RoleMap do
       RoleMap.all.each &:destroy
     end
 
+    let(:expected_role_map) { {"administrator"=>["archivist1@example.com"], "group_manager"=>["archivist1@example.com"], "manager"=>["archivist1@example.com"]} }
+
     it "should properly initialize the map" do
-      expect(RoleMapper.map).to eq(YAML.load(File.read(File.join(Rails.root, "config/role_map.yml")))[Rails.env])
+      expect(RoleMapper.map).to eq expected_role_map
     end
 
     it "should properly persist a hash" do
@@ -33,6 +35,14 @@ describe RoleMap do
       RoleMap.replace_with!(new_hash)
       expect(RoleMapper.map).to eq(new_hash)
       expect(RoleMap.load).to eq(new_hash)
+    end
+  end
+
+  describe '#set_entries' do
+    let!(:role) { RoleMap.create!(entry: 'group')}
+
+    it 'should not create entries for nils' do
+      expect { role.set_entries([nil]) }.not_to change { RoleMap.count }
     end
   end
 end


### PR DESCRIPTION
Based upon the information an implementor gave, I found that if you use the out of box role_map.yml in production environment then it grants the administrator role to non-logged in users (and maybe all users) because of Settings.initial_user not being defined and that leading to a nil entry in the administrator system group.

This PR addresses this problem by being doubly safe and rejecting nils in two places: creating db entries from yaml and reading role map database entries.