### PR TITLE
SME build with fix for overflowing content in modal

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,7 +6375,7 @@ react-redux@^6.0.0:
 
 "react-structural-metadata-editor@https://github.com/avalonmediasystem/react-structural-metadata-editor":
   version "1.1.0"
-  resolved "https://github.com/avalonmediasystem/react-structural-metadata-editor#7f387c13874453353bd6893c974d4bd468445728"
+  resolved "https://github.com/avalonmediasystem/react-structural-metadata-editor#95fc2695a4f997afff513cccf933fd23f0d620be"
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@fortawesome/fontawesome-svg-core" "^1.2.4"


### PR DESCRIPTION
When structural metadata editor is opened, for some screen widths the content overflows the modal.

![Screenshot from 2019-12-13 15-33-33](https://user-images.githubusercontent.com/1331659/70830415-25007480-1dbe-11ea-97ac-863f15efaad0.png)

This happens because all the components within SME are enclosed in a `<div>` with `class="container"`, which is used in Bootstrap for responsive design. When SME is added to Avalon the Bootstrap CSS in Avalon gets applied here causing the overflow.

After the fix:

![Screenshot from 2019-12-13 15-33-54](https://user-images.githubusercontent.com/1331659/70830772-f8992800-1dbe-11ea-9542-d646d5ff60a8.png)
