### PR TITLE
Fix time code update in media player

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -8362,8 +8362,15 @@ function secondsToTimeCode(time) {
 	minutes = minutes <= 0 ? 0 : minutes;
 	seconds = seconds <= 0 ? Number(0).toFixed(secondsDecimalLength) : seconds;
 
-	seconds = seconds === 60 ? 0 : seconds;
-	minutes = minutes === 60 ? 0 : minutes;
+	if(Number(seconds) === 60) {
+		seconds = 0;
+		minutes++;
+	}
+
+	if(minutes === 60) {
+		minutes = 0;
+		hours++;
+	}
 
 	var timeFormatFrags = timeFormat.split(':');
 	var timeFormatSettings = {};


### PR DESCRIPTION
Description: When the timecode updates in the player it goes from 00:59 -> 00:60 -> 01:00. This was fixed in the latest ME.js update in these two lines; [line 3865](https://github.com/avalonmediasystem/avalon/blob/develop/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js#L8365) and [line 3866](https://github.com/avalonmediasystem/avalon/blob/develop/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js#L8366). But this did not work because the `typeof seconds` and `typeof 60` are different, and with `===` operator this check fails.

Before:
![seconds-to-minutes](https://user-images.githubusercontent.com/1331659/65801613-7d24c480-e147-11e9-8f3e-8f7cc2846297.gif)
After fix:
![seconds-to-minutes-after](https://user-images.githubusercontent.com/1331659/65801623-844bd280-e147-11e9-8b85-5115ee192ac1.gif)
