### PR TITLE
Fix check for collection poster

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -162,7 +162,7 @@ class Admin::Collection < ActiveFedora::Base
   def to_solr
     super.tap do |solr_doc|
       solr_doc["name_uniq_si"] = self.name.downcase.gsub(/\s+/,'') if self.name.present?
-      solr_doc["has_poster_bsi"] = !self.poster.content.nil?
+      solr_doc["has_poster_bsi"] = !(poster.content.nil? || poster.content == '')
     end
   end
 


### PR DESCRIPTION
Poster content will be empty string after removing poster (setting to nil doesn't save). Using blank? to check fails in certain circumstances.

Fixes #3628 