### PR TITLE
Don't sanitize rights statement link

### DIFF
--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -102,7 +102,8 @@ module MediaObjectsHelper
         return nil unless media_object.rights_statement.present?
         label = ModsDocument::RIGHTS_STATEMENTS[media_object.rights_statement]
         return nil unless label.present?
-        link_to label, media_object.rights_statement, target: '_blank'
+        link = link_to label, media_object.rights_statement, target: '_blank'
+        content_tag(:dt, 'Rights Statement') + content_tag(:dd) { link }
       end
 
       def current_quality stream_info

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -42,7 +42,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= display_metadata('Collection', @media_object.collection.name) %>
   <%= display_metadata('Unit', @media_object.collection.unit) %>
   <%= display_metadata('Language', display_language(@media_object)) %>
-  <%= display_metadata('Rights Statement', display_rights_statement(@media_object)) %>
+  <%= display_rights_statement(@media_object) %>
   <%= display_metadata('Terms of Use', @media_object.terms_of_use) %>
   <%= display_metadata('Physical Description', @media_object.physical_description) %>
   <%= display_metadata('Related Item', display_related_item(@media_object)) %>

--- a/app/views/playlist_items/_current_item.html.erb
+++ b/app/views/playlist_items/_current_item.html.erb
@@ -48,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= display_metadata('Collection', @current_mediaobject.collection.name) %>
   <%= display_metadata('Unit', @current_mediaobject.collection.unit) %>
   <%= display_metadata('Language', display_language(@current_mediaobject)) %>
-  <%= display_metadata('Rights Statement', display_rights_statement(@current_mediaobject)) %>
+  <%= display_rights_statement(@current_mediaobject) %>
   <%= display_metadata('Terms of Use', @current_mediaobject.terms_of_use) %>
   <%= display_metadata('Physical Description', @current_mediaobject.physical_description) %>
   <%= display_metadata('Related Item', display_related_item(@current_mediaobject)) %>

--- a/app/views/playlists/_current_item.html.erb
+++ b/app/views/playlists/_current_item.html.erb
@@ -45,7 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= display_metadata('Collection', @current_mediaobject.collection.name) %>
   <%= display_metadata('Unit', @current_mediaobject.collection.unit) %>
   <%= display_metadata('Language', display_language(@current_mediaobject)) %>
-  <%= display_metadata('Rights Statement', display_rights_statement(@current_mediaobject)) %>
+  <%= display_rights_statement(@current_mediaobject) %>
   <%= display_metadata('Terms of Use', @current_mediaobject.terms_of_use) %>
   <%= display_metadata('Physical Description', @current_mediaobject.physical_description) %>
   <%= display_metadata('Related Item', display_related_item(@current_mediaobject)) %>

--- a/spec/helpers/media_objects_helper_spec.rb
+++ b/spec/helpers/media_objects_helper_spec.rb
@@ -85,7 +85,7 @@ describe MediaObjectsHelper do
     subject { helper.display_rights_statement(media_object) }
 
     it 'links to the rights statement page' do
-      expect(subject).to eq "<a target=\"_blank\" href=\"#{rights_statement_uri}\">#{rights_statement_label}</a>"
+      expect(subject).to eq "<dt>Rights Statement</dt><dd><a target=\"_blank\" href=\"#{rights_statement_uri}\">#{rights_statement_label}</a></dd>"
     end
 
     context 'when rights statement is not set' do


### PR DESCRIPTION
Sanitization in `display_metadata` was stripping the target attribute.  This PR avoids that helper but embedding the html generated from it in `display_rights_statement`.