### PR TITLE
Fix quality selectore restarting playback at start

### DIFF
--- a/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
+++ b/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
@@ -279,10 +279,12 @@
                   'canplay',
                   function canPlayAfterSourceSwitchHandler() {
                     media.setCurrentTime(currentTime);
-                    media.removeEventListener(
-                      'canplay',
-                      canPlayAfterSourceSwitchHandler
-                    );
+                    if(media.currentTime === currentTime) {
+                      media.removeEventListener(
+                        'canplay',
+                        canPlayAfterSourceSwitchHandler
+                      );
+                    }
                   }
                 );
               });


### PR DESCRIPTION
When playing the media after quality selection, the event that contains setting the currenttime taken from previous playhead position is removed before the action is completed

Fix: conditionally remove the event when the current time of media is equal to the playhead time before updating quality