### PR TITLE
Use SpeedyAF proxy and refactor to avoid using fedora for encode progress

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -516,7 +516,7 @@ class MediaObjectsController < ApplicationController
   def master_file_presenters
     SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{@media_object.id}",
                          order: -> { @media_object.indexed_master_file_ids },
-                         defaults: { permalink: nil, title: nil, encoder_classname: nil, workflow_id: nil })
+                         defaults: { permalink: nil, title: nil, encoder_classname: nil, workflow_id: nil, comment: [] })
   end
 
   def load_master_files(mode = :rw)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -353,11 +353,11 @@ class MediaObjectsController < ApplicationController
         raw_encode = JSON.parse(encode.raw_object)
         status = encode.state.to_s.upcase
         mf_status = {
-          :status => status,
-          :complete => encode.progress.to_i,
-          :success => encode.progress.to_i,
-          :operation => raw_encode['current_operations']&.first,
-          :message => raw_encode['errors'].first.try(:sub,/^.+:/,'')
+          status: status,
+          complete: encode.progress.to_i,
+          success: encode.progress.to_i,
+          operation: raw_encode['current_operations']&.first,
+          message: raw_encode['errors'].first.try(:sub, /^.+:/, '')
         }
         if status == 'FAILED'
           mf_status[:error] = 100 - mf_status[:success]
@@ -515,8 +515,14 @@ class MediaObjectsController < ApplicationController
 
   def master_file_presenters
     SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{@media_object.id}",
-                         order: -> { @media_object.indexed_master_file_ids },
-                         defaults: { permalink: nil, title: nil, encoder_classname: nil, workflow_id: nil, comment: [] })
+                                      order: -> { @media_object.indexed_master_file_ids },
+                                      defaults: {
+                                        permalink: nil,
+                                        title: nil,
+                                        encoder_classname: nil,
+                                        workflow_id: nil,
+                                        comment: []
+                                      })
   end
 
   def load_master_files(mode = :rw)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -347,25 +347,27 @@ class MediaObjectsController < ApplicationController
 
   def show_progress
     overall = { :success => 0, :error => 0 }
-
+    encode_gids = master_file_presenters.collect { |mf| "gid://ActiveEncode/#{mf.encoder_class}/#{mf.workflow_id}" }
     result = Hash[
-      master_file_presenter.collect { |mf|
+      ActiveEncode::EncodeRecord.where(global_id: encode_gids).collect do |encode|
+        raw_encode = JSON.parse(encode.raw_object)
+        status = encode.state.to_s.upcase
         mf_status = {
-          :status => mf.status_code,
-          :complete => mf.percent_complete.to_i,
-          :success => mf.percent_complete.to_i,
-          :operation => mf.operation,
-          :message => mf.error.try(:sub,/^.+:/,'')
+          :status => status,
+          :complete => encode.progress.to_i,
+          :success => encode.progress.to_i,
+          :operation => raw_encode['current_operations']&.first,
+          :message => raw_encode['errors'].first.try(:sub,/^.+:/,'')
         }
-        if mf.status_code == 'FAILED'
+        if status == 'FAILED'
           mf_status[:error] = 100 - mf_status[:success]
           overall[:error] += 100
         else
           mf_status[:error] = 0
           overall[:success] += mf_status[:complete]
         end
-        [mf.id, mf_status]
-      }
+        [encode.master_file_id, mf_status]
+      end
     ]
     master_files_count = @media_object.master_files.size
     if master_files_count > 0
@@ -459,7 +461,7 @@ class MediaObjectsController < ApplicationController
     @media_object = MediaObject.find(params[:id])
     authorize! :read, @media_object
 
-    master_files = master_file_presenter
+    master_files = master_file_presenters
     canvas_presenters = master_files.collect do |mf|
       stream_info = secure_streams(mf.stream_details)
       IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info)
@@ -511,14 +513,14 @@ class MediaObjectsController < ApplicationController
 
   protected
 
-  def master_file_presenter
-    SpeedyAF::Base.where("isPartOf_ssim:#{@media_object.id}",
+  def master_file_presenters
+    SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{@media_object.id}",
                          order: -> { @media_object.indexed_master_file_ids },
-                         defaults: { permalink: nil, title: nil })
+                         defaults: { permalink: nil, title: nil, encoder_classname: nil, workflow_id: nil })
   end
 
   def load_master_files(mode = :rw)
