### PR TITLE
Avoid hard-coding names of visibility permission groups

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -210,7 +210,7 @@ class Admin::Collection < ActiveFedora::Base
   end
 
   def default_virtual_read_groups
-    self.default_read_groups.to_a - ["public", "registered"] - default_local_read_groups - default_ip_read_groups
+    self.default_read_groups.to_a - represented_default_visibility - default_local_read_groups - default_ip_read_groups
   end
 
   def default_visibility=(value)

--- a/app/models/concerns/virtual_groups.rb
+++ b/app/models/concerns/virtual_groups.rb
@@ -26,7 +26,7 @@
       end
 
       def virtual_read_groups
-        self.read_groups - ["public", "registered"] - local_read_groups - ip_read_groups
+        self.read_groups - represented_visibility - local_read_groups - ip_read_groups
       end
     end
 #   end


### PR DESCRIPTION
This allows an implementor to configure these group names using `Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED` and `Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC` as designed.