### PR TITLE
Disable collection poster buttons when user is a depositor

### DIFF
--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -61,7 +61,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post"} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
           <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="<% if @collection.poster.present? %>Change Poster<%else%>Upload Poster<%end%>"
-            <% if is_depositor %>disabled<%end%> />
+            <% if cannot?(:edit, @collection) %>disabled<%end%> />
         <% end %>
         <%= form_for @collection, url: remove_poster_admin_collection_path(@collection.id), html: {method: "delete"} do |form| %>
           <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" <% if is_depositor || @collection.poster.blank? %>disabled<%end%> />

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -64,7 +64,7 @@ Unless required by applicable law or agreed to in writing, software distributed
             <% if cannot?(:edit, @collection) %>disabled<%end%> />
         <% end %>
         <%= form_for @collection, url: remove_poster_admin_collection_path(@collection.id), html: {method: "delete"} do |form| %>
-          <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" <% if is_depositor || @collection.poster.blank? %>disabled<%end%> />
+          <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" <% if @collection.poster.blank? || cannot?(:edit, @collection) %>disabled<%end%> />
         <% end %>
       </div>
       <div class="well-vertical-spacer">

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -57,7 +57,6 @@ Unless required by applicable law or agreed to in writing, software distributed
         <% end %>
       </div>
       <div class="collection_poster">
-        <% is_depositor=can?(:read, Admin::Collection) && !can?(:manage, Admin::Collection) %>
         <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post"} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
           <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="<% if @collection.poster.present? %>Change Poster<%else%>Upload Poster<%end%>"

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -57,12 +57,14 @@ Unless required by applicable law or agreed to in writing, software distributed
         <% end %>
       </div>
       <div class="collection_poster">
+        <% is_depositor=can?(:read, Admin::Collection) && !can?(:manage, Admin::Collection) %>
         <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post"} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;" %>
-          <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="Upload Poster" />
+          <input type="button" class="btn btn-primary btn-xs" onclick="$('.filedata').click();" value="<% if @collection.poster.present? %>Change Poster<%else%>Upload Poster<%end%>"
+            <% if is_depositor %>disabled<%end%> />
         <% end %>
         <%= form_for @collection, url: remove_poster_admin_collection_path(@collection.id), html: {method: "delete"} do |form| %>
-          <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" />
+          <input type="submit" class="btn btn-danger btn-xs" value="Remove Poster" <% if is_depositor || @collection.poster.blank? %>disabled<%end%> />
         <% end %>
       </div>
       <div class="well-vertical-spacer">


### PR DESCRIPTION
Changes in this PR;

1. Disable buttons when the user is a depositor;
![Screenshot from 2020-03-02 14-14-01](https://user-images.githubusercontent.com/1331659/75709371-86830180-5c90-11ea-842e-1c4d37479551.png)

2. Disable `Remove Poster` button when the collection does not have a poster;
![Screenshot from 2020-03-02 14-15-00](https://user-images.githubusercontent.com/1331659/75709366-8551d480-5c90-11ea-94a7-818bc22d8888.png)

3. Changed `Upload Poster` value to `Change Poster` when the collection has a poster;
![Screenshot from 2020-03-02 14-15-24](https://user-images.githubusercontent.com/1331659/75709365-83881100-5c90-11ea-8a9d-c975c88af723.png)
