### PR TITLE
Cross check that usernames and emails are unique

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,8 +35,20 @@ class User < ActiveRecord::Base
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :email, presence: true, uniqueness: { case_sensitive: false }
+  validate :username_email_uniqueness
 
   before_destroy :remove_bookmarks
+
+  def username_email_uniqueness
+    if persisted?
+      errors.add(:email, :taken) if User.find_by_username(email) != self
+      errors.add(:username, :taken) if User.find_by_email(username) != self
+    else
+      errors.add(:email, :taken) if User.find_by_username(email)
+      errors.add(:username, :taken) if User.find_by_email(username)
+    end
+  end
+
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
   # the account.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,15 +15,47 @@
 require 'rails_helper'
 
 describe User do
-  subject {user}
-  let!(:user) {FactoryBot.build(:user)}
-  let!(:list) {0.upto(rand(5)).collect { Faker::Internet.email }}
+  subject { user }
+  let!(:user) { FactoryBot.build(:user) }
+  let!(:list) { 0.upto(rand(5)).collect { Faker::Internet.email } }
 
   describe "validations" do
     it {is_expected.to validate_presence_of(:username)}
     it {is_expected.to validate_uniqueness_of(:username).case_insensitive}
     it {is_expected.to validate_presence_of(:email)}
     it {is_expected.to validate_uniqueness_of(:email).case_insensitive}
+
+    context 'username and email uniqueness' do
+      let(:username) { Faker::Internet.username }
+      let(:email) { Faker::Internet.email }
+
+      context "using an already used email for a username" do
+        let!(:user) { FactoryBot.create(:user, username: username, email: email) }
+        let(:user2) { FactoryBot.build(:user, username: email) }
+        it "is invalid" do
+          expect(user2).not_to be_valid
+          expect(user2.errors[:username]).to include "is taken."
+        end
+      end
+
+      context "using an already used username for an email" do
+        let(:username) { Faker::Internet.email }
+        let!(:user) { FactoryBot.create(:user, username: username, email: email) }
+        let(:user2) { FactoryBot.build(:user, email: username) }
+        it "is invalid" do
+          expect(user2).not_to be_valid
+          expect(user2.errors[:email]).to include "is taken."
+        end
+      end
+
+      context "using email for username" do
+        let!(:user) { FactoryBot.create(:user, username: email, email: email) }
+        it "is valid" do
+          expect(user).to be_valid
+          expect(user.errors).to be_empty
+        end
+      end
+    end
   end
 
   describe "Membership" do


### PR DESCRIPTION
Fixes #3869 

This PR avoids this scenario by not allowing users to register accounts that have a username which matches an existing email address or an email address which matches an existing username.