### PR TITLE
Restore field label to Name

### DIFF
--- a/app/views/timelines/_form.html.erb
+++ b/app/views/timelines/_form.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div id="timeline_edit_div" class="container">
   <%= form_for(@timeline, html: { id: 'timeline_form', class: 'form-horizontal timeline_actions' }) do |f| %>
   <div class="row form-group <% if @timeline.errors[:title].any? %>invalid-feedback<% end %>">
-    <%= f.label "Title", class: 'col-sm-2 control-label' %>
+    <%= f.label "Name", class: 'col-sm-2 control-label' %>
     <div class="col-sm-10"><%= f.text_field :title, class: (@timeline.errors[:title].any? ? 'is-invalid form-control' : 'form-control') %></div>
   </div>
   <div class="row form-group">


### PR DESCRIPTION
This was changed in https://github.com/avalonmediasystem/avalon/pull/3785/files#diff-39b34b2592904bd33622618b25f1b933R19.  I don't think this was intentional so this PR reverts it so it stays consistent with playlists.