### PR TITLE
Fix small issues with intercom push button rendering

### DIFF
--- a/app/views/media_objects/_intercom_push_modal.html.erb
+++ b/app/views/media_objects/_intercom_push_modal.html.erb
@@ -17,7 +17,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div id="intercom_push" class="modal fade" role="dialog" data-backdrop="true" data-submit_url="<%= 'create' %>" >
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
-      <%= form_for @media_object, url: {action: "intercom_push"}, html: { id: 'intercom_push_form' } {}%>
+      <%= form_for(@media_object, url: {action: "intercom_push"}, html: { id: 'intercom_push_form' }) {}%>
       <%= render 'intercom_push_form' %>
     </div>
   </div>

--- a/config/intercom.yml.example
+++ b/config/intercom.yml.example
@@ -4,3 +4,4 @@ intercom:
     api_token: a_valid_token
     import_bib_record: true
     publish: false
+    push_label: Push to Other Avalon


### PR DESCRIPTION
- Add parentheses around arguments to `form_for` to avoid syntax error.
- Add default `push_label` to example config file otherwise default text on the button is `Button`