### PR TITLE
Failed email/password logins show login form with flash message

### DIFF
--- a/app/assets/javascripts/sessions_new.js
+++ b/app/assets/javascripts/sessions_new.js
@@ -22,8 +22,8 @@ $( document ).ready(function() {
   })
   let searchParams = new URLSearchParams(window.location.search)
   if(searchParams.has('email')){
-    $('#email-box').toggleClass('hidden')
-    $('#sign-in-select').toggleClass('hidden')
-    $('#sign-in-buttons').toggleClass('hidden')
+    $('#email-box').removeClass('hidden')
+    $('#sign-in-select').addClass('hidden')
+    $('#sign-in-buttons').addClass('hidden')
   }
 })


### PR DESCRIPTION
Resolves #3991 
#4005 introduced a bug where failed email/password logins showed an error flash message but hide the login form.  This PR resolves that issue and was tested locally with and without other authentication schemes configured.

### Steps to Reproduce
1) Go to /users/sign_in?admin=true
2) Click Email/password (if given the choice)
3) Enter bad username into form and click Connect

### Expected Behavior
Login form appears with flash message

### Existing Behavior
Flash message appears but login form is hidden
<img width="785" alt="Screen Shot 2020-02-27 at 11 57 00 AM" src="https://user-images.githubusercontent.com/1053603/75466494-45b97e80-5958-11ea-9ac9-82b1505615df.png">