-    @masterFiles ||= mode == :rw ? @media_object.indexed_master_files.to_a : master_file_presenter
+    @masterFiles ||= mode == :rw ? @media_object.indexed_master_files.to_a : master_file_presenters
   end
 
   def set_player_token

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -120,7 +120,7 @@ module MediaObjectsHelper
          @currentStream && ( section.id == @currentStream.id )
       end
 
-      def show_progress? sections
+      def show_progress?(sections)
         encode_gids = sections.collect { |mf| "gid://ActiveEncode/#{mf.encoder_class}/#{mf.workflow_id}" }
         ActiveEncode::EncodeRecord.where(global_id: encode_gids).any? { |encode| encode.state.to_s.upcase != 'COMPLETED' }
       end

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -125,6 +125,11 @@ module MediaObjectsHelper
         ActiveEncode::EncodeRecord.where(global_id: encode_gids).any? { |encode| encode.state.to_s.upcase != 'COMPLETED' }
       end
 
+      def any_failed?(sections)
+        encode_gids = sections.collect { |mf| "gid://ActiveEncode/#{mf.encoder_class}/#{mf.workflow_id}" }
+        ActiveEncode::EncodeRecord.where(global_id: encode_gids).any? { |encode| encode.state.to_s.upcase == 'FAILED' }
+      end
+
       def hide_sections? sections
         sections.blank? or (sections.length == 1 and !sections.first.has_structuralMetadata?)
       end

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -120,6 +120,11 @@ module MediaObjectsHelper
          @currentStream && ( section.id == @currentStream.id )
       end
 
+      def show_progress? sections
+        encode_gids = sections.collect { |mf| "gid://ActiveEncode/#{mf.encoder_class}/#{mf.workflow_id}" }
+        ActiveEncode::EncodeRecord.where(global_id: encode_gids).any? { |encode| encode.state.to_s.upcase != 'COMPLETED' }
+      end
+
       def hide_sections? sections
         sections.blank? or (sections.length == 1 and !sections.first.has_structuralMetadata?)
       end

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -1,0 +1,9 @@
+class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
+  def encoder_class
+    find_encoder_class(encoder_classname) || find_encoder_class(workflow_name.to_s.classify) || find_encoder_class((Settings.encoding.engine_adapter + "_encode").classify) || MasterFile.default_encoder_class || WatchedEncode
+  end
+
+  def find_encoder_class(klass_name)
+    ActiveEncode::Base.descendants.find { |c| c.name == klass_name }
+  end
+end

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -1,3 +1,17 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# frozen_string_literal: true
 class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
   def encoder_class
     find_encoder_class(encoder_classname) || find_encoder_class(workflow_name.to_s.classify) || find_encoder_class((Settings.encoding.engine_adapter + "_encode").classify) || MasterFile.default_encoder_class || WatchedEncode

--- a/app/presenters/speedy_af/proxy/structural_metadata.rb
+++ b/app/presenters/speedy_af/proxy/structural_metadata.rb
@@ -1,0 +1,25 @@
+# Copyright 2011-2019, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+# frozen_string_literal: true
+class SpeedyAF::Proxy::StructuralMetadata < SpeedyAF::Base
+  delegate :xpath, to: :ng_xml
+
+  def ng_xml
+    @ng_xml ||= Nokogiri::XML::Document.parse(content).tap { |doc| StructuralMetadata.decorate_ng_xml doc }
+  end
+
+  def section_title
+    xpath('/Item/@label').text
+  end
+end

--- a/app/views/media_objects/_sections.html.erb
+++ b/app/views/media_objects/_sections.html.erb
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% show_progress = sections.any? { |s| s.status_code != 'COMPLETED' } %>
+<% show_progress = show_progress?(sections) %>
 <% unless hide_sections?(sections) and not show_progress %>
 
 <div class="panel-group media-show-page" id="accordion" role="tablist" aria-multiselectable="true">

--- a/app/views/media_objects/_workflow_progress.html.erb
+++ b/app/views/media_objects/_workflow_progress.html.erb
@@ -20,8 +20,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <div class="alert">
             <p>No media is associated with this item</p>
           </div>
-        <% elsif @masterFiles.any? { |mf| mf.status_code != 'COMPLETED' } %>
-          <div class="alert <%= @masterFiles.any? { |mf| mf.failed? } ? 'alert-danger' : 'alert-info' %>">
+        <% elsif show_progress?(@masterFiles) %>
+          <div class="alert <%= any_failed?(@masterFiles) ? 'alert-danger' : 'alert-info' %>">
             <h4>Conversion Process</h4>
             <br/>
             <div id="overall" class="progress progress-striped active hidden-phone">


### PR DESCRIPTION
Part of #3103.