### PR TITLE
Fix rails highlight in player

### DIFF
--- a/app/assets/stylesheets/mejs4/mediaelement-common-styles.scss
+++ b/app/assets/stylesheets/mejs4/mediaelement-common-styles.scss
@@ -176,17 +176,3 @@ $avalon-primary-color: #84a791;
   -webkit-filter: none;
 }
 
-// Accessibility
-.mejs__button > button:focus, .mejs__overlay-button:focus, .mejs__time-total:focus, .mejs__volume-slider:focus, .mejs__qualities-selector-input:focus {
-  outline: solid 2px yellow;
-}
-
-// Chrome hack from mejs4: prevent outlining buttons on a mouse click
-.mejs__container-keyboard-inactive a,
-.mejs__container-keyboard-inactive a:focus,
-.mejs__container-keyboard-inactive button,
-.mejs__container-keyboard-inactive button:focus,
-.mejs__container-keyboard-inactive [role=slider],
-.mejs__container-keyboard-inactive [role=slider]:focus {
-  outline: 0;
-}

--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -4224,11 +4224,11 @@ var MediaElementPlayer = function () {
 					}
 				});
 
-				t.getElement(t.container).addEventListener('click', function (e) {
+				t.getElement(t.container).addEventListener('mousedown', function (e) {
 					dom.addClass(e.currentTarget, t.options.classPrefix + 'container-keyboard-inactive');
 				});
 
-				t.getElement(t.container).addEventListener('focusin', function (e) {
+				t.getElement(t.container).addEventListener('keydown', function (e) {
 					dom.removeClass(e.currentTarget, t.options.classPrefix + 'container-keyboard-inactive');
 					if (t.isVideo && !_constants.IS_ANDROID && !_constants.IS_IOS && t.controlsEnabled && !t.options.alwaysShowControls) {
 						t.killControlsTimer('enter');

--- a/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
+++ b/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
@@ -124,7 +124,10 @@
                 t.options.classPrefix +
                 'qualities-selector ' +
                 t.options.classPrefix +
-                'offscreen">') +
+                'offscreen"' +
+                'aria-label="' + 
+                qualityTitle +
+                '">') +
               ('<ul class="' +
                 t.options.classPrefix +
                 'qualities-selector-list"></ul>') +
@@ -169,9 +172,9 @@
                   '</li>';
               }
             });
-            var inEvents = ['mouseenter', 'focusin'],
+            var inEvents = ['mouseenter', 'focusin', 'keydown'],
               /* Note this line is customized from original plugin - 2017-12-18 */
-              outEvents = ['mouseleave', 'blur'],
+              outEvents = ['mouseleave', 'blur', 'focusout'],
               radios = player.qualitiesButton.querySelectorAll(
                 'input[type="radio"]'
               ),

--- a/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
+++ b/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
@@ -243,10 +243,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 /* :focus for accessibility */
-.mejs__button > button:focus {
-    outline: dotted 1px #999;
+.mejs__button > button:focus, .mejs__overlay-button:focus, .mejs__time-total:focus, .mejs__volume-slider:focus, .mejs__qualities-selector:focus {
+    outline: solid 2px yellow;
 }
 
+// prevent outlining buttons/time rail on a mouse click
 .mejs__container-keyboard-inactive a,
 .mejs__container-keyboard-inactive a:focus,
 .mejs__container-keyboard-inactive button,


### PR DESCRIPTION
Before: 
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/1331659/65331457-de1e2c80-db8a-11e9-929f-850c6f15647f.gif)

After:
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/1331659/65331951-bf6c6580-db8b-11e9-843a-a5274a5b5302.gif)

Along with the fix for the connected issue, this PR contains a fix for the following issue I came across while working on this.

Description: When navigating only using keyboard the quality selector in the media player does not disappear when the element is out of focus as seen in below;

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/1331659/65329474-8087e100-db86-11e9-9537-e81fec7fb14a.gif)

After the fix:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1331659/65329440-6ea63e00-db86-11e9-8f08-bd213ee17f13.gif)
