### PR TITLE
Bug fix: Media player disappearing on reload in Edge 16

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -2269,12 +2269,6 @@ Object.assign(_player2.default.prototype, {
 		    chaptersTitle = (0, _general.isString)(t.options.chaptersText) ? t.options.chaptersText : _i18n2.default.t('mejs.captions-chapters'),
 		    total = player.trackFiles === null ? player.tracks.length : player.trackFiles.length;
 
-		if (t.domNode.textTracks) {
-			for (var i = t.domNode.textTracks.length - 1; i >= 0; i--) {
-				t.domNode.textTracks[i].mode = 'hidden';
-			}
-		}
-
 		t.cleartracks(player);
 
 		player.captions = _document2.default.createElement('div');


### PR DESCRIPTION
```
if (t.domNode.textTracks) {	
			for (var i = t.domNode.textTracks.length - 1; i >= 0; i--) {	
				t.domNode.textTracks[i].mode = 'hidden';	
			}	
		}
```
This code block hides the tracks if browser supports native captions in order to load MEJS captions. But this code block fails when it runs in Edge 16. 
For one of the items this code failed in mallorn (https://mallorn.dlib.indiana.edu/media_objects/td96k2606), on the first page load there was only one `textTracks` item while on the reload  there were 2 `textTracks` items. But this does not happen in Google Chrome.
And it seems the code uses VTTCue interface to handle the captions, which is not supported by Edge 16 (https://caniuse.com/#feat=mdn-api_vttcue).
Even though this fixes the issue, I'm not sure what the exact reason for this to fail on the reload.