### PR TITLE
Change CSS based on the homepage selection

### DIFF
--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -46,8 +46,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 
         <!-- Homepage -->
         <% if current_page?(main_app.root_path) %>
-        <%= render 'modules/flash_messages' %>
-        <%= yield %>
+          <div class="<%= "container" unless Settings.home_page.present? %>">
+            <%= render 'modules/flash_messages' %>
+            <%= yield %>
+          </div>
         <% end %>
 
         <!-- All other pages -->

--- a/app/views/modules/_footer.html.erb
+++ b/app/views/modules/_footer.html.erb
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<div id="footer" class="<%= "homepage-footer" if current_page?(main_app.root_path) %>">
+<div id="footer" class="<%= "homepage-footer" if (current_page?(main_app.root_path) && Settings.home_page.present?) %>">
 
   <footer class="container">
     <div class="separator"></div>


### PR DESCRIPTION
Change CSS on homepage container and footer based on the homepage selection.
When the old homepage is in use, to be consistent with the other pages the content should be sitting in the middle, while the new homepage stretches to the entire width of the screen. 
And the footer needs to be changed based on the homepage design

Old design:
![Screenshot from 2020-01-03 15-11-41](https://user-images.githubusercontent.com/1331659/71746666-7a6af700-2e3b-11ea-9aa2-2602972e55c6.png)

New design:
![Screenshot from 2020-01-03 15-12-27](https://user-images.githubusercontent.com/1331659/71746665-7a6af700-2e3b-11ea-8892-945c6697781d.png)