### PR TITLE
Add common No Results component to Collection filtering UIs

### DIFF
--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -4,6 +4,7 @@ import './collections/Collection.scss';
 import CollectionListStickyUtils from './collections/list/CollectionListStickyUtils';
 import CollectionsSortedByUnit from './collections/list/CollectionsSortedByUnit';
 import CollectionsSortedByAZ from './collections/list/CollectionsSortedByAZ';
+import CollectionsFilterNoResults from './collections/CollectionsFilterNoResults';
 import PropTypes from 'prop-types';
 
 class CollectionList extends Component {
@@ -88,7 +89,8 @@ class CollectionList extends Component {
   };
 
   render() {
-    const { filter, sort, filteredResult, maxItems } = this.state;
+    const { filter, sort, filteredResult = [], maxItems } = this.state;
+
     return (
       <div>
         <CollectionListStickyUtils
@@ -97,6 +99,9 @@ class CollectionList extends Component {
           sort={sort}
           handleSortChange={this.handleSortChange}
         />
+
+        {filteredResult.length === 0 && <CollectionsFilterNoResults />}
+
         <div className="collection-list">
           {sort === 'az' ? (
             <CollectionsSortedByAZ

--- a/app/javascript/components/collections/CollectionsFilterNoResults.js
+++ b/app/javascript/components/collections/CollectionsFilterNoResults.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const CollectionsFilterNoResults = () => (
+  <p className="alert alert-info text-left">
+    <i className="glyphicon glyphicon-exclamation-sign"></i> No results returned
+    for your search
+  </p>
+);
+
+export default CollectionsFilterNoResults;

--- a/app/javascript/components/collections/landing/Pagination.js
+++ b/app/javascript/components/collections/landing/Pagination.js
@@ -45,8 +45,6 @@ function Pagination(props) {
   );
   if (props.pages.total_count) {
     return paginationBlock;
-  } else if (props.pages.total_count === 0) {
-    return <p className="no-search-results">No results matched your search.</p>;
   } else {
     return null;
   }

--- a/app/javascript/components/collections/landing/SearchResults.js
+++ b/app/javascript/components/collections/landing/SearchResults.js
@@ -1,17 +1,31 @@
 import React from 'react';
 import '../Collection.scss';
 import SearchResultsCard from './SearchResultsCard';
+import CollectionFilterNoResults from '../CollectionsFilterNoResults';
+import PropTypes from 'prop-types';
 
-const SearchResults = props => {
+const SearchResults = ({ documents = [], baseUrl }) => {
+  if (documents.length === 0)
+    return (
+      <div style={{ paddingTop: '3rem' }}>
+        <CollectionFilterNoResults />
+      </div>
+    );
+
   return (
     <ul className="row list-unstyled search-within-search-results">
-      {props.documents.map((doc, index) => (
+      {documents.map((doc, index) => (
         <li key={doc.id} className="col-sm-4">
-          <SearchResultsCard doc={doc} index={index} baseUrl={props.baseUrl} />
+          <SearchResultsCard doc={doc} index={index} baseUrl={baseUrl} />
         </li>
       ))}
     </ul>
   );
+};
+
+SearchResults.propTypes = {
+  documents: PropTypes.array,
+  baseUrl: PropTypes.string
 };
 
 export default SearchResults;


### PR DESCRIPTION
This now uses a common component for both UI scenarios where Collections are being filtered... any any future scenarios.

![image](https://user-images.githubusercontent.com/3020266/70268949-091a2480-1767-11ea-9df5-60ac79c38f5a.png)

![image](https://user-images.githubusercontent.com/3020266/70269038-336be200-1767-11ea-904f-89527124f3f9.png)
