### PR TITLE
Run active encode create in a background job

### DIFF
--- a/app/jobs/create_encode_job.rb
+++ b/app/jobs/create_encode_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class CreateEncodeJob < ActiveJob::Base
+  def perform(input, master_file_id)
+    return unless MasterFile.exists? master_file_id
+    master_file = MasterFile.find(master_file_id)
+    return if master_file.workflow_id.present?
+    master_file.encoder_class.create(input, master_file_id: master_file_id, preset: master_file.workflow_name)
+  end
+end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -290,7 +290,7 @@ class MasterFile < ActiveFedora::Base
       end
     end
 
-    encoder_class.create(input, master_file_id: id, preset: workflow_name)
+    CreateEncodeJob.perform_later(input, id)
   end
 
   def finished_processing?

--- a/spec/integration/working_file_path_spec.rb
+++ b/spec/integration/working_file_path_spec.rb
@@ -34,6 +34,8 @@ require 'rails_helper'
 # spec/lib/avalon/batch/entry_spec.rb:80
 #
 describe "MasterFile#working_file_path" do
+  include ActiveJob::TestHelper
+
   let(:master_file) { FactoryBot.build(:master_file) }
   let(:media_object) { FactoryBot.create(:media_object) }
   let(:workflow) { 'avalon' }
@@ -41,6 +43,10 @@ describe "MasterFile#working_file_path" do
 
   before do
     allow(encoder_class).to receive(:create)
+  end
+
+  around(:example) do |example|
+    perform_enqueued_jobs(only: CreateEncodeJob) { example.run }
   end
 
   context "with Settings.encoding.working_file_path set" do

--- a/spec/jobs/create_encode_job_spec.rb
+++ b/spec/jobs/create_encode_job_spec.rb
@@ -1,0 +1,44 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe CreateEncodeJob do
+  let(:master_file) { FactoryBot.create(:master_file, workflow_id: nil, encoder_class: encoder_class ) }
+  let(:encoder_class) { FfmpegEncode }
+  let(:input) { "file://path/to/file" }
+
+  describe "perform" do
+    it 'creates the active_encode job' do
+      expect(encoder_class).to receive(:create).with(input, master_file_id: master_file.id, preset: master_file.workflow_name).once
+      CreateEncodeJob.perform_now(input, master_file.id)
+    end
+
+    context 'when master file does not exist' do
+      it 'does not create the active_encode_job' do
+        expect(encoder_class).not_to receive(:create)
+        CreateEncodeJob.perform_now(input, 'bad-id')
+      end
+    end
+
+    context 'when master file has already been processed' do
+      let(:master_file) { FactoryBot.create(:master_file, workflow_id: '12345', encoder_class: encoder_class ) }
+
+      it 'does not create the active_encode_job' do
+        expect(encoder_class).not_to receive(:create)
+        CreateEncodeJob.perform_now(input, master_file.id)
+      end
+    end
+  end
+end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -15,6 +15,7 @@
 require 'rails_helper'
 
 describe MasterFile do
+  include ActiveJob::TestHelper
 
   describe "validations" do
     subject { MasterFile.new }
@@ -113,6 +114,10 @@ describe MasterFile do
 
   describe '#process' do
     let(:master_file) { FactoryBot.create(:master_file, :not_processing) }
+
+    around(:example) do |example|
+      perform_enqueued_jobs { example.run }
+    end
 
     it 'creates an encode' do
       expect(master_file.encoder_class).to receive(:create).with("file://" + URI.escape(master_file.file_location), { master_file_id: master_file.id, preset: master_file.workflow_name })


### PR DESCRIPTION
The FfmpegAdapter spawns the ffmpeg process as part of the encode create.  In order to run the FfmpegAdapter on a separate machine or container than avalon the create call needs to be run in a background job.