### PR TITLE
Save hls_url if present

### DIFF
--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -110,6 +110,9 @@ class Derivative < ActiveFedora::Base
 
     # FIXME: Transform to stream url here? How do we distribute to the streaming server?
     derivative.location_url = output[:url]
+    # For Intercom push
+    derivative.hls_url = output[:hls_url] if output[:hls_url].present?
+
     derivative.absolute_location = output[:url]
 
     derivative


### PR DESCRIPTION
This line was removed from avalon 7 as part of the transcoding backend
switch to newer active_encode with ffmpeg adapter instead of matterhorn.
It is reinserted here to avoid breaking streaming of intercom pushed
items that are not managed streams.  In this case hls_url isn't being
set and location_url is the rtmp url because setStreamingLocations isn't
setting it because the derivative is unmanaged.  In the end the item is
not streamable since it doesn't have an HLS url and only an RTMP url.
It would be good to switch to get rid of the need for two separate
fields for RTMP and HLS streaming urls but it would require a larger
refactoring of the code and possibly a data migration which probably
isn't worth it at this stage.

Fixes VOV-6113.