### PR TITLE
SME with support accepted time formats, ss(.ss), mm:ss(.ss), hh:mm:ss(.ss)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4680,11 +4680,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdir
   dependencies:
     minimist "0.0.8"
 
-moment@^2.22.2:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -6362,7 +6357,7 @@ react-redux@^6.0.0:
 
 "react-structural-metadata-editor@https://github.com/avalonmediasystem/react-structural-metadata-editor":
   version "1.1.0"
-  resolved "https://github.com/avalonmediasystem/react-structural-metadata-editor#0790e709102bd4878e4a45d79f4e3dfd501a32f7"
+  resolved "https://github.com/avalonmediasystem/react-structural-metadata-editor#2ad6225343776e499d37c8cdc5f8581e8a2b76e6"
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@fortawesome/fontawesome-svg-core" "^1.2.4"
@@ -6374,7 +6369,6 @@ react-redux@^6.0.0:
     base-64 "^0.1.0"
     hls.js "0.12.3-canary.4258"
     lodash "4.17.13"
-    moment "^2.22.2"
     peaks.js "0.10.1"
     prop-types "^15.6.2"
     react-bootstrap "^0.32.4"


### PR DESCRIPTION
Changes in this PR:
1. Support for hh:mm:ss(.ss), mm:ss(.ss), and ss(.ss) time formats
2. Removed moment.js dependency
3. Quick fix for timespan validation when dragging handles in waveform