### PR TITLE
Use older JS syntax for IE11

### DIFF
--- a/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
+++ b/vendor/assets/javascripts/mediaelement/plugins/quality-avalon.js
@@ -370,9 +370,8 @@
           keyExist: function keyExist(map, searchKey) {
             return -1 < map.get('map_keys_1').indexOf(searchKey.toLowerCase());
           },
-          isMobile() {
-            var { isAndroid, isiOS } = mejs.Features;
-            return isAndroid || isiOS;
+          isMobile: function isMobile() {
+            return mejs.Features.isAndroid || mejs.Features.isiOS;
           }
         });
       },


### PR DESCRIPTION
I'm kind of guessing here but it looks like this avoids newer ES6 syntax.  I've tested and this works in browserstack on MCO staging.

I think this method is pretty much copied from another file so it makes me wonder if vendor isn't going through the same JS pipeline processing as other JS files.  Or maybe it is just that the other code hasn't been reached in our testing of IE11.