### PR TITLE
Don't sort user playlists before using them in paged_index since it does all of the sorting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
        environment:
          - POSTGRES_USER=postgres
          - POSTGRES_DB=avalon
+         - POSTGRES_PASSWORD=password
      - image: ualbertalib/docker-fcrepo4:4.7
        environment:
          CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -271,7 +271,7 @@ class PlaylistsController < ApplicationController
   private
 
   def get_user_playlists
-    @playlists = Playlist.by_user(current_user).order(:title)
+    @playlists = Playlist.by_user(current_user)
   end
 
   def get_all_other_playlists

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -33,7 +33,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <dd><%= @playlist.title %></dd>
       <dt><%= t("activerecord.attributes.playlist.comment") %></dt>
       <dd>
-        <% if @playlist.comment.empty? %>
+        <% if @playlist.comment.blank? %>
         <span class="info-text-gray">No description</span>
         <% else %>
         <%= @playlist.comment %>


### PR DESCRIPTION
This appears to have been a bug in the bugfix done in https://github.com/avalonmediasystem/avalon/pull/3783/commits/d96f7ba5a43cbca53d8606d9e04ce3d1dd5e3743
The change from that commit to `get_user_playlists` was unnecessary and the change to `get_all_other_playlists` was sufficient.

This fixes VOV-6132 by removing the `order(:title)` to keep it from competing and complicating the order set in `paged_index`.

I tested this on spruce and mco-staging and both worked as expected after this fix.