### PR TITLE
Mount blacklight at /catalog to fix generated links

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,14 @@ require 'avalon/routing/can_constraint'
 
 Rails.application.routes.draw do
   mount Samvera::Persona::Engine => '/'
-  mount Blacklight::Engine => '/'
+  mount Blacklight::Engine => '/catalog'
+  concern :searchable, Blacklight::Routes::Searchable.new
+  concern :exportable, Blacklight::Routes::Exportable.new
   root to: "catalog#index"
-    concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
   end
-
-  concern :exportable, Blacklight::Routes::Exportable.new
 
   get '/mejs/:version', to: 'application#mejs'
 


### PR DESCRIPTION
Without this prev/next buttons as well as facet constraints and sort/per page all use the root path leading users back to the home page.