### PR TITLE
Add root level config to player for duration

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -502,6 +502,11 @@ class MEJSPlayer {
       startLanguage: this.localStorage.getItem('captions') || ''
     };
 
+    // Add duration as a root level config for Android devices
+    if(mejs.Features.isAndroid) {
+      defaults.duration = currentStreamInfo.duration
+    }
+
     if (this.currentStreamInfo.cookie_auth) {
       defaults.hls = {
         xhrSetup: (xhr, url) => {


### PR DESCRIPTION
When the `loadedmetadata` event is fired for the mediaelement.js instance in Android, the player's duration is not updated. Therefore the player shows `0:00` as the end time.

Fix: add `duration` as a root level config for Android devices, which updates player's duration when the `loadedmetadata` event is fired.