### PR TITLE
Use active_encode master and default to using Ffmpeg adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ jobs:
       parallelism:
         type: integer
         default: 4
-      bundler_version:
-        type: string
-        default: "2.0.1"
 
     working_directory: /home/app/avalon
 
@@ -50,25 +47,11 @@ jobs:
 
       - run: cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 
-      - restore_cache:
-          keys:
-            - gem-cache-v1-{{ checksum "Gemfile.lock" }}-<< parameters.ruby_ver >>
-
-      - run:
-          name: Update bundler
-          command: |
-            echo 'export BUNDLER_VERSION=<< parameters.bundler_version >>' >> $BASH_ENV
-            gem install bundler -v << parameters.bundler_version >>
-
       - run:
           command: |
-            bundle install --with aws development test postgres --without production --path=vendor/bundle --jobs=4 --retry=3
+            unset BUNDLE_APP_CONFIG
+            bundle install --with aws development test postgres --without production --jobs=4 --retry=3
             bundle exec rake db:migrate
-
-      - save_cache:
-          key: gem-cache-v1-{{ checksum "Gemfile.lock" }}-<< parameters.ruby_ver >>
-          paths:
-            - vendor/bundle
 
       - restore_cache:
           keys:

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'omniauth-identity'
 gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'avalon-r4'
 
 # Media Access & Transcoding
-gem 'active_encode', '~> 0.1.1'
+gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git", branch: "master"
 gem 'audio_waveform-ruby', require: 'audio_waveform'
 gem 'browse-everything', '~> 0.13.0'
 gem 'media_element_add_to_playlist', git: 'https://github.com/avalonmediasystem/media-element-add-to-playlist.git', tag: 'avalon-r6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,14 @@ GIT
   specs:
     bootstrap-toggle-rails (2.2.1.0)
 
+GIT
+  remote: https://github.com/samvera-labs/active_encode.git
+  revision: 7c5b8039ba9a85f3a2e445c83b61d3c45455cbf0
+  branch: master
+  specs:
+    active_encode (0.6.0)
+      rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -178,8 +186,6 @@ GEM
     active_elastic_job (2.0.1)
       aws-sdk (~> 2)
       rails (>= 4.2)
-    active_encode (0.1.1)
-      activesupport
     active_fedora-datastreams (0.2.0)
       active-fedora (>= 11.0.0.pre, < 13)
       nom-xml (>= 0.5.1)
@@ -947,7 +953,7 @@ DEPENDENCIES
   active-fedora (~> 12.1)
   active_annotations (~> 0.2.2)
   active_elastic_job (~> 2.0)
-  active_encode (~> 0.1.1)
+  active_encode!
   active_fedora-datastreams (~> 0.2.0)
   activejob-traffic_control
   activerecord-session_store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,14 +58,6 @@ services:
     volumes:
       - ./solr/config:/opt/solr/avalon_conf
 
-  matterhorn:
-    image: avalonmediasystem/matterhorn
-    volumes:
-      - ./masterfiles:/masterfiles
-      - streaming:/streamfiles
-      - work:/work
-    networks:
-      internal:
   hls:
     image: avalonmediasystem/nginx
     environment:
@@ -93,7 +85,7 @@ services:
       - fedora
       - solr
       - redis
-      - matterhorn
+      - hls
     environment:
       - APP_NAME=avalon
       - AVALON_BRANCH=develop
@@ -106,14 +98,13 @@ services:
       - EMAIL_COMMENTS
       - EMAIL_NOTIFICATION
       - EMAIL_SUPPORT
+      - ENCODE_WORK_DIR=/streamfiles
       - FEDORA_BASE_PATH
       - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
       - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - MASTER_FILE_PATH
       - MASTER_FILE_STRATEGY=delete
-      - MATTERHORN_URL=http://matterhorn_system_account:CHANGE_ME@matterhorn:8080/
-      - SETTINGS__MATTERHORN__MEDIA_PATH=/masterfiles
       - MEDIAINFO_PATH=/usr/bin/mediainfo
       - RAILS_ENV=development
       - SETTINGS__REDIS__HOST=redis
@@ -141,6 +132,7 @@ services:
     volumes:
       - .:/home/app/avalon
       - ./masterfiles:/masterfiles
+      - streaming:/streamfiles
       - npms:/home/app/avalon/node_modules
     ports:
       - '3000:3000'

