### PR TITLE
No results alert flashes at initial load in Collections

### DIFF
--- a/app/assets/stylesheets/avalon/_nav.scss
+++ b/app/assets/stylesheets/avalon/_nav.scss
@@ -160,6 +160,7 @@
 
 .manage-dropdown-menu {
   border: none;
+  border-radius: inherit;
   li {
     width: 100%;
   }

--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -6,6 +6,7 @@ import CollectionsSortedByUnit from './collections/list/CollectionsSortedByUnit'
 import CollectionsSortedByAZ from './collections/list/CollectionsSortedByAZ';
 import CollectionsFilterNoResults from './collections/CollectionsFilterNoResults';
 import PropTypes from 'prop-types';
+import LoadingSpinner from './ui/LoadingSpinner';
 
 class CollectionList extends Component {
   constructor(props) {
@@ -15,7 +16,8 @@ class CollectionList extends Component {
       searchResult: [],
       filteredResult: [],
       maxItems: 3,
-      sort: 'unit'
+      sort: 'unit',
+      isLoading: false
     };
   }
 
@@ -35,13 +37,15 @@ class CollectionList extends Component {
   }
 
   async retrieveResults() {
+    this.setState({ isLoading: true });
     let url = this.props.baseUrl;
 
     try {
       const response = await Axios({ url });
       this.setState({
         searchResult: response.data,
-        filteredResult: this.filterCollections(this.state.filter, response.data)
+        filteredResult: this.filterCollections(this.state.filter, response.data),
+        isLoading: false
       });
     } catch (error) {
       console.log('Error in retrieveResults(): ', error);
@@ -89,7 +93,7 @@ class CollectionList extends Component {
   };
 
   render() {
-    const { filter, sort, filteredResult = [], maxItems } = this.state;
+    const { filter, sort, filteredResult = [], maxItems, isLoading } = this.state;
 
     return (
       <div>
@@ -99,8 +103,8 @@ class CollectionList extends Component {
           sort={sort}
           handleSortChange={this.handleSortChange}
         />
-
-        {filteredResult.length === 0 && <CollectionsFilterNoResults />}
+        {isLoading && <LoadingSpinner isLoading={isLoading} />}
+        {(filteredResult.length === 0 && !isLoading) && <CollectionsFilterNoResults />}
 
         <div className="collection-list">
           {sort === 'az' ? (

--- a/app/javascript/components/Search.js
+++ b/app/javascript/components/Search.js
@@ -126,10 +126,7 @@ class Search extends Component {
         </div>
         <div className="collection-search-results-wrapper">
           <LoadingSpinner isLoading={isLoading} />
-          <SearchResults
-            documents={searchResult.docs}
-            baseUrl={this.props.baseUrl}
-          />
+          {!isLoading && <SearchResults documents={searchResult.docs} baseUrl={this.props.baseUrl} />}
         </div>
       </div>
     );


### PR DESCRIPTION
At initial load both Collections Index and Landing pages shows the `No results returned for your search` alert, while waiting for data from the server. This results in a flashing alert in the page.

![ezgif com-video-to-gif (8)](https://user-images.githubusercontent.com/1331659/71024401-d4955980-20d2-11ea-8553-417827e8bad8.gif)

This PR fixes the flashing alert when loading the components.