### PR TITLE
Collection landing cleanup more

### DIFF
--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -118,7 +118,7 @@ class CollectionList extends Component {
 
 CollectionList.propTypes = {
   baseUrl: PropTypes.string,
-  filter: PropTypes.bool
+  filter: PropTypes.string
 };
 
 export default CollectionList;

--- a/app/javascript/components/Search.js
+++ b/app/javascript/components/Search.js
@@ -125,12 +125,10 @@ class Search extends Component {
         </div>
         <div className="collection-search-results-wrapper">
           <LoadingSpinner isLoading={isLoading} />
-          <div className="row">
-            <SearchResults
-              documents={searchResult.docs}
-              baseUrl={this.props.baseUrl}
-            />
-          </div>
+          <SearchResults
+            documents={searchResult.docs}
+            baseUrl={this.props.baseUrl}
+          />
         </div>
       </div>
     );

--- a/app/javascript/components/Search.js
+++ b/app/javascript/components/Search.js
@@ -17,7 +17,7 @@ class Search extends Component {
       isLoading: false
     };
     // Put a 1000ms delay on search network requests
-    this.retrieveResults = debounce(this.retrieveResults, 1000);
+    this.delayedRetrieveResults = debounce(this.delayedRetrieveResults, 1000);
 
     this.filterURL = `${props.baseUrl}?f[collection_ssim][]=${props.collection}`;
   }
@@ -33,11 +33,18 @@ class Search extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (
       prevState.query != this.state.query ||
-      prevState.currentPage != this.state.currentPage ||
       prevState.appliedFacets != this.state.appliedFacets
     ) {
+      // Handle updates to either search box or facets (facets not currently supported)
+      this.delayedRetrieveResults();
+    } else if (prevState.currentPage != this.state.currentPage) {
+      // Handle pagination update
       this.retrieveResults();
     }
+  }
+
+  delayedRetrieveResults() {
+    this.retrieveResults();
   }
 
   /**
@@ -85,10 +92,6 @@ class Search extends Component {
     if (this.props.collection) {
       facetFilters = `${facetFilters}&f[collection_ssim][]=${this.props.collection}`;
     }
-    console.log(
-      'TCL: Search -> prepFacetFilters -> facetFilters',
-      facetFilters
-    );
     return facetFilters;
   }
 

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -64,28 +64,12 @@
 }
 
 /* Search Results card */
-ul.search-within-search-results {
+.search-within-search-results {
   margin-top: 3rem;
   padding-left: 0;
-}
-
-.search-within-search-result {
-  list-style-type: none;
 
   .document-thumbnail {
     position: relative;
-  }
-}
-
-@media screen and (min-width: 767px) {
-  .search-within-search-result {
-    height: 350px;
-    margin-bottom: 16px;
-    overflow: hidden;
-
-    .panel-default {
-      height: inherit;
-    }
   }
 }
 

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -77,7 +77,7 @@ ul.search-within-search-results {
   }
 }
 
