### PR TITLE
Move popover time float in MEJS

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1752,6 +1752,7 @@ Object.assign(_player2.default.prototype, {
 				leftPos = t.timefloat.offsetWidth + width >= t.getElement(t.container).offsetWidth ? t.timefloat.offsetWidth / 2 : 0;
 				t.timefloat.style.left = leftPos + 'px';
 				t.timefloat.style.left = leftPos + 'px';
+				t.timefloat.style.bottom = '3px';
 				t.timefloat.style.display = 'block';
 			}
 		},

--- a/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
+++ b/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
@@ -440,7 +440,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     bottom: 100%;
     color: #111;
     display: none;
-    height: 17px;
+    height: 14px;
     margin-bottom: 9px;
     position: absolute;
     text-align: center;
@@ -453,13 +453,14 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__time-float-current {
     display: block;
     left: 0;
-    margin: 2px;
+    margin-top: 2px;
+    margin-left: 2px;
     text-align: center;
     width: 30px;
 }
 
 .mejs__time-float-corner {
-    border: solid 5px #eee;
+    border: solid 3px #eee;
     border-color: #eee transparent transparent;
     border-radius: 0;
     display: block;


### PR DESCRIPTION
In embedded player, the time popover when hovered looks like below;

<img width="616" alt="Screen Shot 2019-12-11 at 1 49 45 PM" src="https://user-images.githubusercontent.com/1331659/70654454-55aca680-1c24-11ea-8dcc-b0530933e547.png">

To fix this, move the popover further down towards the time rail and make it smaller, so that it doesn't get cut-off.

![Screenshot from 2019-12-11 15-22-38](https://user-images.githubusercontent.com/1331659/70657593-1b460800-1c2a-11ea-8677-fdada1df256e.png)
