### PR TITLE
Fix time float position in MEJS player

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1744,13 +1744,13 @@ Object.assign(_player2.default.prototype, {
 						}
 
 						t.timefloat.style.left = leftPos + 'px';
+						t.timefloat.style.bottom = '3px';
 						t.timefloatcurrent.innerHTML = (0, _time.secondsToTimeCode)(t.newTime, player.options.alwaysShowHours, player.options.showTimecodeFrameCount, player.options.framesPerSecond, player.options.secondsDecimalLength, player.options.timeFormat);
 						t.timefloat.style.display = 'block';
 					}
 				}
 			} else if (!_constants.IS_IOS && !_constants.IS_ANDROID && t.timefloat) {
 				leftPos = t.timefloat.offsetWidth + width >= t.getElement(t.container).offsetWidth ? t.timefloat.offsetWidth / 2 : 0;
-				t.timefloat.style.left = leftPos + 'px';
 				t.timefloat.style.left = leftPos + 'px';
 				t.timefloat.style.bottom = '3px';
 				t.timefloat.style.display = 'block';

--- a/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
+++ b/vendor/assets/stylesheets/mediaelement/mediaelementplayer.scss
@@ -437,7 +437,6 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__time-float {
     background: #eee;
     border: solid 1px #333;
-    bottom: 100%;
     color: #111;
     display: none;
     height: 14px;


### PR DESCRIPTION
Pop-over time label for the embedded player from mallorn still gets cut as follows;
![Screenshot from 2020-01-07 14-47-08](https://user-images.githubusercontent.com/1331659/71924457-0d1dd580-315d-11ea-8f84-f5168a1926c7.jpg)

Because the style application in JS for `mejs__time-float` (`bottom` CSS property) from [#3839](https://github.com/avalonmediasystem/avalon/pull/3839) is overridden by the styles in in CSS files. This does not happen in local development environment.

** Need to test this once it is on Spruce.