### PR TITLE
Fix IE11 urlSearchParams issue

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,7 @@
 //= require modernizr
 //= require bootstrap-toggle
 //= require cropperjs/dist/cropper.min
+//= require url-search-params-polyfill/index.js
 
 // include all of our vendored js
 //= require_tree ../../../vendor/assets/javascripts/.

--- a/app/assets/javascripts/refresh_token.js.coffee
+++ b/app/assets/javascripts/refresh_token.js.coffee
@@ -14,11 +14,12 @@
 
 $ ->
   refreshToken = ->
-    token = currentPlayer.media.src.split('?')[1]
-    if token && token.match(/^token=/)
-      mount_point = $('body').data('mountpoint')
-      $.get("#{mount_point}authorize.txt?#{token}")
-        .done -> console.log("Token refreshed")
-        .fail -> console.error("Token refresh failed")
+    if currentPlayer != undefined
+      token = currentPlayer.media.src.split('?')[1]
+      if token && token.match(/^token=/)
+        mount_point = $('body').data('mountpoint')
+        $.get("#{mount_point}authorize.txt?#{token}")
+          .done -> console.log("Token refreshed")
+          .fail -> console.error("Token refresh failed")
 
   setInterval(refreshToken, 5*60*1000)

--- a/app/views/encode_records/index.html.erb
+++ b/app/views/encode_records/index.html.erb
@@ -30,13 +30,14 @@
 var encodeProgressTimeout;
 
 update_encode_progress = function() {
-  let ids = $('.progress-bar').map(function(d){ return $(this).data('encode-id') }).get()
-  $.post($('#encode-records').data('progress-url'),
-    {ids},
-    function(progress_data) {
-      let stop = true;
+  var ids = $('.progress-bar').map(function(d){ return $(this).data('encode-id') }).get();
+  $.post({
+    url: $('#encode-records').data('progress-url'),
+    data: {ids: ids},
+    success: function(progress_data) {
+      var stop = true;
       $('.progress-bar').each(function(i, bar) {
-        let encode_data = progress_data[$(bar).data('encode-id')]
+        var encode_data = progress_data[$(bar).data('encode-id')]
         $(bar).closest('tr').find('.encode-status').text(encode_data['status'])
         toggleCSS($(bar), encode_data['status'].toLowerCase())
         $(bar).attr('aria-valuenow', encode_data['progress'])
@@ -47,6 +48,7 @@ update_encode_progress = function() {
         encodeProgressTimeout = setTimeout(update_encode_progress, 10000);
       }
     }
+  }
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-bootstrap": "^1.0.0-beta.8",
     "react-dom": "^16.8.4",
     "react-structural-metadata-editor": "https://github.com/avalonmediasystem/react-structural-metadata-editor",
-    "react_ujs": "^2.4.4"
+    "react_ujs": "^2.4.4",
+    "url-search-params-polyfill": "^7.0.1"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7679,6 +7679,11 @@ url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-search-params-polyfill@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz#b900cd9a0d9d2ff757d500135256f2344879cbff"
+  integrity sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ==
+
 url-toolkit@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.6.tgz#6d03246499e519aad224c44044a4ae20544154f2"


### PR DESCRIPTION
IE doesn't support `urlSearchParams()` constructor, therefore every time the respective pages load in IE, line 7 in `app/assets/javascript/sessions_new.js` file throws an error.
The `url-search-params-polyfill` in the application comes in when the browser does not support.