### PR TITLE
Fix manage nav wrapping to a new line

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -76,7 +76,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%# Fallback if the test above fails %>
   <%= link_to 'Sign in', main_app.new_user_session_path %>
   <% end %>
-  <% unless current_page?(root_path) %>
+  <% unless current_page?(main_app.root_path) %>
   <li class="desktop-hidden"><%= render :partial=>'modules/avalon_search_form' %></li>
   <% end %>
 </ul>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -40,9 +40,9 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
   </li>
   <% end %>
-
   <% if can?(:read, Admin::Collection) || can?(:manage, Admin::Group) || (defined?(Samvera::Persona) && can?(:manage, User)) %>
-    <div class="btn-group" id="manage-dropdown">
+    <li>
+      <div class="btn-group" id="manage-dropdown">
         <button id="manageDropdown" class="dropdown-toggle btn btn-primary manage-btn" data-toggle="dropdown">
           Manage
         </button>
@@ -67,7 +67,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <% end %>
           <% end %>
         </ul>
-    </div>
+      </div>
+    </li>
   <% end %>
 
   <li class="divider desktop-hidden" />
@@ -75,7 +76,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%# Fallback if the test above fails %>
   <%= link_to 'Sign in', main_app.new_user_session_path %>
   <% end %>
-  <% unless current_page?(main_app.root_path) %>
+  <% unless current_page?(root_path) %>
   <li class="desktop-hidden"><%= render :partial=>'modules/avalon_search_form' %></li>
   <% end %>
 </ul>


### PR DESCRIPTION
In Safari, the `Manage` menu link in the nav-bar wraps into a new line,

![Screenshot from 2019-12-16 09-31-08](https://user-images.githubusercontent.com/1331659/70923071-439c8080-1ff5-11ea-95c3-31a1bff17c80.png)

This PR fixes this, so that all the nav items are on the same line.