### PR TITLE
Fix hover and focus CSS for manage menu in mobile devices

### DIFF
--- a/app/assets/stylesheets/avalon/_nav.scss
+++ b/app/assets/stylesheets/avalon/_nav.scss
@@ -138,23 +138,39 @@
   }
 }
 
+/* Manage menu in the nav-bar */
 .manage-btn {
   height: 50px;
-  font-size: 16px;
+  font-size: inherit;
   border: none;
   border-radius: 0px;
+  width: 100%;
+  text-align: left;
 }
 
 .manage-btn:hover {
   background-color: $yellow!important;
-}
-.manage-btn:focus {
-  background-color: $yellow;
+  color: $primaryDark;
 }
 
-.manage-dropwdown-menu {
-  border-radius: inherit;
+.manage-btn:focus {
+  background-color: $yellow;
+  color: $primaryDark;
+}
+
+.manage-dropdown-menu {
+  border: none;
   li {
     width: 100%;
+  }
+}
+
+.manage-dropdown {
+  width: 100%;
+}
+
+@media (max-width: $screen-xs-max) {
+  .manage-btn {
+    height: 40px;
   }
 }

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -42,11 +42,11 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% end %>
   <% if can?(:read, Admin::Collection) || can?(:manage, Admin::Group) || (defined?(Samvera::Persona) && can?(:manage, User)) %>
     <li>
-      <div class="btn-group" id="manage-dropdown">
-        <button id="manageDropdown" class="dropdown-toggle btn btn-primary manage-btn" data-toggle="dropdown">
+      <div class="btn-group manage-dropdown" id="manage-dropdown">
+        <button id="manageDropdown" class="btn btn-primary manage-btn" data-toggle="dropdown">
           Manage
         </button>
-        <ul class="dropdown-menu nav navbar-default navbar-nav manage-dropwdown-menu">
+        <ul class="dropdown-menu nav navbar-default navbar-nav manage-dropdown-menu">
           <% if can? :read, Admin::Collection %>
           <li class=<%= active_for_controller('admin/collections') %>>
             <%= link_to 'Manage Content', main_app.admin_collections_path %></li>


### PR DESCRIPTION
### Description

On mobile devices `Manage` menu link highlight does not span the full width of the list item.

![Screenshot from 2019-12-16 16-30-52](https://user-images.githubusercontent.com/1331659/70944739-aefc4780-2021-11ea-85e6-f706502c1620.png)

### Done Looks Like

When focused on `Manage` menu list item and its child items, the respective row gets highlighted.

![Screenshot from 2019-12-16 16-34-40](https://user-images.githubusercontent.com/1331659/70944881-f84c9700-2021-11ea-812e-75af3a705754.png)
