### PR TITLE
Use css classes to scope styling of search results

### DIFF
--- a/app/javascript/components/Collection.css
+++ b/app/javascript/components/Collection.css
@@ -6,13 +6,13 @@
   /* min-width: 25rem; */
 }
 
-ul {
+ul.search-within-search-results {
   padding-inline-start: 1rem;
   list-style-type: none;
   padding-left: 0px;
 }
 
-li {
+li.search-within-search-result {
   padding-bottom: 2rem;
 }
 

--- a/app/javascript/components/SearchResults.js
+++ b/app/javascript/components/SearchResults.js
@@ -43,10 +43,10 @@ class SearchResults extends Component {
 
     render() {
         return (
-        <ul>
+        <ul className="search-within-search-results">
             { this.props.documents.map((doc,index) => {
                 return (
-                    <li key={index} className="row">
+                    <li key={index} className="row search-within-search-result">
                         <div className="document-thumbnail col-sm-3">
                             <span className="timestamp badge badge-dark">{this.duration(doc['duration_ssi'])}</span>
                             <a href={this.props.baseUrl + "/media_objects/" + doc['id']}>


### PR DESCRIPTION
This fixes the global nav being oversided on the collection landing page.
Before:

<img width="433" alt="Screen Shot 2019-09-24 at 9 59 56 AM" src="https://user-images.githubusercontent.com/1053603/65518333-25b9f680-deb2-11e9-9cab-c39ba72b039e.png">

After:

<img width="433" alt="Screen Shot 2019-09-24 at 9 59 23 AM" src="https://user-images.githubusercontent.com/1053603/65518314-1d61bb80-deb2-11e9-880b-b5500e732a8f.png">