### PR TITLE
Don't try to read poster data as a string

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -246,7 +246,7 @@ class Admin::CollectionsController < ApplicationController
     if params.dig(:admin_collection, :poster).present?
       poster_file = params[:admin_collection][:poster]
       resized_poster = resize_uploaded_poster(poster_file.path)
-      if resized_poster.present?
+      if resized_poster
         @collection.poster.content = resized_poster
         @collection.poster.mime_type = 'image/png'
         @collection.poster.original_name = poster_file.original_filename


### PR DESCRIPTION
When testing on spruce uploading a poster errored with "invalid byte sequence in UTF-8".  This PR avoids this issue by only checking for nil instead of present.