### PR TITLE
Log to stdout only in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,6 @@ config.webpacker.check_yarn_integrity = false
   # config.force_ssl = true
 
   # Enable logging to both stdout and file, in more compact format
-  config.logger = Logger.new("| tee -a log/production.log")
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     {:time => event.time}


### PR DESCRIPTION
It's good practice and also fixes a problem with Ruby 2.5.7