### PR TITLE
From IU customization

### DIFF
--- a/app/assets/javascripts/dynamic_fields.js.coffee
+++ b/app/assets/javascripts/dynamic_fields.js.coffee
@@ -14,8 +14,8 @@
 
 
 $ ->
-  add_button_html = '<div class="input-group-btn"><button type="button" class="add-dynamic-field btn btn-success"><span class="glyphicon glyphicon-plus"></span></button></div>'
-  remove_button_html = '<div class="input-group-btn"><button type="button" class="remove-dynamic-field btn btn-success"><span class="glyphicon glyphicon-minus"></span></button></div>'
+  add_button_html = '<div class="input-group-btn"><button type="button" class="add-dynamic-field btn btn-default btn-light"><span class="glyphicon glyphicon-plus"></span></button></div>'
+  remove_button_html = '<div class="input-group-btn"><button type="button" class="remove-dynamic-field btn btn-default btn-light"><span class="glyphicon glyphicon-minus"></span></button></div>'
   
   $('.form-group.multivalued').each ->
       t = $(this)

--- a/app/assets/javascripts/import_button.js.coffee
+++ b/app/assets/javascripts/import_button.js.coffee
@@ -15,7 +15,7 @@
 
 $ ->
   form = $('div.import-button').closest('form').prop('id')
-  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-success" value="yes" >Import</button></div>'
+  import_button_html = '<div class="input-group-btn"><button id="media_object_bibliographic_id_btn" type="submit" name="media_object[import_bib_record]" class="btn btn-default btn-light" value="yes" >Import</button></div>'
   $('div.import-button').append(import_button_html)
   enable_bib_btn()
   $('#media_object_bibliographic_id').keyup -> enable_bib_btn()

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -951,3 +951,7 @@ h5.panel-title {
   margin: 20px 0 0 5px;
   clear: both;
 }
+
+.btn-light {
+  background-color: $btn-light-bg;
+}

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -102,10 +102,8 @@ div.alert-danger {
 // Page title area (because looks like we're sneaking in
 // buttons, and other stuff horizontally positioned alongside title
 .page-title-wrapper {
-  margin-bottom: 2rem;
-
-  .headline-button {
-    margin-top: 20px;
+  h3 {
+    margin-top: 0;
   }
 }
 
@@ -947,4 +945,9 @@ h5.panel-title {
 
 #users-table th, td{
   padding-right: 6px !important;
+}
+
+.create-buttons {
+  margin: 20px 0 0 5px;
+  clear: both;
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -776,6 +776,10 @@ h5.panel-title {
   }
 }
 
+.mediaobject-filename {
+  word-break: break-all;
+}
+
 // Fixes the input displaying over the dropdown datepicker calendar
 .fileinput {
   position: relative;

--- a/app/assets/stylesheets/avalon/_playlists.scss
+++ b/app/assets/stylesheets/avalon/_playlists.scss
@@ -165,6 +165,14 @@
   }
 }
 
+#playlist_view_div {
+  .dl-horizontal {
+    dd {
+      margin-bottom: 5px;
+    }
+  }
+}
+
 /* Playlist show page */
 .queue {
   opacity: 0.8;

--- a/app/assets/stylesheets/avalon/_playlists.scss
+++ b/app/assets/stylesheets/avalon/_playlists.scss
@@ -20,11 +20,6 @@
   }
 }
 
-// Data table applied class
-#Playlists_wrapper {
-  margin-bottom: 2rem;
-}
-
 .playlist-details-headline-wrapper {
   margin: 3rem 0 1rem;
   display: flex;

--- a/app/assets/stylesheets/avalon/_timeliner.scss
+++ b/app/assets/stylesheets/avalon/_timeliner.scss
@@ -28,3 +28,9 @@
 #Timelines_paginate {
   float: right;
 }
+
+.timeliner-contianer {
+  left: 0;
+  right: 0;
+  position: absolute;
+}

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -144,6 +144,7 @@ $btn-info-color: $primaryDark;
 $btn-info-bg: $info;
 $btn-info-border: $info;
 $btn-danger-color: $white;
+$btn-light-bg: $lightgray;
 
 /* Pagination */
 $pagination-color: $link-color;

--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -31,7 +31,7 @@ class CollectionList extends Component {
       filter: props.filter ? props.filter : '',
       searchResult: [],
       filteredResult: [],
-      maxItems: 3,
+      maxItems: 4,
       sort: 'unit',
       isLoading: false
     };

