### PR TITLE
Display create options on encode record show page

### DIFF
--- a/app/presenters/encode_presenter.rb
+++ b/app/presenters/encode_presenter.rb
@@ -64,6 +64,10 @@ class EncodePresenter
     JSON.pretty_generate(@raw_object)
   end
 
+  def create_options
+    JSON.pretty_generate(@create_options)
+  end
+
   def errors
     @raw_object["errors"]
   end

--- a/app/views/encode_records/show.html.erb
+++ b/app/views/encode_records/show.html.erb
@@ -44,6 +44,13 @@
       </section>
 
       <p>
+        <strong>Create Options:</strong>
+        <div class="box box-default">
+          <pre><%= encode_presenter.create_options %></pre>
+        </div>
+      </p>
+
+      <p>
         <strong>Raw Obejct:</strong>
         <div class="box box-default">
           <pre><%= encode_presenter.raw_object %></pre>


### PR DESCRIPTION
The options that a encode was created with are only stored on the encode record and are important so this PR adds them to the show page.