--- a/spec/factories/encode.rb
+++ b/spec/factories/encode.rb
@@ -1,0 +1,58 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+FactoryBot.define do
+  factory :encode, class: ActiveEncode::Base do
+    id { SecureRandom.uuid }
+    errors {}
+    state { :running }
+    percent_complete { 0 }
+    current_operations { ['Queued'] }
+
+    initialize_with { new('file://path/to/input.mp4') }
+
+    trait :in_progress do
+      state { :running }
+      percent_complete { 50.5 }
+      current_operations { ['encoding'] }
+    end
+      
+    trait :succeeded do
+      state { :completed }
+      percent_complete { 100 }
+      current_operations { ['DONE'] }
+      output { [ FactoryBot.build(:encode_output) ] }
+    end
+
+    trait :failed do
+      state { :failed }
+      percent_complete { 50.5 }
+      current_operations { ['FAILED'] }
+      errors { ['Out of disk space.'] }
+    end
+  end
+
+  factory :encode_output, class: ActiveEncode::Output do
+    id { SecureRandom.uuid }
+    label { 'quality-high' }
+    url { 'file://path/to/output.mp4' }
+    duration { '21575' }
+    audio_bitrate { '163842.0' }
+    audio_codec { 'AAC' }
+    video_bitrate { '4000000.0' }
+    video_codec { 'AVC' }
+    width { '1024' }
+    height { '768' }
+  end
+end

--- a/spec/models/derivative_spec.rb
+++ b/spec/models/derivative_spec.rb
@@ -17,51 +17,37 @@ require 'rails_helper'
 describe Derivative do
 
   describe "#from_output" do
-    let!(:api_output){[{ label: 'quality-high',
-                    id: 'track-1',
-                    url: 'rtmp://www.test.com/test.mp4',
-                    hls_url: 'http://www.test.com/test.mp4.m3u8',
-                    duration: "6315",
-                    mime_type:  "video/mp4",
-                    audio_bitrate: "127716.0",
-                    audio_codec: "AAC",
-                    video_bitrate: "1000000.0",
-                    video_codec: "AVC",
-                    width: "640",
-                    height: "480" }]}
+    let(:api_output) do
+      { 
+        id: 'track-1',
+        label: 'quality-high',
+        url: 'http://www.test.com/test.mp4.m3u8',
+        duration: "6315",
+        mime_type:  "video/mp4",
+        audio_bitrate: "127716.0",
+        audio_codec: "AAC",
+        video_bitrate: "1000000.0",
+        video_codec: "AVC",
+        width: "640",
+        height: "480"
+      }
+    end
+    let(:derivative) { described_class.from_output(api_output, false) }
+                  
     it "Call from ingest API should populate :url and :hls_url" do
-      d = Derivative.from_output(api_output,false)
-      expect(d.location_url).to eq('rtmp://www.test.com/test.mp4')
-      expect(d.hls_url).to eq('http://www.test.com/test.mp4.m3u8')
+      expect(derivative.location_url).to eq('http://www.test.com/test.mp4.m3u8')
     end
   end
 
   describe "#destroy" do
-    let(:derivative) {FactoryBot.create(:derivative)}
+    let(:derivative) { FactoryBot.create(:derivative) }
     let(:master_file) { double }
     before do
       allow(derivative).to receive(:master_file).and_return(master_file)
-      allow(master_file).to receive(:encoder_class).and_return(ActiveEncode::Base)
-      allow(master_file).to receive(:workflow_id).and_return(Faker::Number.digit)
     end
 
-    it "should delete and retract files" do
-      encode = ActiveEncode::Base.new(nil)
-      expect(ActiveEncode::Base).to receive(:find).and_return(encode)
-      expect(encode).to receive(:remove_output!).twice.and_return({})
-      expect{derivative.destroy}.to change{Derivative.count}.by(-1)
-    end
-
-    it "should not throw error when encode doesn't exist anymore" do
-      expect(ActiveEncode::Base).to receive(:find).and_return nil
-      expect{derivative.destroy}.to change{Derivative.count}.by(-1)
-    end
-
-    it "should delete even if retraction fails" do
-      encode = ActiveEncode::Base.new(nil)
-      expect(ActiveEncode::Base).to receive(:find).and_return(encode)
-      expect(encode).to receive(:remove_output!).and_raise StandardError
-      expect{derivative.destroy}.to change{Derivative.count}.by(-1)
+    it "should delete" do
+      expect { derivative.destroy }.to change { Derivative.count }.by(-1)
     end
   end
 


### PR DESCRIPTION
Configure Ffmpeg adapter to use streaming server directory.
With this Avalon no longer attempts to delete derivative files when the Derivative object is destroyed.
Future work includes making the ffmpeg profiles configurable (and the other stories in the backlog).

After this is merged, we'll need to reconfigure Spruce slightly and test there then we can close #3574.