### PR TITLE
Make edit structure UI stick to rows in smaller screens

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -466,9 +466,23 @@ div.status-detail {
 }
 
 #mediaobject_structure {
+  overflow-x: auto;
+
   a.structure_toggle,
   a.captions_toggle {
     cursor: pointer;
+  }
+
+  @media (max-width: 1199px) and (min-width: 768px) {
+    ul {
+      width: 750px;
+    }
+  }
+
+  @media (max-width: 767px) {
+    ul {
+      width: 730px;
+    }
   }
 
   ul {


### PR DESCRIPTION
When screen size is`992px x 758px`,

before fix:
![Screenshot from 2019-12-16 14-55-07](https://user-images.githubusercontent.com/1331659/70938580-743fe280-2014-11ea-9df0-a187d274701d.jpg)

after fix:
![Screenshot from 2019-12-16 14-54-42](https://user-images.githubusercontent.com/1331659/70938584-786c0000-2014-11ea-94ca-efe74898ed83.jpg)
