### PR TITLE
Use if/elsif instead of ||= with guard clause

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -101,9 +101,14 @@ module MasterFileBehavior
   end
 
   def display_title
-    mf_title = structuralMetadata.section_title if has_structuralMetadata?
-    mf_title ||= title if title.present?
-    mf_title ||= file_location.split("/").last if file_location.present? && (media_object.master_file_ids.size > 1)
+    mf_title = if has_structuralMetadata?
+                 structuralMetadata.section_title
+               elsif title.present?
+                 title
+               # FIXME: The test for media_object.master_file_ids.size is expensive and takes ~0.25 seconds
+               elsif file_location.present? && (media_object.master_file_ids.size > 1)
+                 file_location.split("/").last
+               end
     mf_title.blank? ? nil : mf_title
   end
 

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -22,9 +22,14 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
   end
 
   def display_title
-    mf_title = structuralMetadata.section_title if has_structuralMetadata?
-    mf_title ||= title if title.present?
-    mf_title ||= file_location.split("/").last if file_location.present? && (media_object.master_file_ids.size > 1)
+    mf_title = if has_structuralMetadata?
+                 structuralMetadata.section_title
+               elsif title.present?
+                 title
+               # FIXME: The test for media_object.master_file_ids.size is expensive and takes ~0.25 seconds
+               elsif file_location.present? && (media_object.master_file_ids.size > 1)
+                 file_location.split("/").last
+               end
     mf_title.blank? ? nil : mf_title
   end
 end


### PR DESCRIPTION
The previous version needlessly required that all guard clauses run even when a
prior line had matched and initialized mf_title.  Switching to explicit
if/elsif allows for early breaking.  This switch helps speed up the view
page of an item with hundreds of sections by avoiding the third case of
file_location which turns out to be expensive (~0.25s).  

Making this change resulted in `gather_all_comments` for this item running under 2s as opposed to 360s before the change.