### PR TITLE
[WIP] Move popover time float in MEJS

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1752,6 +1752,7 @@ Object.assign(_player2.default.prototype, {
 				leftPos = t.timefloat.offsetWidth + width >= t.getElement(t.container).offsetWidth ? t.timefloat.offsetWidth / 2 : 0;
 				t.timefloat.style.left = leftPos + 'px';
 				t.timefloat.style.left = leftPos + 'px';
+				t.timefloat.style.bottom = '5px';
 				t.timefloat.style.display = 'block';
 			}
 		},


### PR DESCRIPTION
In embedded player, the time popover when hovered looks like below;

<img width="616" alt="Screen Shot 2019-12-11 at 1 49 45 PM" src="https://user-images.githubusercontent.com/1331659/70654454-55aca680-1c24-11ea-8dcc-b0530933e547.png">

To fix this, move the popover further down towards the time rail, so that it doesn't get cut-off.