### PR TITLE
Collection poster

### DIFF
--- a/app/assets/javascripts/crop_upload.js
+++ b/app/assets/javascripts/crop_upload.js
@@ -69,9 +69,16 @@ function add_cropper_handler(upload_path) {
         height: width / aspectRatio,
       });
       initialPosterURL = $poster.prop("src");
-      $poster.prop("src", canvas.toDataURL());
+      $alert.removeClass('alert-success alert-warning alert-danger');
+      try {
+        $poster.prop("src", canvas.toDataURL());
+      } catch(err) {
+        console.log(err);
+        // $alert.css('cssText', 'display: block !important;');
+        // $alert.show().addClass('alert-danger');
+        // $alert.find('p').text('Uploaded file is not a recognized poster image file');
+      }      
       $progress.show();
-      $alert.removeClass('alert-success alert-warning');
       canvas.toBlob(function (blob) {
         let formData = new FormData();
         $input.val("")
@@ -97,12 +104,16 @@ function add_cropper_handler(upload_path) {
             };
             return xhr;
           },
-          success: function () {
-            //$alert.show().addClass('alert-success').text('Upload success');
+          success: function (response) {
+            console.log(response);
+            // $alert.css('cssText', 'display: block !important;');
+            // $alert.show().addClass('alert-success');
+            // $alert.find('p').text(response.message);
           },
-          error: function () {
+          error: function (error) {
             $poster.prop("src", initialPosterURL);
-            $alert.show().addClass('alert-warning').text('Upload error');
+            // $alert.css('cssText', 'display: block !important;');
+            // $alert.show().addClass('alert-warning').text(error.message);
           },
           complete: function () {
             $progress.hide();

--- a/app/assets/javascripts/crop_upload.js
+++ b/app/assets/javascripts/crop_upload.js
@@ -15,12 +15,8 @@
 */
 
 function add_cropper_handler(upload_path) {
-  let $poster = $('#poster-image');
   let $image = $('#image');
   let $input = $('#poster_input');
-  let $progress = $('#cropper-progress');
-  let $progressBar = $('#cropper-progress-bar');
-  let $alert = $('#cropper-alert');
   let $modal = $('#modal');
   let cropper;
   let width = 700;
@@ -29,12 +25,10 @@ function add_cropper_handler(upload_path) {
     let files = e.target.files;
     let done = function (url) {
       $image.prop("src", url);
-      $alert.hide();
       $modal.modal('show');
     };
     let reader;
     let file;
-    let url;
     if (files && files.length > 0) {
       file = files[0];
       if (URL) {
@@ -59,7 +53,6 @@ function add_cropper_handler(upload_path) {
     cropper = null;
   });
   $('#crop').on('click', function () {
-    let initialPosterURL;
     let canvas;
     let inputfile = $input.val().split('\\').pop();
     $modal.modal('hide');
@@ -68,56 +61,18 @@ function add_cropper_handler(upload_path) {
         width: width,
         height: width / aspectRatio,
       });
-      initialPosterURL = $poster.prop("src");
-      $alert.removeClass('alert-success alert-warning alert-danger');
-      try {
-        $poster.prop("src", canvas.toDataURL());
-      } catch(err) {
-        console.log(err);
-        // $alert.css('cssText', 'display: block !important;');
-        // $alert.show().addClass('alert-danger');
-        // $alert.find('p').text('Uploaded file is not a recognized poster image file');
-      }      
-      $progress.show();
       canvas.toBlob(function (blob) {
         let formData = new FormData();
         $input.val("")
-        $('#poster_original_name').text(inputfile)
         formData.append('admin_collection[poster]', blob, inputfile);
-        formData.append('authenticity_token', $('input[name=authenticity_token]').val())
+        formData.append('authenticity_token', $('input[name=authenticity_token]').val());
 
-        $.ajax(upload_path, {
-          method: 'POST',
-          data: formData,
-          processData: false,
-          contentType: false,
-          xhr: function () {
-            let xhr = new XMLHttpRequest();
-            xhr.upload.onprogress = function (e) {
-              let percent = '0';
-              let percentage = '0%';
-              if (e.lengthComputable) {
-                percent = Math.round((e.loaded / e.total) * 100);
-                percentage = percent + '%';
-                $progressBar.width(percentage).attr('aria-valuenow', percent).text(percentage);
-              }
-            };
-            return xhr;
-          },
-          success: function (response) {
-            console.log(response);
-            // $alert.css('cssText', 'display: block !important;');
-            // $alert.show().addClass('alert-success');
-            // $alert.find('p').text(response.message);
-          },
-          error: function (error) {
-            $poster.prop("src", initialPosterURL);
-            // $alert.css('cssText', 'display: block !important;');
-            // $alert.show().addClass('alert-warning').text(error.message);
-          },
-          complete: function () {
-            $progress.hide();
-          },
+        fetch(upload_path, {
+          method: "POST",
+          body: formData
+        }).then(() => {
+          // Page reload to show the flash message
+          location.reload();
         });
       });
     }

--- a/app/assets/stylesheets/avalon/_collections.scss
+++ b/app/assets/stylesheets/avalon/_collections.scss
@@ -41,8 +41,20 @@
   }
 }
 
-form.collection_poster {
+.collection_poster {
+  display: flex;
+  justify-content: space-evenly;
+
+  form {
+    flex: auto;
+    margin-right: 5px;
+  }
+
+  form:last-child {
+    margin-right: 0px;
+  }
+
   input.btn {
-    width: 49%;
+    width: 100%;
   }
 }

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -16,7 +16,7 @@ class Admin::CollectionsController < ApplicationController
   include Rails::Pagination
 
   before_action :authenticate_user!
-  load_and_authorize_resource except: [:index, :remove, :attach_poster, :poster]
+  load_and_authorize_resource except: [:index, :remove, :attach_poster, :remove_poster, :poster]
   before_action :load_and_authorize_collections, only: [:index]
   respond_to :html
 
@@ -245,27 +245,38 @@ class Admin::CollectionsController < ApplicationController
     @collection = Admin::Collection.find(params['id'])
     authorize! :edit, @collection, message: "You do not have sufficient privileges to add a poster image."
 
-    if params.dig(:admin_collection, :poster).present?
-      poster_file = params[:admin_collection][:poster]
-      resized_poster = resize_uploaded_poster(poster_file.path)
-      if resized_poster
-        @collection.poster.content = resized_poster
-        @collection.poster.mime_type = 'image/png'
-        @collection.poster.original_name = poster_file.original_filename
+    poster_file = params[:admin_collection][:poster]
+    resized_poster = resize_uploaded_poster(poster_file&.path)
+    if resized_poster
+      @collection.poster.content = resized_poster
+      @collection.poster.mime_type = 'image/png'
+      @collection.poster.original_name = poster_file.original_filename
+
+      if @collection.save
         flash[:success] = "Poster file successfully added."
       else
-        flash[:error] = "Uploaded file is not a recognized poster image file"
+        flash[:error] = "There was a problem storing the poster image."
       end
     else
-      @collection.poster.content = ''
-      @collection.poster.original_name = ''
-      flash[:success] = "Poster file successfully removed."
-      redirect_to admin_collection_path(@collection)
+      flash[:error] = "Uploaded file is not a recognized poster image file"
     end
 
-    return if @collection.save
-    flash[:success] = nil
-    flash[:error] = "There was a problem storing the poster image."
+    redirect_to admin_collection_path(@collection)
+  end
+
+  def remove_poster
+    @collection = Admin::Collection.find(params['id'])
+    authorize! :edit, @collection, message: "You do not have sufficient privileges to remove a poster image."
+
+    @collection.poster.content = ''
+    @collection.poster.original_name = ''
+
+    if @collection.save
+      flash[:success] = "Poster file successfully removed."
+    else
+      flash[:error] = "There was a problem removing the poster image."
+    end
+
     redirect_to admin_collection_path(@collection)
   end
 

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -252,37 +252,21 @@ class Admin::CollectionsController < ApplicationController
         @collection.poster.content = resized_poster
         @collection.poster.mime_type = 'image/png'
         @collection.poster.original_name = poster_file.original_filename
-        # render json: { status: 'success', message: "Poster file successfully added." }
         flash[:success] = "Poster file successfully added."
-        # respond_to do |format|
-        #   format.js { flash[:success] = "Poster file successfully added." }
-        # end
       else
-        # render json: { status: 'error', message: "Uploaded file is not a recognized poster image file" }
         flash[:error] = "Uploaded file is not a recognized poster image file"
       end
     else
-      if @collection.poster.present?
-        @collection.poster.content = ''
-        @collection.poster.original_name = ''
-        flash[:success] = "Poster file successfully removed."
-      else
-        flash[:notice] = "No poster file present for the collection."
-      end
+      @collection.poster.content = ''
+      @collection.poster.original_name = ''
+      flash[:success] = "Poster file successfully removed."
+      redirect_to admin_collection_path(@collection)
     end
 
-    unless @collection.save
-      flash[:success] = nil
-      flash[:error] = "There was a problem storing the poster image."
-      # respond_to do |format|
-      #   format.html { redirect_to admin_collection_path(@collection) }
-      # end
-    end
-
-    respond_to do |format|
-      format.html { redirect_to admin_collection_path(@collection) }
-      format.js
-    end
+    return if @collection.save
+    flash[:success] = nil
+    flash[:error] = "There was a problem storing the poster image."
+    redirect_to admin_collection_path(@collection)
   end
 
   def poster

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -252,23 +252,36 @@ class Admin::CollectionsController < ApplicationController
         @collection.poster.content = resized_poster
         @collection.poster.mime_type = 'image/png'
         @collection.poster.original_name = poster_file.original_filename
-        flash[:success] = "Poster file succesfully added."
+        # render json: { status: 'success', message: "Poster file successfully added." }
+        flash[:success] = "Poster file successfully added."
+        # respond_to do |format|
+        #   format.js { flash[:success] = "Poster file successfully added." }
+        # end
       else
+        # render json: { status: 'error', message: "Uploaded file is not a recognized poster image file" }
         flash[:error] = "Uploaded file is not a recognized poster image file"
       end
     else
-      @collection.poster.content = ''
-      @collection.poster.original_name = ''
-      flash[:success] = "Poster file succesfully removed."
+      if @collection.poster.present?
+        @collection.poster.content = ''
+        @collection.poster.original_name = ''
+        flash[:success] = "Poster file successfully removed."
+      else
+        flash[:notice] = "No poster file present for the collection."
+      end
     end
 
     unless @collection.save
       flash[:success] = nil
       flash[:error] = "There was a problem storing the poster image."
+      # respond_to do |format|
+      #   format.html { redirect_to admin_collection_path(@collection) }
+      # end
     end
 
     respond_to do |format|
       format.html { redirect_to admin_collection_path(@collection) }
+      format.js
     end
   end
 

--- a/app/views/admin/collections/attach_poster.js.erb
+++ b/app/views/admin/collections/attach_poster.js.erb
@@ -1,0 +1,1 @@
+$("#flash_messages").html(<%=j render admin_collection_path(@collection) ) %>);

--- a/app/views/admin/collections/attach_poster.js.erb
+++ b/app/views/admin/collections/attach_poster.js.erb
@@ -1,1 +1,0 @@
-$("#flash_messages").html(<%=j render admin_collection_path(@collection) ) %>);

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -57,10 +57,10 @@ Unless required by applicable law or agreed to in writing, software distributed
         <% end %>
       </div>
       <div>
-        <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post", class: 'collection_poster'} do |form| %>
-        <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
-        <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="Upload Poster" />
-        <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" />
+        <%= form_for @collection, remote: true, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post", class: 'collection_poster'} do |form| %>
+          <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
+          <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="Upload Poster" />
+          <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" />
         <% end %>
       </div>
       <div class="well-vertical-spacer">

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -56,10 +56,12 @@ Unless required by applicable law or agreed to in writing, software distributed
         <img src="" class="img-responsive" id="poster-image">
         <% end %>
       </div>
-      <div>
-        <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post", class: 'collection_poster'} do |form| %>
+      <div class="collection_poster">
+        <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post"} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
           <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="Upload Poster" />
+        <% end %>
+        <%= form_for @collection, url: remove_poster_admin_collection_path(@collection.id), html: {method: "delete"} do |form| %>
           <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" />
         <% end %>
       </div>

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -57,7 +57,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <% end %>
       </div>
       <div>
-        <%= form_for @collection, remote: true, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post", class: 'collection_poster'} do |form| %>
+        <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post", class: 'collection_poster'} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
           <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="Upload Poster" />
           <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" />

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -30,9 +30,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       end
     -%>
     <% if flash[type] %>
-      <div class="alert <%=alert_class %>">
+      <div class="alert <%=alert_class %>" id="flash_messages">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
-	<% Array(flash[type]).each do |msg| %>
+        <% Array(flash[type]).each do |msg| %>
           <p><%= msg %></p>
         <% end %>
       </div>

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -30,9 +30,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       end
     -%>
     <% if flash[type] %>
-      <div class="alert <%=alert_class %>" id="flash_messages">
+      <div class="alert <%=alert_class %>">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <% Array(flash[type]).each do |msg| %>
+          <% Array(flash[type]).each do |msg| %>
           <p><%= msg %></p>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,8 @@ Rails.application.routes.draw do
         get 'remove'
         get 'items'
         get 'poster'
-        post 'attach_poster'
+        post 'poster', action: :attach_poster, as: 'attach_poster'
+        delete 'poster', action: :remove_poster, as: 'remove_poster'
       end
     end
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -375,7 +375,7 @@ describe Admin::CollectionsController, type: :controller do
         expect(collection.poster.mime_type).to eq 'image/png'
         expect(collection.poster.original_name).to eq 'collection_poster.jpg'
         expect(collection.poster.content).not_to be_blank
-        expect(response).to redirect_to(admin_collection_path(collection))
+        expect(flash[:success]).not_to be_empty
       end
 
       context 'with an invalid file' do
@@ -385,7 +385,6 @@ describe Admin::CollectionsController, type: :controller do
           file = fixture_file_upload('/captions.vtt', 'text/vtt')
           expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.not_to change { collection.reload.poster.present? }
           expect(flash[:error]).not_to be_empty
-          expect(response).to redirect_to(admin_collection_path(collection))
         end
       end
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -56,6 +56,7 @@ describe Admin::CollectionsController, type: :controller do
           expect(patch :update, params: { id: collection.id }).to redirect_to(root_path)
           expect(delete :destroy, params: { id: collection.id }).to redirect_to(root_path)
           expect(post :attach_poster, params: { id: collection.id }).to redirect_to(root_path)
+          expect(delete :remove_poster, params: { id: collection.id }).to redirect_to(root_path)
           expect(get :poster, params: { id: collection.id }).to redirect_to(root_path)
         end
       end
@@ -360,58 +361,71 @@ describe Admin::CollectionsController, type: :controller do
   end
 
   describe '#attach_poster' do
-    context 'adding a poster' do
-      let(:collection) { FactoryBot.create(:collection) }
-      let(:resized_poster_data) { "image data" }
+    let(:collection) { FactoryBot.create(:collection) }
+    let(:resized_poster_data) { "image data" }
 
-      before do
-        login_user collection.managers.first
-        allow(controller).to receive(:resize_uploaded_poster).and_return(resized_poster_data)
-      end
+    before do
+      login_user collection.managers.first
+      allow(controller).to receive(:resize_uploaded_poster).and_return(resized_poster_data)
+    end
 
-      it 'adds the poster' do
-        file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
-        expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.to change { collection.reload.poster.present? }.from(false).to(true)
-        expect(collection.poster.mime_type).to eq 'image/png'
-        expect(collection.poster.original_name).to eq 'collection_poster.jpg'
-        expect(collection.poster.content).not_to be_blank
-        expect(flash[:success]).not_to be_empty
-      end
+    it 'adds the poster' do
+      file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
+      expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.to change { collection.reload.poster.present? }.from(false).to(true)
+      expect(collection.poster.mime_type).to eq 'image/png'
+      expect(collection.poster.original_name).to eq 'collection_poster.jpg'
+      expect(collection.poster.content).not_to be_blank
+      expect(response).to redirect_to(admin_collection_path(collection))
+      expect(flash[:success]).not_to be_empty
+    end
 
-      context 'with an invalid file' do
-        let(:resized_poster_data) { nil }
+    context 'with an invalid file' do
+      let(:resized_poster_data) { nil }
 
-        it 'displays an error when the file is not an image' do
-          file = fixture_file_upload('/captions.vtt', 'text/vtt')
-          expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.not_to change { collection.reload.poster.present? }
-          expect(flash[:error]).not_to be_empty
-        end
-      end
-
-      context 'when saving fails' do
-        before do
-          allow_any_instance_of(Admin::Collection).to receive(:save).and_return(false)
-        end
-  
-        it 'returns an error' do
-          file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
-          expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.not_to change { collection.reload.poster.present? }
-          expect(flash[:error]).not_to be_empty
-          expect(response).to redirect_to(admin_collection_path(collection))
-        end
+      it 'displays an error when the file is not an image' do
+        file = fixture_file_upload('/captions.vtt', 'text/vtt')
+        expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.not_to change { collection.reload.poster.present? }
+        expect(response).to redirect_to(admin_collection_path(collection))
+        expect(flash[:error]).not_to be_empty
       end
     end
 
-    context 'removing a poster' do
-      let(:collection) { FactoryBot.create(:collection, :with_poster) }
-
+    context 'when saving fails' do
       before do
-        login_user collection.managers.first
+        allow_any_instance_of(Admin::Collection).to receive(:save).and_return(false)
       end
 
-      it 'removes the poster' do
-        expect { post :attach_poster, params: { id: collection.id } }.to change { collection.reload.poster.present? }.from(true).to(false)
+      it 'returns an error' do
+        file = fixture_file_upload('/collection_poster.jpg', 'image/jpeg')
+        expect { post :attach_poster, params: { id: collection.id, admin_collection: { poster: file } } }.not_to change { collection.reload.poster.present? }
+        expect(flash[:error]).not_to be_empty
         expect(response).to redirect_to(admin_collection_path(collection))
+      end
+    end
+  end
+
+  describe '#remove_poster' do
+    let(:collection) { FactoryBot.create(:collection, :with_poster) }
+
+    before do
+      login_user collection.managers.first
+    end
+
+    it 'removes the poster' do
+      expect { delete :remove_poster, params: { id: collection.id } }.to change { collection.reload.poster.present? }.from(true).to(false)
+      expect(response).to redirect_to(admin_collection_path(collection))
+      expect(flash[:success]).not_to be_empty
+    end
+
+    context 'when saving fails' do
+      before do
+        allow_any_instance_of(Admin::Collection).to receive(:save).and_return(false)
+      end
+
+      it 'returns an error' do
+        expect { delete :remove_poster, params: { id: collection.id } }.not_to change { collection.reload.poster.present? }
+        expect(response).to redirect_to(admin_collection_path(collection))
+        expect(flash[:error]).not_to be_empty
       end
     end
   end

--- a/spec/routing/admin_collections_controller_routing_spec.rb
+++ b/spec/routing/admin_collections_controller_routing_spec.rb
@@ -17,7 +17,10 @@ require "rails_helper"
 RSpec.describe Admin::CollectionsController, type: :routing do
   describe "routing" do
     it 'routes to #attach_poster' do
-      expect(:post => "/admin/collections/1/attach_poster").to route_to("admin/collections#attach_poster", :id => "1")
+      expect(:post => "/admin/collections/1/poster").to route_to("admin/collections#attach_poster", :id => "1")
+    end
+    it 'routes to #remove_poster' do
+      expect(:delete => "/admin/collections/1/poster").to route_to("admin/collections#remove_poster", :id => "1")
     end
     it 'routes to #poster' do
       expect(:get => "/admin/collections/1/poster").to route_to("admin/collections#poster", :id => "1")


### PR DESCRIPTION
Fixes: #3937 

Show the poster added success message on top of the page, which was not shown before;
![Screenshot from 2020-02-28 14-00-14](https://user-images.githubusercontent.com/1331659/75578866-aae1a280-5a32-11ea-9fd1-2ea5d4a9bbaa.png)

Shows the cropped new poster after the upload is successful.

Before:
![ezgif com-video-to-gif (11)](https://user-images.githubusercontent.com/1331659/75580182-51c73e00-5a35-11ea-860e-6f162889c543.gif)
After:
![ezgif com-video-to-gif (12)](https://user-images.githubusercontent.com/1331659/75580193-555ac500-5a35-11ea-843d-1d55592bbeb3.gif)