--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -108,6 +108,10 @@ class CollectionList extends Component {
     this.setState({ sort: val });
   };
 
+  handleSubmit = event => {
+    event.preventDefault();
+  }
+
   render() {
     const { filter, sort, filteredResult = [], maxItems, isLoading } = this.state;
 
@@ -118,6 +122,7 @@ class CollectionList extends Component {
           handleFilterChange={this.handleFilterChange}
           sort={sort}
           handleSortChange={this.handleSortChange}
+	  handleSubmit={this.handleSubmit}
         />
         {isLoading && <LoadingSpinner isLoading={isLoading} />}
         {(filteredResult.length === 0 && !isLoading) && <CollectionsFilterNoResults />}

--- a/app/javascript/components/Search.js
+++ b/app/javascript/components/Search.js
@@ -48,6 +48,10 @@ class Search extends Component {
     this.setState({ query: event.target.value, currentPage: 1 });
   };
 
+  handleSubmit = event => {
+    event.preventDefault();
+  }
+
   componentDidMount() {
     this.retrieveResults();
   }
@@ -123,7 +127,7 @@ class Search extends Component {
     return (
       <div className="search-wrapper">
         <div className="row">
-          <form className="search-bar col-sm-6 col-sm-offset-3">
+          <form onSubmit={this.handleSubmit} className="search-bar col-sm-6 col-sm-offset-3">
             <label htmlFor="q" className="sr-only">
               search for
             </label>

--- a/app/javascript/components/Search.js
+++ b/app/javascript/components/Search.js
@@ -148,6 +148,11 @@ class Search extends Component {
           <LoadingSpinner isLoading={isLoading} />
           {!isLoading && <SearchResults documents={searchResult.docs} baseUrl={this.props.baseUrl} />}
         </div>
+        <div className="collection-landing-pagination-wrapper">
+          { searchResult.pages.total_count > searchResult.pages.limit_value && 
+              <Pagination pages={searchResult.pages} changePage={this.changePage} />
+          }
+        </div>
       </div>
     );
   }

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -46,7 +46,8 @@
   height: 375px;
   overflow: hidden;
 
-  @media screen and (max-width: 780px) {
+  // For smaller screens
+  @media screen and (max-width: 767px) {
     height: auto;
   }
 

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -43,7 +43,7 @@
 
 /* Collection cards */
 .collection-card {
-  height: 475px;
+  height: 375px;
   overflow: hidden;
 
   @media screen and (max-width: 780px) {
@@ -63,7 +63,11 @@
 }
 
 .collection-card-description {
-  padding: 2rem 0;
+  padding: 0;
+
+  .italic {
+    font-style: italic;
+  }
 }
 
 .search-within-facets {

--- a/app/javascript/components/collections/landing/SearchResults.js
+++ b/app/javascript/components/collections/landing/SearchResults.js
@@ -31,7 +31,7 @@ const SearchResults = ({ documents = [], baseUrl }) => {
   return (
     <ul className="row list-unstyled search-within-search-results">
       {documents.map((doc, index) => (
-        <li key={doc.id} className="col-sm-4">
+        <li key={doc.id} className="col-sm-3">
           <SearchResultsCard doc={doc} index={index} baseUrl={baseUrl} />
         </li>
       ))}

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -94,7 +94,8 @@ const SearchResultsCard = props => {
         <>
           <h4>
             <a href={baseUrl + 'media_objects/' + doc['id']}>
-              {doc['title_tesi'] || doc['id']}
+              { doc['title_tesi'] && doc['title_tesi'].substring(0, 50) || doc['id'] }
+              { doc['title_tesi'] && doc['title_tesi'].length >= 50 && <span>...</span> }
             </a>
           </h4>
           <dl id={'card-body-' + index} className="card-text dl-horizontal">

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -25,8 +25,8 @@ const CardMetaData = ({ doc, fieldLabel, fieldName }) => {
   if (Array.isArray(doc[fieldName]) && doc[fieldName].length > 1) {
     metaData = doc[fieldName].join(', ');
   } else if (typeof doc[fieldName] == 'string') {
-    const summary = doc[fieldName].substring(0, 30);
-    metaData = doc[fieldName].length >= 30 ? `${summary}...` : doc[fieldName];
+    const summary = doc[fieldName].substring(0, 50);
+    metaData = doc[fieldName].length >= 50 ? `${summary}...` : doc[fieldName];
   } else {
     metaData = doc[fieldName];
   }

--- a/app/javascript/components/collections/list/CollectionCard.js
+++ b/app/javascript/components/collections/list/CollectionCard.js
@@ -35,7 +35,10 @@ const CollectionCard = ({ attributes, showUnit }) => {
       </CollectionCardThumbnail>
       <CollectionCardBody>
         <h4>
-          <a href={attributes.url}>{attributes.name}</a>
+          <a href={attributes.url}>
+            {attributes.name.substring(0, 50)}
+            {attributes.name.length >= 50 && <span>...</span>}
+          </a>
         </h4>
         <dl>
           { showUnit && <dt>Unit</dt> && 
@@ -47,8 +50,8 @@ const CollectionCard = ({ attributes, showUnit }) => {
           {attributes.description && (
             <div>
               <dd>
-                {attributes.description.substring(0, 200)}
-                {attributes.description.length >= 200 && <span>...</span>}
+                {attributes.description.substring(0, 100)}
+                {attributes.description.length >= 100 && <span>...</span>}
               </dd>
             </div>
           )}

--- a/app/javascript/components/collections/list/CollectionCard.js
+++ b/app/javascript/components/collections/list/CollectionCard.js
@@ -22,6 +22,8 @@ import CollectionCardThumbnail from '../CollectionCardThumbnail';
 import CollectionCardBody from '../CollectionCardBody';
 
 const CollectionCard = ({ attributes, showUnit }) => {
+  const unitName = attributes.description ? attributes.unit.substring(0, 30) : attributes.unit;
+  const ellipsis = attributes.description ? <span>...</span> : null;
   return (
     <CollectionCardShell>
       <CollectionCardThumbnail>
@@ -36,7 +38,12 @@ const CollectionCard = ({ attributes, showUnit }) => {
           <a href={attributes.url}>{attributes.name}</a>
         </h4>
         <dl>
-          {showUnit && <dt>Unit</dt> && <dd>{attributes.unit}</dd>}
+          { showUnit && <dt>Unit</dt> && 
+            <dd className="italic">
+              {unitName}
+              {attributes.unit.length >= 30 && ellipsis}
+            </dd>
+          }
           {attributes.description && (
             <div>
               <dd>

--- a/app/javascript/components/collections/list/CollectionListStickyUtils.js
+++ b/app/javascript/components/collections/list/CollectionListStickyUtils.js
@@ -21,12 +21,13 @@ const CollectionListStickyUtils = ({
   filter,
   handleFilterChange,
   handleSortChange,
+  handleSubmit,
   sort
 }) => {
   return (
     <section className="row stickyUtils collection-list-sticky-utils">
       <div className="col-sm-6">
-        <form>
+        <form onSubmit={handleSubmit}>
           <div className="form-group">
             <label htmlFor="q" className="sr-only">
               search for
@@ -73,6 +74,7 @@ CollectionListStickyUtils.propTypes = {
   filter: PropTypes.string,
   handleFilterChange: PropTypes.func,
   handleSortChange: PropTypes.func,
+  handleSubmit: PropTypes.func,
   sort: PropTypes.string
 };
 

--- a/app/javascript/components/collections/list/CollectionsSortedByAZ.js
+++ b/app/javascript/components/collections/list/CollectionsSortedByAZ.js
@@ -23,7 +23,7 @@ const CollectionsSortedByAZ = ({ sortByAZ, filteredResult }) => {
     <ul className="row list-unstyled">
       {sortByAZ(filteredResult).map(col => {
         return (
-          <li className="col-sm-4" key={col.id}>
+          <li className="col-sm-3" key={col.id}>
             <CollectionCard attributes={col} showUnit={true} />
           </li>
         );

--- a/app/javascript/components/collections/list/Unit.js
+++ b/app/javascript/components/collections/list/Unit.js
@@ -36,7 +36,7 @@ const CollectionsListUnit = ({ unitArr, index, sortByAZ, maxItems }) => {
       <div className="row">
         {collections.slice(0, maxItems).map(col => {
           return (
-            <div className="col-sm-4" key={col.id}>
+            <div className="col-sm-3" key={col.id}>
               <CollectionCard attributes={col} showUnit={false} />
             </div>
           );
@@ -47,7 +47,7 @@ const CollectionsListUnit = ({ unitArr, index, sortByAZ, maxItems }) => {
         <div className="row" id="collections-list-remaining-collections">
           {collections.slice(maxItems, collections.length).map(col => {
             return (
-              <div className="col-sm-4" key={col.id}>
+              <div className="col-sm-3" key={col.id}>
                 <CollectionCard attributes={col} showUnit={false} />
               </div>
             );

--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -70,9 +70,9 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
   # Calcuates the mediafragment_uri based on either the internal fragment value or start and end times
   # @return [String] the uri with time bounding
   def mediafragment_uri
-    master_file.rdf_uri + "?#{internal.fragment_value.object}"
+    "#{master_file&.rdf_uri}?#{internal.fragment_value.object}"
   rescue
-    master_file.rdf_uri + "?t=#{start_time},#{end_time}"
+    "#{master_file&.rdf_uri}?t=#{start_time},#{end_time}"
   end
 
 end

--- a/app/views/bookmarks/update_access_control.html.erb
+++ b/app/views/bookmarks/update_access_control.html.erb
@@ -80,8 +80,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= text_field_tag "user_display", nil,
         class: "typeahead from-model form-control",
         data: { model: 'user', target: "user" } %><br>
-            <%= text_field_tag "add_user_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-            <%= text_field_tag "add_user_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+            <%= text_field_tag "add_user_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %><br>
+            <%= text_field_tag "add_user_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %>
           </div>
           <%= button_tag "Add", name: 'submit_add_user', class:'btn btn-default', value: 'Add' %>
           <%= button_tag "Remove", name: 'submit_remove_user', class:'btn btn-default remove_access', value: 'Remove' %>
@@ -93,8 +93,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= select_tag "group",
         dropdown_values,
         { include_blank: true, class: "form-control"}%><br>
-            <%= text_field_tag "add_group_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-            <%= text_field_tag "add_group_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+            <%= text_field_tag "add_group_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %><br>
+            <%= text_field_tag "add_group_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %>
           <%= button_tag "Add", name: 'submit_add_group', class:'btn btn-default', value: 'Add'  %>
           <%= button_tag "Remove", name: 'submit_remove_group', class:'btn btn-default remove_access', value: 'Remove' %>
         <% end %>
@@ -105,8 +105,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= text_field_tag "class_display", nil,
         class: "typeahead from-model form-control",
         data: { model: 'externalGroup', target: "class" } %><br>
-            <%= text_field_tag "add_class_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-            <%= text_field_tag "add_class_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+            <%= text_field_tag "add_class_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %><br>
+            <%= text_field_tag "add_class_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %>
           </div>
           <%= button_tag "Add", name: 'submit_add_class', class:'btn btn-default', value: 'Add'  %>
           <%= button_tag "Remove", name: 'submit_remove_class', class:'btn btn-default remove_access', value: 'Remove' %>
@@ -115,8 +115,8 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= render partial: "modules/tooltip", locals: { form: form, field: 'ipaddress', tooltip: t("access_control.ipaddress"), options: {display_label: t("access_control.ipaddresslabel").html_safe} } %>
           <div style='display:inline-block;top:1px;position:relative;'>
           <%= text_field_tag "ipaddress", nil, class: "form-control" %><br>
-            <%= text_field_tag "add_ipaddress_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %><br>
-            <%= text_field_tag "add_ipaddress_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date' %>
+            <%= text_field_tag "add_ipaddress_begin", nil, placeholder: 'Begin Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %><br>
+            <%= text_field_tag "add_ipaddress_end", nil, placeholder: 'End Date (yyyy-mm-dd)', class: 'form-control date-input access_date', autocomplete: 'off' %>
           </div>
           <%= button_tag "Add", name: 'submit_add_ipaddress', class:'btn btn-default', value: 'Add'  %>
           <%= button_tag "Remove", name: 'submit_remove_ipaddress', class:'btn btn-default remove_access', value: 'Remove' %>

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -64,7 +64,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <i class="fa fa-question-sign"></i>
                 <% end %>
               </span>
-              <span><%= truncate_center(File.basename(part.file_location.to_s), 50, 20) %></span>
+              <span class="mediaobject-filename"><%= truncate_center(File.basename(part.file_location.to_s), 50, 20) %></span>
               <span><%= number_to_human_size(part.file_size) %></span>
             </div>
             <div class="col-sm-6 right">

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -24,10 +24,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       <% end %>
     </div>
     <div class="panel-body">
-      <p>
-        <%= "/ #{@media_object.statement_of_responsibility}" if @media_object.statement_of_responsibility.present? %>
-      </p>
-
       <dl id="creation_metadata">
         <%= display_metadata('Date', combined_display_date(@media_object), 'Not provided') %>
         <%= display_metadata('Main contributor', @media_object.creator) %>

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -45,7 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <li>
           <%= section.title.blank? ? '&#8212;'.html_safe : section.title %>
         </li>
-        <li>
+        <li class="mediaobject-filename">
           <% if section.file_location.present? %>
           <%= truncate_center(File.basename(section.file_location.to_s), 50, 20) %>
           <% else %>

--- a/app/views/media_objects/show.html.erb
+++ b/app/views/media_objects/show.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div class="page-title-wrapper">
   <h1>
     <% unless @media_object.title.blank? %>
-    <%= @media_object.title %>
+    <%= @media_object.title %><%= " / #{@media_object.statement_of_responsibility}" if @media_object.statement_of_responsibility.present? %>
     <% else %>
     <%= @media_object.id %>
     <% end %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<div class="col-md-9">
+<div class="col-md-12">
   <div>
     <%= link_to "View Playlist", @playlist, { class: 'btn btn-primary'} %>
     <% if can?(:destroy, @playlist) %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -32,7 +32,13 @@ Unless required by applicable law or agreed to in writing, software distributed
       <dt><%=t("activerecord.attributes.playlist.title")%></dt>
       <dd><%= @playlist.title %></dd>
       <dt><%= t("activerecord.attributes.playlist.comment") %></dt>
-      <dd><%= @playlist.comment %></dd>
+      <dd>
+        <% if @playlist.comment.empty? %>
+        <span class="info-text-gray">No description</span>
+        <% else %>
+        <%= @playlist.comment %>
+        <% end %>
+      </dd>
       <dt><%= t("playlist.visibility") %></dt>
       <dd>
         <%= human_friendly_visibility @playlist.visibility %> -
@@ -61,7 +67,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <dt><%= t("playlist.tags.label") %></dt>
       <dd>
         <% if @playlist.tags.empty? %>
-        <p class="info-text-gray">No tags</p>
+        <span class="info-text-gray">No tags</span>
         <% end %>
         <% @playlist.tags.each do |tag| %>
         <span class="btn btn-xs btn-info"><%=tag%></span>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -25,9 +25,18 @@ Unless required by applicable law or agreed to in writing, software distributed
         <div class="col-sm-6">
           <h1 class="page-title">Playlists <small>(<%= playlists.size %> total)</small></h1>
         </div>
-        <div class="col-sm-6 text-right">
-          <%= link_to('<span class="btn btn-primary headline-button">Create New Playlist</span>'.html_safe, new_playlist_path) %>
-        </div>
+          <div class="<% if !playlists.empty? %>col-sm-6 text-right<% end %>">
+            <div class="create-buttons">
+              <%= link_to('<span class="btn btn-primary headline-button">Create New Playlist</span>'.html_safe, new_playlist_path) %>
+              <% if Settings['variations'].present? %>
+                <%= form_tag(import_variations_playlist_playlists_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
+                  <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
+                  <input type="button" class="btn btn-primary outline_on" id="variations_import"
+                    onclick="$(this).closest('form').find('.filedata').click();" value="Import Variations Playlist" />
+                <% end %>
+              <% end %>
+            </div>
+          </div>
       </div>
     </div>
 
@@ -55,19 +64,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <tbody>
         </tbody>
       </table>
-      <div> </div>
     <% end %>
-    <div>
-      <%# pass body to link_to to avoid block form of link_to which creates an odd underline that overflows the button %>
-
-      <% if Settings['variations'].present? %>
-      <%= form_tag(import_variations_playlist_playlists_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
-      <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
-      <input type="button" class="btn btn-primary outline_on" id="variations_import"
-        onclick="$(this).closest('form').find('.filedata').click();" value="Import Variations Playlist" />
-      <% end %>
-      <% end %>
-    </div>
   </div>
   <% unless !playlists.empty? %>
   <% end %>

--- a/app/views/timelines/_form.html.erb
+++ b/app/views/timelines/_form.html.erb
@@ -95,7 +95,8 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="row">
     <div class="col-sm-offset-2 col-sm-10">
       <div>
-        <%= f.submit id: 'submit-timeline-form', class: 'btn btn-primary btn-xs', value: t("timeline.#{params[:action]}.action") %>
+        <%= f.submit id: 'submit-timeline-form', class: 'btn btn-primary', value: t("timeline.#{params[:action]}.action") %>
+        <a id="timeline-edit-cancel" class="btn btn-default" href="/timelines">Cancel</a>
       </div>
     </div>
   </div>

--- a/app/views/timelines/_show_timeline_details.html.erb
+++ b/app/views/timelines/_show_timeline_details.html.erb
@@ -16,9 +16,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div class="col-md-9">
   <div class="row">
     <div class="col-sm-12">
-      <%= link_to "View Timeline", @timeline, { class: 'btn btn-xs btn-primary' } %>
+      <%= link_to "View Timeline", @timeline, { class: 'btn btn-primary' } %>
       <% if can?(:destroy, @timeline) %>
-        <%= link_to "Delete Timeline", @timeline, method: :delete, class: 'btn btn-xs btn-danger btn-confirmation', data: {placement: 'bottom'} %>
+        <%= link_to "Delete Timeline", @timeline, method: :delete, class: 'btn btn-link btn-confirmation', data: {placement: 'bottom'} %>
       <% end %>
     </div>
   </div>

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -20,37 +20,14 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% timelines = Timeline.where(user_id: current_user.id) %>
   <div class="container-fluid">
     <div class="row">
-      <div class="container">
-        <div class="Timeline-index">
+      <div class="Timeline-index">
+        <div class="page-title-wrapper">
           <div class="row">
-            <div>
-              <h1 class=>Timelines <small>(<%= timelines.size %> total)</small></h1>
-              <% unless timelines.empty? %>
-                <div class="tag_filter_container">
-                  Filter: <select name="tag_filter" class="tag_filter form-control input-sm" style="width:auto">
-                    <option value="" selected="selected"></option>
-                    <% current_user.timeline_tags.each do |tag| %>
-                      <option value="<%= tag %>"><%= tag %></option>
-                    <% end %>
-                  </select>
-                </div>
-                <table id="Timelines" class="table table-striped">
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Description</th>
-                      <th>Visibility</th>
-                      <th>Last Updated</th>
-                      <th>Tags</th>
-                      <th class="text-right" data-orderable="false">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                  </tbody>
-                </table>
-                <div> </div>
-              <% end %>
-              <div>
+            <div class="col-sm-6">
+              <h1 class="page-title">Timelines <small>(<%= timelines.size %> total)</small></h1>
+            </div>
+            <div class="<% if !timelines.empty? %>col-sm-6 text-right<% end %>">
+              <div class="create-buttons">
                 <% if Settings['variations'].present? %>
                   <%= form_tag(import_variations_timeline_timelines_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
                     <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
@@ -60,6 +37,33 @@ Unless required by applicable law or agreed to in writing, software distributed
               </div>
             </div>
           </div>
+        </div>
+        <div>
+          <% unless timelines.empty? %>
+            <div class="tag_filter_container">
+              Filter: <select name="tag_filter" class="tag_filter form-control input-sm" style="width:auto">
+                <option value="" selected="selected"></option>
+                <% current_user.timeline_tags.each do |tag| %>
+                  <option value="<%= tag %>"><%= tag %></option>
+                <% end %>
+              </select>
+            </div>
+            <table id="Timelines" class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Description</th>
+                  <th>Visibility</th>
+                  <th>Last Updated</th>
+                  <th>Tags</th>
+                  <th class="text-right" data-orderable="false">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+            </table>
+            <div> </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -13,6 +13,15 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<div class="embed-responsive embed-responsive-16by9" id="content" style="max-width: 100%;">
+<div class="embed-responsive embed-responsive-16by9 timeliner-contianer" id="content" style="max-width: 100%;">
     <iframe class="embed-responsive-item" src="<%= @timeliner_iframe_url %>"></iframe>
 </div>
+
+<% content_for :page_scripts do %>
+  <script>
+    $(document).ready(function () {
+      // Push footer to the bottom of the page content
+      $('.footer-container').css('top', $(this).height());
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
Following is a list of commits that were omitted in this PR;

1. Set timeliner to full width
2. Fix VOV-6089: Unnecessary scrollbar in smaller window (this horizontal scrollbar was introduced by the IU header and footer customization)
3. VOV-6092: tighten up collection cards
4. Make field buttons on resource description be gray
5. Show full unit name in AZSort view when no description available
6. Upgrage axios to deal with false XSS warning bug
7. Use new persona-aware method for creating a new user
8. Show physical format facet
9. Use 4 columns instead of 3 in Collections