### PR TITLE
API logins get same abilities as UI logins for all users.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,7 +36,7 @@ class Ability
   end
 
   def create_permissions(user=nil, session=nil)
-    if full_login?
+    if full_login? || is_api_request?
       if is_administrator?
         can :manage, :all
       end
@@ -59,7 +59,7 @@ class Ability
 
   def custom_permissions(user=nil, session=nil)
 
-    unless full_login? and is_administrator?
+    unless (full_login? || is_api_request?) and is_administrator?
       cannot :read, MediaObject do |media_object|
         !(test_read(media_object.id) && media_object.published?) && !test_edit(media_object.id)
       end
@@ -72,9 +72,9 @@ class Ability
         can? :read, derivative.masterfile.media_object
       end
 
-      cannot :read, Admin::Collection unless full_login?
+      cannot :read, Admin::Collection unless (full_login? || is_api_request?)
 
-      if full_login?
+      if full_login? || is_api_request?
         can :read, Admin::Collection do |collection|
           is_member_of?(collection)
         end
@@ -132,25 +132,25 @@ class Ability
         can :share, MediaObject
       end
 
-      if is_api_request?
-        can :manage, MediaObject
-        can :manage, Admin::Collection
-        can :manage, Avalon::ControlledVocabulary
-      end
+      # if is_api_request?
+      #   can :manage, MediaObject
+      #   can :manage, Admin::Collection
+      #   can :manage, Avalon::ControlledVocabulary
+      # end
 
       cannot :update, MediaObject do |media_object|
-        (not full_login?) || (!is_member_of?(media_object.collection)) ||
+        (not (full_login? || is_api_request?)) || (!is_member_of?(media_object.collection)) ||
           ( media_object.published? && !@user.in?(media_object.collection.managers) )
       end
 
       cannot :destroy, MediaObject do |media_object|
         # non-managers can only destroy media_object if it's unpublished
-        (not full_login?) || (!is_member_of?(media_object.collection)) ||
+        (not (full_login? || is_api_request?)) || (!is_member_of?(media_object.collection)) ||
           ( media_object.published? && !@user.in?(media_object.collection.managers) )
       end
 
       cannot :destroy, Admin::Collection do |collection, other_user_collections=[]|
-        (not full_login?) || !@user.in?(collection.managers)
+        (not (full_login? || is_api_request?)) || !@user.in?(collection.managers)
       end
 
       can :intercom_push, MediaObject do |media_object|

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -252,10 +252,11 @@ describe CatalogController do
     describe "atom feed" do
       let!(:private_media_object) { FactoryBot.create(:media_object, visibility: 'private') }
       let!(:public_media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+      let(:administrator) { FactoryBot.create(:administrator) }
 
       context "with an api key" do
         before do
-          ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+          ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
         end
         it "should show results for all items" do
           request.headers['Avalon-Api-Key'] = 'secret_token'

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -274,10 +274,12 @@ describe MediaObjectsController, type: :controller do
 
     describe "#create" do
       context 'using api' do
-        before do
-           ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
-           request.headers['Avalon-Api-Key'] = 'secret_token'
-           allow_any_instance_of(MasterFile).to receive(:get_ffmpeg_frame_data).and_return('some data')
+        let(:administrator) { FactoryBot.create(:administrator) }
+
+        before(:each) do
+          ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
+          request.headers['Avalon-Api-Key'] = 'secret_token'
+          allow_any_instance_of(MasterFile).to receive(:get_ffmpeg_frame_data).and_return('some data')
         end
         it "should respond with 422 if collection not found" do
           post 'create', params: { format: 'json', collection_id: "doesnt_exist" }
@@ -436,8 +438,10 @@ describe MediaObjectsController, type: :controller do
     end
     describe "#update" do
       context 'using api' do
-        before do
-          ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        let(:administrator) { FactoryBot.create(:administrator) }
+
+        before(:each) do
+          ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
           request.headers['Avalon-Api-Key'] = 'secret_token'
           allow_any_instance_of(MasterFile).to receive(:get_ffmpeg_frame_data).and_return('some data')
         end
@@ -623,12 +627,14 @@ describe MediaObjectsController, type: :controller do
   describe "#index" do
     let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
     subject(:json) { JSON.parse(response.body) }
-    before do
-      ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+    let(:administrator) { FactoryBot.create(:administrator) }
+
+    before(:each) do
+      ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
+      request.headers['Avalon-Api-Key'] = 'secret_token'
     end
 
     it "should return list of media_objects" do
-      request.headers['Avalon-Api-Key'] = 'secret_token'
       get 'index', format:'json'
       expect(json.count).to eq(1)
       expect(json.first['id']).to eq(media_object.id)
@@ -644,10 +650,11 @@ describe MediaObjectsController, type: :controller do
 
   describe 'pagination' do
       let(:collection) { FactoryBot.create(:collection) }
+      let(:administrator) { FactoryBot.create(:administrator) }
       subject(:json) { JSON.parse(response.body) }
       before do
         5.times { FactoryBot.create(:published_media_object, visibility: 'public', collection: collection) }
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
         request.headers['Avalon-Api-Key'] = 'secret_token'
         get 'index', params: { format:'json', per_page: '2' }
       end
@@ -873,9 +880,10 @@ describe MediaObjectsController, type: :controller do
     context "with json format" do
       subject(:json) { JSON.parse(response.body) }
       let!(:media_object) { FactoryBot.create(:media_object) }
+      let(:administrator) { FactoryBot.create(:administrator) }
 
       before do
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+        ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
         request.headers['Avalon-Api-Key'] = 'secret_token'
       end
 

--- a/spec/controllers/vocabulary_controller_spec.rb
+++ b/spec/controllers/vocabulary_controller_spec.rb
@@ -27,8 +27,10 @@ describe VocabularyController, type: :controller do
     Avalon::ControlledVocabulary.class_variable_set :@@path, Rails.root.join(Settings.controlled_vocabulary.path)
   }
 
+  let(:administrator) { FactoryBot.create(:administrator) }
+
   before(:each) do
-    ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+    ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
     request.headers['Avalon-Api-Key'] = 'secret_token'
   end
 


### PR DESCRIPTION
In support of local work where a power user is requesting api access to push structural metadata.