### PR TITLE
Fix ingest API handling of certain failures.

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -244,7 +244,6 @@ class MediaObjectsController < ApplicationController
             message = "Problem saving MasterFile for #{file_location}:"
             error_messages += [message]
             error_messages += master_file.errors.full_messages
-            @media_object.destroy
             break
           end
         end
@@ -267,7 +266,6 @@ class MediaObjectsController < ApplicationController
         @media_object.workflow.last_completed_step = HYDRANT_STEPS.last.step
         if !@media_object.save
           error_messages += ['Failed to create media object:']+@media_object.errors.full_messages
-          @media_object.destroy
         else
           if !!api_params[:publish]
             @media_object.publish!('REST API')
@@ -283,7 +281,7 @@ class MediaObjectsController < ApplicationController
     else
       logger.warn "update_media_object failed for #{params[:fields][:title] rescue '<unknown>'}: #{error_messages}"
       render json: {errors: error_messages}, status: 422
-      @media_object.destroy
+      @media_object.destroy unless action_name == 'json_update'
     end
   end
 


### PR DESCRIPTION
Fix API handling of errors. Looks like a previous refactor might have not been completely finished.
Before, if master files were invalid, the code would try to destroy the related media_object twice, which failed. This failure generated an extra render, which obfuscated any meaningful error messages returned.

Also, this PR changes the behavior of API updates. Before, if the api attempted and failed to update an existing media_object, the media_object would be destroyed. Now it will not update the record and will return errors, leaving the original media_object intact.