### PR TITLE
Fix SME validation error message color

### DIFF
--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -93,7 +93,7 @@ $state-warning-border: $warning;
 $state-warning-text: $white;
 $state-danger-bg: $danger;
 $state-danger-border: $danger;
-$state-danger-text: $white;
+$state-danger-text: $danger;
 
 /* Header */
 $login-text-color: $gray;
@@ -107,7 +107,7 @@ $navCollapseWidth: 650px;
 
 /* Navbar */
 $navbar-default-bg: $primaryDark;
-$avbar-default-color: $white;
+$navbar-default-color: $white;
 $navbar-default-toggle-hover-bg: $yellow;
 $navbar-default-link-color: $white;
 $navbar-default-link-hover-color: $primaryDark;


### PR DESCRIPTION
SME uses `has-error` class to change the color of the input fields when there is a validation error. The `$state-danger-text` variable in `branding.css` is the variable used in `has-error` class.