### PR TITLE
Log an error when waveform generation fails instead of raising an error and failing the job

### DIFF
--- a/app/jobs/waveform_job.rb
+++ b/app/jobs/waveform_job.rb
@@ -26,7 +26,10 @@ class WaveformJob < ActiveJob::Base
     service = WaveformService.new(8, SAMPLES_PER_FRAME)
     uri = file_uri(master_file) || playlist_url(master_file)
     json = service.get_waveform_json(uri)
-    return unless json.present?
+    if json.blank?
+      Rails.logger.error "No waveform generated for #{master_file.id}"
+      return
+    end
 
     master_file.waveform.content = Zlib::Deflate.deflate(json)
     master_file.waveform.mime_type = 'application/zlib'

--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -29,6 +29,7 @@ class WaveformService
       bits: @bit_res
     )
     get_normalized_peaks(uri).each { |peak| waveform.append(peak[0], peak[1]) }
+    return nil if waveform.size.zero?
     waveform.to_json
   end
 
@@ -37,6 +38,7 @@ private
   def get_normalized_peaks(uri)
     wave_io = get_wave_io(uri)
     peaks = gather_peaks(wave_io)
+    return [] if peaks.blank?
     max_peak = peaks.flatten.map(&:abs).max
     res = 2**(@bit_res - 1)
     factor = max_peak.zero? ? 1 : res / max_peak.to_f

--- a/spec/jobs/waveform_job_spec.rb
+++ b/spec/jobs/waveform_job_spec.rb
@@ -85,5 +85,15 @@ describe WaveformJob do
         end
       end
     end
+
+    context 'when processing fails to generate waveform data' do
+      let(:waveform_json) { nil }
+
+      it 'logs and does not set the waveform' do
+        expect(Rails.logger).to receive(:error)
+        expect { job.perform(master_file.id, true) }.not_to change { master_file.reload.waveform.content }
+        expect(service).to have_received(:get_waveform_json)
+      end
+    end
   end
 end


### PR DESCRIPTION
Since waveforms aren't critical, I decided to let the job finish without failure and log the error instead of having the job rerun.  I think that if a user comes across a file without a waveform in the SME then they can raise the issue and someone can troubleshoot it.  Anyways this is the likely result even if the job were to fail and rerun.

The original issue of ffmpeg not returning any waveform data is concerning and still not resolved.