### PR TITLE
Provide option to remove identifiers from ingest api pushed through intercom

### DIFF
--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MediaObjectIntercom
-  def to_ingest_api_hash(include_structure = true)
+  def to_ingest_api_hash(include_structure = true, remove_identifiers: false)
     {
       files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash include_structure },
       fields:
@@ -22,7 +22,7 @@ module MediaObjectIntercom
           avalon_resource_type: avalon_resource_type.to_a,
           avalon_publisher: avalon_publisher,
           avalon_uploader: avalon_uploader,
-          identifier: identifier.to_a,
+          identifier: (remove_identifiers ? [] : identifier.to_a),
           title: title,
           alternative_title: alternative_title,
           translated_title: translated_title,

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -54,7 +54,7 @@ module Avalon
     private
 
       def build_payload(media_object, collection_id, include_structure)
-        payload = media_object.to_ingest_api_hash(include_structure)
+        payload = media_object.to_ingest_api_hash(include_structure, remove_identifiers: @avalon['remove_identifiers'])
         payload[:collection_id] = collection_id
         payload[:import_bib_record] = @avalon['import_bib_record']
         payload[:publish] = @avalon['publish']

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -893,4 +893,21 @@ describe MediaObject do
       expect(media_object.reload.terms_of_use).to eq terms_of_use_value
     end
   end
+
+  describe '#to_ingest_api_hash' do
+    let(:media_object) { FactoryBot.build(:fully_searchable_media_object, identifier: ['ABCDE12345']) }
+
+    context 'remove_identifiers parameter' do
+      it 'removes identifiers if parameter is true' do
+        expect(media_object.identifier).not_to be_empty
+        expect(media_object.to_ingest_api_hash(false, remove_identifiers: true)[:fields][:identifier]).to be_empty
+      end
+
+      it 'does not remove identifiers if parameter is not present' do
+        expect(media_object.identifier).not_to be_empty
+        expect(media_object.to_ingest_api_hash(false, remove_identifiers: false)[:fields][:identifier]).not_to be_empty
+        expect(media_object.to_ingest_api_hash(false)[:fields][:identifier]).not_to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Identifiers in this case is not other identifiers stored in the MODS but DC identifiers that are used by the objects controller.  These could be permalink id and migrated from id (avalon:xxxxxx).