### PR TITLE
Make 'Manage Content' in main nav-bar, keyboard accessible

### DIFF
--- a/app/assets/javascripts/avalon.js
+++ b/app/assets/javascripts/avalon.js
@@ -107,31 +107,19 @@ $(document).ready(function() {
 
   /* Handle dropdown list for `Manage` in nav-bar */
   // Manage user access with mouse-point
-  $('#manageDropdown').hover(
+  $('#manage-dropdown').hover(
     function() {
-      $('#manageDropdown').addClass('open');
+      $(this).addClass('open');
       $(this).attr('aria-expanded', 'true');
     },
     function() {
-      $('#manageDropdown').removeClass('open');
+      $(this).removeClass('open');
       $(this).attr('aria-expanded', 'false');
     }
   );
 
-  // Manage user access with keyboard navigation
-  $('#manageDropdown').focus(function() {
-    if ($(this).hasClass('has-submenu') && !$(this).hasClass('open')) {
-      $(this).addClass('open');
-      $(this).attr('aria-expanded', 'true');
-    } else {
-      $(this).removeClass('open');
-      $(this).attr('aria-expanded', 'false');
-    }
-    event.preventDefault();
-  });
-
   // Close dropdown when Tab key is used with Shift key
-  $('#manageDropdown').keydown(function(e) {
+  $('#manage-dropdown').keydown(function(e) {
     if (e.which == 9 && e.shiftKey) {
       $(this).removeClass('open');
       $(this).attr('aria-expanded', 'false');
@@ -139,10 +127,10 @@ $(document).ready(function() {
   });
 
   // Close dropdown if Tab key is pressed when focused on last element
-  $('#manageDropdown ul > li:last-child').keydown(function(e) {
+  $('#manage-dropdown ul > li:last-child').keydown(function(e) {
     if (e.which == 9) {
-      $('#manageDropdown').removeClass('open');
-      $('#manageDropdown').attr('aria-expanded', 'false');
+      $('#manage-dropdown').removeClass('open');
+      $('#manage-dropdown').attr('aria-expanded', 'false');
     }
   });
 });

--- a/app/assets/javascripts/avalon.js
+++ b/app/assets/javascripts/avalon.js
@@ -80,15 +80,6 @@ $(document).ready(function() {
   // Set CSS to push the page content above footer
   $('.content-wrapper').css('padding-bottom', $('#footer').css('height'));
 
-  $('#manageDropdown').hover(
-    function() {
-      $('#manageDropdown').addClass('open');
-    },
-    function() {
-      $('#manageDropdown').removeClass('open');
-    }
-  );
-
   /* Toggle CSS classes for global search form */
   const $searchWrapper = $('.global-search-wrapper');
   const $searchSubmit = $('.global-search-submit');
@@ -111,6 +102,47 @@ $(document).ready(function() {
     } else {
       $searchWrapper.addClass('input-group-lg');
       $searchSubmit.addClass('btn-primary');
+    }
+  });
+
+  /* Handle dropdown list for `Manage` in nav-bar */
+  // Manage user access with mouse-point
+  $('#manageDropdown').hover(
+    function() {
+      $('#manageDropdown').addClass('open');
+      $(this).attr('aria-expanded', 'true');
+    },
+    function() {
+      $('#manageDropdown').removeClass('open');
+      $(this).attr('aria-expanded', 'false');
+    }
+  );
+
+  // Manage user access with keyboard navigation
+  $('#manageDropdown').focus(function() {
+    if ($(this).hasClass('has-submenu') && !$(this).hasClass('open')) {
+      $(this).addClass('open');
+      $(this).attr('aria-expanded', 'true');
+    } else {
+      $(this).removeClass('open');
+      $(this).attr('aria-expanded', 'false');
+    }
+    event.preventDefault();
+  });
+
+  // Close dropdown when Tab key is used with Shift key
+  $('#manageDropdown').keydown(function(e) {
+    if (e.which == 9 && e.shiftKey) {
+      $(this).removeClass('open');
+      $(this).attr('aria-expanded', 'false');
+    }
+  });
+
+  // Close dropdown if Tab key is pressed when focused on last element
+  $('#manageDropdown ul > li:last-child').keydown(function(e) {
+    if (e.which == 9) {
+      $('#manageDropdown').removeClass('open');
+      $('#manageDropdown').attr('aria-expanded', 'false');
     }
   });
 });

--- a/app/assets/stylesheets/avalon/_nav.scss
+++ b/app/assets/stylesheets/avalon/_nav.scss
@@ -137,3 +137,19 @@
     @extend .btn-danger;
   }
 }
+
+.manage-btn {
+  height: 50px;
+  font-size: 16px;
+}
+
+.manage-btn:hover {
+  background-color: $yellow!important;
+}
+.manage-btn:focus {
+  background-color: $yellow;
+}
+
+.manage-dropwdown-menu {
+  border-radius: inherit;
+}

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -42,33 +42,32 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% end %>
 
   <% if can?(:read, Admin::Collection) || can?(:manage, Admin::Group) || (defined?(Samvera::Persona) && can?(:manage, User)) %>
-  <li id="manageDropdown" class="dropdown has-submenu" tabindex="0">
-    <a class="dropdown-toggle" id="manageDropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-      Manage
-      <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu nav navbar-default navbar-nav" aria-labelledby="manageDropdownMenu">
-      <% if can? :read, Admin::Collection %>
-      <li class=<%= active_for_controller('admin/collections') %>>
-        <%= link_to 'Manage Content', main_app.admin_collections_path %></li>
-      <% end %>
-      <% if can? :read, :encode_dashboard %>
-      <li class=<%= active_for_controller('encode_records') %>>
-        <%= link_to 'Manage Encoding Jobs', main_app.encode_records_path %></li>
-      <% end %>
+    <div class="btn-group" id="manage-dropdown">
+        <button id="manageDropdown" class="dropdown-toggle btn btn-primary manage-btn" data-toggle="dropdown">
+          Manage
+        </button>
+        <ul class="dropdown-menu nav navbar-default navbar-nav manage-dropwdown-menu">
+          <% if can? :read, Admin::Collection %>
+          <li class=<%= active_for_controller('admin/collections') %>>
+            <%= link_to 'Manage Content', main_app.admin_collections_path %></li>
+          <% end %>
+          <% if can? :read, :encode_dashboard %>
+          <li class=<%= active_for_controller('encode_records') %>>
+            <%= link_to 'Manage Encoding Jobs', main_app.encode_records_path %></li>
+          <% end %>
 
-      <% if can? :manage, Admin::Group %>
-      <li class=<%= active_for_controller('admin/groups') %>>
-        <%= link_to 'Manage Groups', main_app.admin_groups_path %></li>
-      <% end %>
-      <% if defined?(Samvera::Persona) %>
-      <% if can? :manage, User %>
-      <li class=<%= active_for_controller('samvera/persona/users') %>>
-        <%= link_to 'Manage Users', main_app.persona_users_path %></li>
-      <% end %>
-      <% end %>
-    </ul>
-  </li>
+          <% if can? :manage, Admin::Group %>
+          <li class=<%= active_for_controller('admin/groups') %>>
+            <%= link_to 'Manage Groups', main_app.admin_groups_path %></li>
+          <% end %>
+          <% if defined?(Samvera::Persona) %>
+          <% if can? :manage, User %>
+          <li class=<%= active_for_controller('samvera/persona/users') %>>
+            <%= link_to 'Manage Users', main_app.persona_users_path %></li>
+          <% end %>
+          <% end %>
+        </ul>
+    </div>
   <% end %>
 
   <li class="divider desktop-hidden" />

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -42,7 +42,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% end %>
 
   <% if can?(:read, Admin::Collection) || can?(:manage, Admin::Group) || (defined?(Samvera::Persona) && can?(:manage, User)) %>
-  <li id="manageDropdown" class="dropdown">
+  <li id="manageDropdown" class="dropdown has-submenu" tabindex="0">
     <a class="dropdown-toggle" id="manageDropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
       Manage
       <span class="caret"></span>


### PR DESCRIPTION
I tested this on Chrome, Firefox, and Safari in local development environment.

This is when using `Tab` to navigate and pressing `Enter` key to go to `Manage Groups` page:

![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/1331659/69278939-4bf9cb00-0bb1-11ea-8586-14fc662cae87.gif)

When using `Shift` + `Tab` to go in reverse this works properly in Chrome and Safari. But in Firefox, the dropdown menu closes and opens again before going to the previous item like as seen below (but works as intended):

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/1331659/69279199-dd693d00-0bb1-11ea-8b7a-e90a7a211976.gif)

This happens unlike in Chrome and Safari, Firefox handles the 2 events that get fired at that particular moment with a slight time gap. 

Following is a screen grab of reverse tabbing working in Chrome;

![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/1331659/69279891-49987080-0bb3-11ea-91e2-955bdc5b2271.gif)
 