### PR TITLE
Update encoding profiles

### DIFF
--- a/config/ffmpeg_presets.yml
+++ b/config/ffmpeg_presets.yml
@@ -2,17 +2,17 @@
 fullaudio:
   - :label: 'high'
     :extension: 'mp4'
-    :ffmpeg_opt: "-ac 2 -ab 192k -ar 44100 -acodec aac"
+    :ffmpeg_opt: "-ac 2 -ar 44100 -ab 320k -vn -acodec aac -strict -2"
   - :label: 'medium'
     :extension: 'mp4'
-    :ffmpeg_opt: "-ac 2 -ab 128k -ar 44100 -acodec aac"
+    :ffmpeg_opt: "-ac 2 -ar 44100 -ab 128k -vn -acodec aac -strict -2"
 avalon:
   - :label: 'high'
     :extension: 'mp4'
-    :ffmpeg_opt: "-s 1920x1080 -g 30 -b:v 800k -ac 2 -ab 192k -ar 44100 -vcodec libx264 -acodec aac"
+    :ffmpeg_opt: '-vf "yadif=0:-1:1,scale=trunc(oh*dar/2)*2:min(ih\\,1080)" -vcodec libx264 -preset fast -profile main -level 3.1 -b 3M -maxrate 3M -bufsize 4M -threads 0 -r 30 -force_key_frames "expr:gte(t,n_forced*2)" -pix_fmt yuv420p -acodec aac -ab 192k -ar 44100 -movflags faststart -strict -2'
   - :label: 'medium'
     :extension: 'mp4'
-    :ffmpeg_opt: "-s 1280x720 -g 30 -b:v 500k -ac 2 -ab 128k -ar 44100 -vcodec libx264 -acodec aac"
+    :ffmpeg_opt: '-vf "yadif=0:-1:1,scale=trunc(oh*dar/2)*2:min(ih\\,720)" -vcodec libx264 -preset fast -profile main -level 3.1 -b 1.5M -maxrate 1.5M -bufsize 2M -threads 0 -r 30 -force_key_frames "expr:gte(t,n_forced*2)" -pix_fmt yuv420p -acodec aac -ab 128k -ar 44100 -movflags faststart -strict -2'
   - :label: 'low'
     :extension: 'mp4'
-    :ffmpeg_opt: "-s 720x360 -g 30 -b:v 300k -ac 2 -ab 96k -ar 44100 -vcodec libx264 -acodec aac"
+    :ffmpeg_opt: '-vf "yadif=0:-1:1,scale=trunc(oh*dar/2)*2:min(ih\\,480)" -vcodec libx264 -preset fast -profile:v baseline -level 3.0 -b:v 500k -maxrate 500k -bufsize 1M -bf 0 -threads 0 -r 30 -force_key_frames "expr:gte(t,n_forced*2)" -pix_fmt yuv420p -acodec aac -ab 128k -ar 44100 -movflags faststart -strict -2'


### PR DESCRIPTION
Update ffmpeg_presets.yml to reflect the current Avalon encoding profiles, with some minor adjustments:
- ffmpeg parameters string escaped with single quote and double quotes added for proper parsing
- certain flags made explicit "-b:v instead of -b"
- bitrate increased for high quality setting