### PR TITLE
Maintain whitespace when displaying metadata on item show page.

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -219,7 +219,7 @@ span.constraints-label {
     word-wrap: normal;
     word-break: normal;
     overflow-wrap: normal;
-    white-space: inherit;
+    white-space: pre-wrap;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,10 +98,10 @@ module ApplicationHelper
     return if sanitized_values.empty? and default.nil?
     sanitized_values = Array(default) if sanitized_values.empty?
     label = label.pluralize(sanitized_values.size)
-    result = content_tag(:dt, label) +
-    content_tag(:dd) {
-      safe_join(sanitized_values,'; ')
-    }
+    contents = content_tag(:dd) do
+      content_tag(:pre) { safe_join(sanitized_values, '; ') }
+    end
+    content_tag(:dt, label) + contents
   end
 
   def search_result_label item

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -80,7 +80,7 @@ module MediaObjectsHelper
           notes = note_type == 'table of contents'? media_object.table_of_contents : gather_notes_of_type(media_object, note_type)
           notes.each_with_index do |note, i|
             note_string += "<p class='item_note_header'>#{note_types[note_type]}</p>" if i==0 and note_type!='general'
-            note_string += simple_format(note, class:'item_note')
+            note_string += "<pre>#{note}</pre>"
           end
         end
         note_string

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -155,11 +155,11 @@ describe ApplicationHelper do
     end
 
     it "should return a pluralized label and semicolon-separated string for multiple values" do
-      expect(helper.display_metadata("Label", ["Value1", "Value2"])).to eq("<dt>Labels</dt><dd>Value1; Value2</dd>")
+      expect(helper.display_metadata("Label", ["Value1", "Value2"])).to eq("<dt>Labels</dt><dd><pre>Value1; Value2</pre></dd>")
     end
 
     it "should return a default value if provided" do
-      expect(helper.display_metadata("Label", [""], "Default value")).to eq("<dt>Label</dt><dd>Default value</dd>")
+      expect(helper.display_metadata("Label", [""], "Default value")).to eq("<dt>Label</dt><dd><pre>Default value</pre></dd>")
     end
   end
 


### PR DESCRIPTION
Fixes #3643 
