### PR TITLE
Use id equivalence instead of object equivalence

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,8 +40,8 @@ class User < ActiveRecord::Base
   before_destroy :remove_bookmarks
 
   def username_email_uniqueness
-    errors.add(:email, :taken, value: email) if User.find_by_username(email) && User.find_by_username(email).id != self.id
-    errors.add(:username, :taken, valud: username) if User.find_by_email(username) && User.find_by_email(username).id != self.id
+    errors.add(:email, :taken, value: email) if User.find_by_username(email) && User.find_by_username(email).id != id
+    errors.add(:username, :taken, valud: username) if User.find_by_email(username) && User.find_by_email(username).id != id
   end
 
   # Method added by Blacklight; Blacklight uses #to_s on your

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,13 +40,8 @@ class User < ActiveRecord::Base
   before_destroy :remove_bookmarks
 
   def username_email_uniqueness
-    if persisted?
-      errors.add(:email, :taken) if User.find_by_username(email) != self
-      errors.add(:username, :taken) if User.find_by_email(username) != self
-    else
-      errors.add(:email, :taken) if User.find_by_username(email)
-      errors.add(:username, :taken) if User.find_by_email(username)
-    end
+    errors.add(:email, :taken, value: email) if User.find_by_username(email) && User.find_by_username(email).id != self.id
+    errors.add(:username, :taken, valud: username) if User.find_by_email(username) && User.find_by_email(username).id != self.id
   end
 
   # Method added by Blacklight; Blacklight uses #to_s on your

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,6 +55,18 @@ describe User do
           expect(user.errors).to be_empty
         end
       end
+
+      context "updating" do
+        let!(:user) { FactoryBot.create(:user, username: username, email: email) }
+        it "is valid" do
+          user.username = "new.username"
+          expect(user).to be_valid
+          expect(user.errors).to be_empty
+          user.email = "new.email@example.com"
+          expect(user).to be_valid
+          expect(user.errors).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Also refactor and add value to error messages.

I manually tested this on spruce and it works as expected now.
Finishes #3869 