### PR TITLE
Fix stacked actions in datatables

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -911,7 +911,7 @@ h5.panel-title {
 }
 
 
-/* DataTables in Playlists, Timelines, Encode Dashboard */
+/* DataTables in Playlists, Timelines, Persona Users, and Encode Dashboard */
 .dataTableToolsTop {
   text-align: right;
 }
@@ -922,10 +922,21 @@ h5.panel-title {
   }
 }
 
-/* Make table body scrollable in mobile devices */
+// Make table body scrollable in mobile devices
 @media (max-width: $screen-xs-max) {
   .dataTableBody {
     width: 100%;
     overflow-x: scroll;
   }
+}
+
+// Action column of each table
+#Playlists, #Timelines, #users-table {
+  td:last-child {
+    white-space: nowrap;
+  }
+}
+
+#users-table th, td{
+  padding-right: 6px !important;
 }

--- a/app/views/samvera/persona/users/index.html.erb
+++ b/app/views/samvera/persona/users/index.html.erb
@@ -45,65 +45,66 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 
   <div class="panel-body">
-    <div class="table-responsive">
-      <table id="users-table" class="table table-striped datatable">
-        <thead>
-          <tr>
-            <th><%= t('.id_label') %></th>
-            <th><%= t('.email_label') %></th>
-            <th><%= t('.role_label') %></th>
-            <th><%= t('.access_label') %></th>
-            <th><%= t('.status_label') %></th>
-            <% if User.column_names.include? 'provider' %>
-              <th><%= t('.auth_label') %></th>
-            <% end %>
-            <th><%= t('.action_label') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @presenter.users.each do |user| %>
-            <tr>
-              <td><%= link_to user.username, main_app.edit_persona_user_path(user) %></td>
-              <td><%= link_to user.email, main_app.edit_persona_user_path(user) %></td>
-              <td><% roles = @presenter.user_roles(user) %>
-                  <ul><% roles.each do |role| %>
-                    <li><%= role %></li>
-                    <% end %>
-                  </ul>
-              </td>
-              <td>
-                <%# in the case that a user is created who never signs in, this is necessary %>
-                <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
-                  <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
-                </relative-time>
-              </td>
-              <td><%= user.accepted_or_not_invited? ? t('.status.active') : t('.status.pending') %></td>
-              <% if user.has_attribute?(:provider) %>
-                <td>
-                  <%= user.provider %>
-                </td>
-                <% end %>
-              <td>
-                <% if user.has_attribute?(:provider) && !user.provider.nil? %>
-                  <span class="text-muted" data-toggle="tooltip" title="Edit user is unavailable because this user is single sign on"><%= t('.edit') %>&nbsp;|&nbsp;</span>
-                <% else %>
-                  <%= link_to t('.edit'), main_app.edit_persona_user_path(user) %>&nbsp;|&nbsp;
-                <% end %>
-                <%= link_to t('.become'), main_app.impersonate_persona_user_path(user.id), method: :post %>&nbsp;|&nbsp; 
-                <%= link_to t('.delete'), main_app.persona_user_path(user), class: 'btn btn-danger btn-xs action-delete', method: :delete, data: { confirm: t('.destroy.confirmation', user: user.email) } %>
-              </td>
-            </tr>
+    <table id="users-table" class="table table-striped datatable">
+      <thead>
+        <tr>
+          <th><%= t('.id_label') %></th>
+          <th><%= t('.email_label') %></th>
+          <th><%= t('.role_label') %></th>
+          <th><%= t('.access_label') %></th>
+          <th><%= t('.status_label') %></th>
+          <% if User.column_names.include? 'provider' %>
+            <th><%= t('.auth_label') %></th>
           <% end %>
-        </tbody>
-      </table>
-    </div>
+          <th class="text-right" data-orderable="false"><%= t('.action_label') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @presenter.users.each do |user| %>
+          <tr>
+            <td><%= link_to user.username, main_app.edit_persona_user_path(user) %></td>
+            <td><%= link_to user.email, main_app.edit_persona_user_path(user) %></td>
+            <td><% roles = @presenter.user_roles(user) %>
+                <ul><% roles.each do |role| %>
+                  <li><%= role %></li>
+                  <% end %>
+                </ul>
+            </td>
+            <td>
+              <%# in the case that a user is created who never signs in, this is necessary %>
+              <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+                <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+              </relative-time>
+            </td>
+            <td><%= user.accepted_or_not_invited? ? t('.status.active') : t('.status.pending') %></td>
+            <% if user.has_attribute?(:provider) %>
+              <td>
+                <%= user.provider %>
+              </td>
+            <% end %>
+            <td>
+              <% if user.has_attribute?(:provider) && !user.provider.nil? %>
+                <span class="text-muted" data-toggle="tooltip" title="Edit user is unavailable because this user is single sign on"><%= t('.edit') %>&nbsp;|&nbsp;</span>
+              <% else %>
+                <%= link_to t('.edit'), main_app.edit_persona_user_path(user) %>&nbsp;|&nbsp;
+              <% end %>
+              <%= link_to t('.become'), main_app.impersonate_persona_user_path(user.id), method: :post %>&nbsp;|&nbsp; 
+              <%= link_to t('.delete'), main_app.persona_user_path(user), class: 'btn btn-danger btn-xs action-delete', method: :delete, data: { confirm: t('.destroy.confirmation', user: user.email) } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>
 
 <% content_for :page_scripts do %>
   <script>
     $(document).ready( function () {
-      $('#users-table').DataTable();
+      $('#users-table').DataTable({
+        dom: '<"dataTableToolsTop"lf><"dataTableBody"t><"dataTableToolsBottom"ip>',
+        autoWidth: true
+      });
     });
   </script>
 <% end %>


### PR DESCRIPTION
This was happening in all table, when the `Actions` column get smaller (this happens automatically). But only seen in `Manage Users` table in Spruce. This PR contains CSS to hold all the action buttons in the same line when the column gets smaller.