### PR TITLE
Fix CSS when form validation fails

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -763,27 +763,27 @@ h5.panel-title {
 
 // Input form validation styling
 .invalid-feedback {
-  color: #b24b47;
+  color: $danger;
 }
 
 .is-invalid {
-  border-color: #b24b47;
+  border-color:$danger;
 }
 
 .is-invalid:focus {
   outline: 0px !important;
   -webkit-appearance: none;
-  border-color: #b24b47;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #b24b47;
+  border-color: $danger;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px $danger;
 }
 
 .is-valid {
-  border-color: #206e32;
+  border-color: $success;
 }
 
 .is-valid:focus {
-  border-color: #206e32;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #206e32;
+  border-color: $success;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px $success;
 }
 
 /**

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -175,6 +175,7 @@ class TimelinesController < ApplicationController
         if @timeline.update(timeline_params)
           redirect_to edit_timeline_path(@timeline), notice: 'Timeline was successfully updated.'
         else
+          flash.now[:error] = "There are errors with your submission.  #{@timeline.errors.full_messages.join(', ')}"
           render :edit
         end
       end

--- a/app/views/media_objects/_dropdown_field.html.erb
+++ b/app/views/media_objects/_dropdown_field.html.erb
@@ -16,10 +16,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 <!-- <%= field.to_s.humanize %> field -->
 <% selected_value ||= options[:dropdown_options].keys.first %>
 
-  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>has-error<% end %>">
+  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>invalid-feedback<% end %>">
     <%= render partial: "modules/tooltip", locals: { form: form, field: field, tooltip: t("metadata_tip.#{field.to_s}"), options: options } %>
     <% if @media_object.errors[field].any? %>
-      <%= content_tag :span, @media_object.errors[field].join(", "), class: 'help-block' %>
+      <%= content_tag :span, @media_object.errors[field].join(", "), class: (@media_object.errors[field].any? ? 'help-block invalid-feedback' : 'help-block') %>
     <% end %>
     <% values = @media_object.send(field) || "" %>
     <% fieldarray = "" %>

--- a/app/views/media_objects/_text_area.html.erb
+++ b/app/views/media_objects/_text_area.html.erb
@@ -14,10 +14,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>has-error<% end %>">
+  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>invalid-feedback<% end %>">
     <%= render partial: "modules/tooltip", locals: { form: form, field: field, tooltip: t("metadata_tip.#{field.to_s}"), options: options } %>
     <% if @media_object.errors[field].any? %>
-      <%= content_tag :span, @media_object.errors[field].join(", "), class: 'help-block' %>
+      <%= content_tag :span, @media_object.errors[field].join(", "), class: (@media_object.errors[field].any? ? 'help-block invalid-feedback' : 'help-block') %>
     <% end %>
     <% values = @media_object.send(field) || "" %>
     <% fieldarray = "" %>
@@ -39,7 +39,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <%= text_area_tag fieldname, value || '', rows: 10, class: 'form-control typed-textarea', id: "typed_textarea_#{field}_#{i}" %>
       <% else %>
         <div class="input-group <%=options[:extra_classes]%>">
-          <%= text_area_tag fieldname, value || '', rows: 10, class: 'form-control', id: "#{field}_#{i}" %>
+          <%= text_area_tag fieldname, value || '', rows: 10, class: (@media_object.errors[field].any? ? 'form-control is-invalid' : 'form-control'), id: "#{field}_#{i}" %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/media_objects/_text_field.html.erb
+++ b/app/views/media_objects/_text_field.html.erb
@@ -14,10 +14,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <!-- <%= field.to_s.humanize %> field -->
-  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>has-error<% end %>">
-    <%= render partial: "modules/tooltip", locals: { form: form, field: field, tooltip: t("metadata_tip.#{field.to_s}"), options: options } %>
+  <div class="form-group <% if options[:multivalued] %>multivalued<% end %> <% if @media_object.errors[field].any? %>invalid-feedback<% end %>">
+    <%= render partial: "modules/tooltip", locals: { form: form, field: field, tooltip: t("metadata_tip.#{field.to_s}"), error: @media_object.errors[field].any?, options: options } %>
     <% if @media_object.errors[field].any? %>
-      <%= content_tag :span, @media_object.errors[field].join(", "), class: 'help-block' %>
+      <%= content_tag :span, @media_object.errors[field].join(", "), class: (@media_object.errors[field].any? ? 'help-block invalid-feedback' : 'help-block') %>
     <% end %>
     <% values = @media_object.send(field) || "" %>
     <% fieldarray = "" %>
@@ -31,16 +31,16 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% count.times do |i| %>
       <% value = values[i] %>
       <div class="input-group <%=options[:extra_classes]%>">
-	<% if options[:autocomplete_model] and options[:autocomplete_model].present? %>
-	  <%= render partial: "typeahead_field", locals: {fieldname: fieldname, value: value, options: options} %>
-	<% elsif options[:secondary_field] and options[:secondary_field].present? %>
-	  <%= render partial: "two_part_field", locals: {fieldname: fieldname, value: value, options: options} %>
-	<% else %>
+        <% if options[:autocomplete_model] and options[:autocomplete_model].present? %>
+          <%= render partial: "typeahead_field", locals: {fieldname: fieldname, value: value, options: options} %>
+        <% elsif options[:secondary_field] and options[:secondary_field].present? %>
+          <%= render partial: "two_part_field", locals: {fieldname: fieldname, value: value, options: options} %>
+        <% else %>
           <% if options[:dropdown_field] %>
-	    <%= render partial: "multipart_dropdown_field", locals: {selected_value: value.present? ? value[options[:secondary_hash_key]] : nil, options: options} %>
-            <% value = value.present? ? value[options[:primary_hash_key]] : "" %>
-	  <% end %>
-	  <%= text_field_tag fieldname, value || '', class: 'form-control' %>
+            <%= render partial: "multipart_dropdown_field", locals: {selected_value: value.present? ? value[options[:secondary_hash_key]] : nil, options: options} %>
+              <% value = value.present? ? value[options[:primary_hash_key]] : "" %>
+          <% end %>
+          <%= text_field_tag fieldname, value || '', class: (@media_object.errors[field].any? ? 'form-control is-invalid' : 'form-control') %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -15,9 +15,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <div id="playlist_edit_div" class="collapse <%= 'in' if !@playlist.persisted? || !@playlist.errors.empty? %>">
   <%= form_for(@playlist, html: { id: 'playlist_form', class: 'playlist_actions' }) do |f| %>
-  <div class="form-group <% if @playlist.errors[:title].any? %>has-error<% end %>">
+  <div class="form-group <% if @playlist.errors[:title].any? %>invalid-feedback<% end %>">
     <%= f.label "Name" %>
-    <%= f.text_field :title, class: 'form-control' %>
+    <%= f.text_field :title, class: (@playlist.errors[:title].any? ? 'is-invalid form-control' : 'form-control') %>
   </div>
 
   <div class="form-group">

--- a/app/views/timelines/_form.html.erb
+++ b/app/views/timelines/_form.html.erb
@@ -15,9 +15,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <div id="timeline_edit_div" class="container">
   <%= form_for(@timeline, html: { id: 'timeline_form', class: 'form-horizontal timeline_actions' }) do |f| %>
-  <div class="row form-group <% if @timeline.errors[:title].any? %>has-error<% end %>">
-    <%= f.label "Name", class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.text_field :title, class: 'form-control' %></div>
+  <div class="row form-group <% if @timeline.errors[:title].any? %>invalid-feedback<% end %>">
+    <%= f.label "Title", class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10"><%= f.text_field :title, class: (@timeline.errors[:title].any? ? 'is-invalid form-control' : 'form-control') %></div>
   </div>
   <div class="row form-group">
     <%= f.label :description, 'Description', class: 'col-sm-2 control-label' %>


### PR DESCRIPTION
Replace existing CSS class for required fields on failed validation.

Previous `has-error` CSS class fades the input field and turn the label color to `white` on failed validation for required fields. 

![before-error](https://user-images.githubusercontent.com/1331659/70180900-e3314900-16ae-11ea-8793-044ac3b13195.png)

Now `is-invalid` and `invalid-feedback` CSS classes are used instead, which shows erroneous required fields in `red` color (from `branding.css`) on submission.
![after-error](https://user-images.githubusercontent.com/1331659/70180901-e3314900-16ae-11ea-99a7-6444cb18edf5.png)