-@media (min-width: 767px) {
+@media screen and (min-width: 767px) {
   .search-within-search-result {
     height: 350px;
     margin-bottom: 16px;

--- a/app/javascript/components/collections/CollectionCardBody.js
+++ b/app/javascript/components/collections/CollectionCardBody.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CollectionCardBody = ({ children }) => (
+  <div className="panel-body">
+    <div className="collection-card-description">{children}</div>
+  </div>
+);
+
+export default CollectionCardBody;

--- a/app/javascript/components/collections/CollectionCardShell.js
+++ b/app/javascript/components/collections/CollectionCardShell.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CollectionCardShell = ({ children }) => (
+  <div className="collection-card panel panel-default">{children}</div>
+);
+
+export default CollectionCardShell;

--- a/app/javascript/components/collections/CollectionCardThumbnail.js
+++ b/app/javascript/components/collections/CollectionCardThumbnail.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CollectionCardThumbnail = ({ children }) => (
+  <div className="document-thumbnail">{children}</div>
+);
+
+export default CollectionCardThumbnail;

--- a/app/javascript/components/collections/landing/Pagination.js
+++ b/app/javascript/components/collections/landing/Pagination.js
@@ -14,17 +14,39 @@ function Pagination(props) {
     return Math.min(pages.offset_value + pages.limit_value, pages.total_count);
   };
 
-  const paginationBlock = <div className="sort-pagination mb-3 pull-right">
-                            {props.pages.prev_page != null ?
-                              (<a href="#" onClick={event => handleClick(props.pages.prev_page, event) }>Previous</a>) : ( <span>Previous</span> )}
-                            <span>{' '}| {pageStart(props.pages)}-{pageEnd(props.pages)} of {props.pages.total_count} |{' '}</span>
-                            {props.pages.next_page != null ?
-                              (<a href="#" onClick={event => handleClick(props.pages.next_page, event) }>Next</a>) : ( <span>Next</span> )}
-                          </div>;
+  const paginationBlock = (
+    <div className="sort-pagination mb-3 pull-right">
+      {props.pages.prev_page != null ? (
+        <a
+          href="#"
+          onClick={event => handleClick(props.pages.prev_page, event)}
+        >
+          Previous
+        </a>
+      ) : (
+        <span>Previous</span>
+      )}
+      <span>
+        {' '}
+        | {pageStart(props.pages)}-{pageEnd(props.pages)} of{' '}
+        {props.pages.total_count} |{' '}
+      </span>
+      {props.pages.next_page != null ? (
+        <a
+          href="#"
+          onClick={event => handleClick(props.pages.next_page, event)}
+        >
+          Next
+        </a>
+      ) : (
+        <span>Next</span>
+      )}
+    </div>
+  );
   if (props.pages.total_count) {
     return paginationBlock;
   } else if (props.pages.total_count === 0) {
-    return ( <p className="no-search-results">No results matched your search.</p> );
+    return <p className="no-search-results">No results matched your search.</p>;
   } else {
     return null;
   }

--- a/app/javascript/components/collections/landing/SearchResults.js
+++ b/app/javascript/components/collections/landing/SearchResults.js
@@ -4,14 +4,11 @@ import SearchResultsCard from './SearchResultsCard';
 
 const SearchResults = props => {
   return (
-    <ul className="search-within-search-results">
+    <ul className="row list-unstyled search-within-search-results">
       {props.documents.map((doc, index) => (
-        <SearchResultsCard
-          key={doc['id']}
-          doc={doc}
-          index={index}
-          baseUrl={props.baseUrl}
-        />
+        <li key={doc.id} className="col-sm-4">
+          <SearchResultsCard doc={doc} index={index} baseUrl={props.baseUrl} />
+        </li>
       ))}
     </ul>
   );

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CollectionCardShell from '../CollectionCardShell';
+import CollectionCardThumbnail from '../CollectionCardThumbnail';
+import CollectionCardBody from '../CollectionCardBody';
 
 const CardMetaData = ({ doc, fieldLabel, fieldName }) => {
   let metaData = null;
@@ -56,23 +59,23 @@ const thumbnailSrc = (doc, props) => {
 const SearchResultsCard = props => {
   const { baseUrl, index, doc } = props;
   return (
-    <li key={index} className="search-within-search-result col-sm-4">
-      <div className="panel panel-default">
-        <div className="document-thumbnail">
-          <span className="timestamp badge badge-dark">
-            {duration(doc['duration_ssi'])}
-          </span>
-          <a href={baseUrl + 'media_objects/' + doc['id']}>
-            {thumbnailSrc(doc, props) && (
-              <img
-                className="card-img-top img-cover"
-                src={thumbnailSrc(doc, props)}
-                alt="Card image cap"
-              />
-            )}
-          </a>
-        </div>
-        <div className="panel-body description">
+    <CollectionCardShell>
+      <CollectionCardThumbnail>
+        <span className="timestamp badge badge-dark">
+          {duration(doc['duration_ssi'])}
+        </span>
+        <a href={baseUrl + 'media_objects/' + doc['id']}>
+          {thumbnailSrc(doc, props) && (
+            <img
+              className="card-img-top img-cover"
+              src={thumbnailSrc(doc, props)}
+              alt="Card image cap"
+            />
+          )}
+        </a>
+      </CollectionCardThumbnail>
+      <CollectionCardBody>
+        <>
           <h4>
             <a href={baseUrl + 'media_objects/' + doc['id']}>
               {doc['title_tesi'] || doc['id']}
@@ -91,9 +94,9 @@ const SearchResultsCard = props => {
               fieldName="summary_ssi"
             />
           </dl>
-        </div>
-      </div>
-    </li>
+        </>
+      </CollectionCardBody>
+    </CollectionCardShell>
   );
 };
 

--- a/app/javascript/components/collections/list/CollectionCard.js
+++ b/app/javascript/components/collections/list/CollectionCard.js
@@ -1,36 +1,37 @@
 import React from 'react';
 import '../Collection.scss';
 import PropTypes from 'prop-types';
+import CollectionCardShell from '../CollectionCardShell';
+import CollectionCardThumbnail from '../CollectionCardThumbnail';
+import CollectionCardBody from '../CollectionCardBody';
 
 const CollectionCard = ({ attributes, showUnit }) => {
   return (
-    <div className="collection-card panel panel-default">
-      <div className="document-thumbnail">
+    <CollectionCardShell>
+      <CollectionCardThumbnail>
         {attributes.poster_url && (
           <a href={attributes.url}>
             <img src={attributes.poster_url} alt="Collection thumbnail"></img>
           </a>
         )}
-      </div>
-      <div className="panel-body">
-        <div className="collection-card-description">
-          <h4>
-            <a href={attributes.url}>{attributes.name}</a>
-          </h4>
-          <dl>
-            {showUnit && <dt>Unit</dt> && <dd>{attributes.unit}</dd>}
-            {attributes.description && (
-              <div>
-                <dd>
-                  {attributes.description.substring(0, 200)}
-                  {attributes.description.length >= 200 && <span>...</span>}
-                </dd>
-              </div>
-            )}
-          </dl>
-        </div>
-      </div>
-    </div>
+      </CollectionCardThumbnail>
+      <CollectionCardBody>
+        <h4>
+          <a href={attributes.url}>{attributes.name}</a>
+        </h4>
+        <dl>
+          {showUnit && <dt>Unit</dt> && <dd>{attributes.unit}</dd>}
+          {attributes.description && (
+            <div>
+              <dd>
+                {attributes.description.substring(0, 200)}
+                {attributes.description.length >= 200 && <span>...</span>}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </CollectionCardBody>
+    </CollectionCardShell>
   );
 };
 


### PR DESCRIPTION
This PR does a few quick things:
- Decouples pagination clicks from the delayed network request
- Adds some higher order components to make `Card` components more consistent between Collections landing and listing pages.
- Other general CSS cleanup