### PR TITLE
Clean up some CSS / Sass structure for more clear UI customization

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -15,9 +15,7 @@
 */
 
 @import 'branding';
-@import 'bootstrap/variables';
 @import 'avalon/mixins';
-
 @import 'avalon/accordions';
 @import 'avalon/buttons';
 @import 'avalon/facets';
@@ -39,6 +37,11 @@ body {
 
 main {
   padding-bottom: 20px;
+}
+
+h1,
+h2 {
+  font-family: $museoSlab;
 }
 
 tr.active-false td {
@@ -99,13 +102,16 @@ input[type='text']#admin_group {
 /* Headlines / page titles */
 .page-title {
   font-size: 32px;
+  font-family: $museoSlab;
 }
 .headline {
   color: $primaryDark;
   font-size: 29.3px;
+  font-family: $museoSlab;
 }
 .sub-headline {
   color: $primary;
+  font-family: $museoSlab;
 }
 
 .mobile-hidden {

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -18,28 +18,16 @@
  * Custom branding for Avalon to override Bootstrap, Hydra, and Blacklight
  * defaults. This should be included at the top of the application.scss file
  * so it is preferred over the defaults. */
+
+/**
+  Custom variables (Non-bootstrap)
+*/
 @font-face {
   font-family: 'MuseoSlab';
   src: url('fonts/Museo_Slab_500-webfont.woff') format('woff');
 }
 $sansFontFamily: Arial, Helvetica, sans-serif;
 $museoSlab: 'MuseoSlab';
-
-/**
- * If you want to override the default color scheme do so here
- *
- * Bootstrap provides settings for
- * blue
- * red
- * green
- * yellow
- * orange
- * pink
- * purple
- * white
- * black
- * gray
- */
 
 // Primary colors
 $primary: #80a590;
@@ -51,7 +39,8 @@ $yellow: #ffcf08;
 $orange: #fbb040;
 $white: rgb(255, 255, 255);
 
-// Generated palate colors from http://colormind.io/
+// Generated palate colors from http://colormind.io/ for Avalon style guide
+// Add new HEX values below to match your organization's flavor of info/success/warning/danger
 $info: #fbb040;
 $success: #429453;
 $warning: #bf841b;
@@ -64,7 +53,13 @@ $lightgray: #f2f2f2;
 $red: #d9534f;
 $blue: #2a4d59;
 
-/* Bootstrap branding colors */
+/**
+  * Bootstrap variable overrides
+  *
+  * A full list of supported overrides can be found at:
+  * https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss */
+
+/* Branding colors */
 $brand-primary: $primaryDark;
 $brand-success: $success;
 $brand-info: $info;
@@ -77,10 +72,9 @@ $font-family-serif: $museoSlab;
 
 /* Components */
 $padding-base-vertical: 4px;
-//$padding-base-horizontal: 1.5rem;
 
 /* Headings */
-$headings-font-family: $museoSlab;
+// $headings-font-family: $museoSlab;
 
 /* Links */
 $link-color: $primaryDark;
@@ -135,7 +129,6 @@ $grid-gutter-width: 16px;
 
 /* Buttons */
 $btn-border-radius-base: 2px;
-
 $btn-default-color: $dark;
 $btn-default-bg: $white;
 $btn-default-border: $gray;
@@ -150,6 +143,7 @@ $btn-info-bg: $info;
 $btn-info-border: $info;
 $btn-danger-color: $white;
 
+/* Pagination */
 $pagination-color: $link-color;
 $pagination-bg: $white;
 $pagination-border: $gray;

--- a/app/views/admin/collections/index.html.erb
+++ b/app/views/admin/collections/index.html.erb
@@ -56,7 +56,7 @@ Unless required by applicable law or agreed to in writing, software distributed
               aria-expanded="false">
               Action <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu dropdown-menu-right">
               <li><a href="#">View</a></li>
               <li><a href="#">Edit</a></li>
               <li><%= link_to('Delete', remove_admin_collection_path(collection.id)) %></li>

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -14,48 +14,48 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if can? :update, @media_object %>
-  <div class="row-fluid">
-      <p>
-        <ul class="unstyled hidden">
-          <li>
-            <% if @media_object.published? %>
-              <span class="label label-success">Published</span> Authorized users can view the item</li>
-            <% else %>
-              <span class="label label-important">Unpublished</span> Users cannot view the item</li>
-            <% end %>
-          <li>
-            <% unless @media_object.discover_groups.include? "nobody" %>
-              <span class="label label-success">Visible</span> Users can search for the item</li>
-            <% else %>
-              <span class="label label-important">Hidden</span> Users cannot search for the item</li>
-            <% end %>
-        </ul>
-      </p>
-
-      <div id="administrative_options" style="margin-bottom:1em;">
-
-      <% if @media_object.published? %>
-        <% if can?(:unpublish, @media_object) %>
-          <%= link_to 'Unpublish', update_status_media_object_path(@media_object, status:'unpublish'), method: :put, class: 'btn btn-default' %>
-        <% end %>
+<div class="row-fluid">
+  <p>
+    <ul class="unstyled hidden">
+      <li>
+        <% if @media_object.published? %>
+        <span class="label label-success">Published</span> Authorized users can view the item</li>
       <% else %>
-        <%= link_to 'Publish', update_status_media_object_path(@media_object, status:'publish'), method: :put, class: 'btn btn-default' %>
+      <span class="label label-important">Unpublished</span> Users cannot view the item</li>
       <% end %>
+      <li>
+        <% unless @media_object.discover_groups.include? "nobody" %>
+        <span class="label label-success">Visible</span> Users can search for the item</li>
+      <% else %>
+      <span class="label label-important">Hidden</span> Users cannot search for the item</li>
+      <% end %>
+    </ul>
+  </p>
 
+  <div id="administrative_options" style="margin-bottom:1em;">
 
-        <%= link_to 'Edit', edit_media_object_path(@media_object), class: 'btn btn-default' %>
-        <%# This might not be the best approach because it makes accidental
+    <%= link_to 'Edit', edit_media_object_path(@media_object), class: 'btn btn-primary' %>
+
+    <% if @media_object.published? %>
+    <% if can?(:unpublish, @media_object) %>
+    <%= link_to 'Unpublish', update_status_media_object_path(@media_object, status:'unpublish'), method: :put, class: 'btn btn-default' %>
+    <% end %>
+    <% else %>
+    <%= link_to 'Publish', update_status_media_object_path(@media_object, status:'publish'), method: :put, class: 'btn btn-default' %>
+    <% end %>
+
+    <%# This might not be the best approach because it makes accidental
             deletion possible just by following a link. Need to revisit when
             extra cycles are available %>
 
-        <% if can? :destroy, @media_object %>
-          <%= link_to 'Delete', confirm_remove_media_object_path(@media_object), class: 'btn btn-danger' %>
-        <% end %>
+    <% if can? :destroy, @media_object %>
+    <%= link_to 'Delete', confirm_remove_media_object_path(@media_object), class: 'btn btn-link' %>
+    <% end %>
 
-        <% if Settings.intercom.present? and can? :intercom_push, @media_object %>
-          <%= button_tag(Settings.intercom['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
-          <%= render "intercom_push_modal" %>
-        <% end %>
-      </div>
+    <% if Settings.intercom.present? and can? :intercom_push, @media_object %>
+    <%= button_tag(Settings.intercom['default']['push_label'], class: 'btn btn-default', data: {toggle:"modal", target:"#intercom_push"}) %>
+    <%= render "intercom_push_modal" %>
+    <% end %>
   </div>
+</div>
 <% end %>


### PR DESCRIPTION
This isn't too big a change, but cleaned up some code in the `branding` and `avalon` Sass pages.  I also took away "MuseoSlab" as the default font for all headings, and just applied to `h1` and `h2`s.

I'm writing some documentation in the Wiki, on where to point people interested in customizing the UI against Avalon/Bootstrap.

https://github.com/avalonmediasystem/avalon/wiki/Customizing-the-UI