### PR TITLE
Remove identifiers

### DIFF
--- a/app/models/concerns/master_file_intercom.rb
+++ b/app/models/concerns/master_file_intercom.rb
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MasterFileIntercom
-  def to_ingest_api_hash(include_structure = true)
+  def to_ingest_api_hash(include_structure = true, remove_identifiers: false)
     {
       id: id,
       workflow_name: workflow_name,
@@ -32,7 +32,7 @@ module MasterFileIntercom
       date_digitized: date_digitized,
       file_checksum: file_checksum,
       file_format: file_format,
-      other_identifier: identifier.to_a,
+      other_identifier: (remove_identifiers ? [] : identifier.to_a),
       captions: captions.content,
       captions_type: caption_type,
       comment: comment.to_a,

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -13,14 +13,14 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module MediaObjectIntercom
-  def to_ingest_api_hash(include_structure = true, remove_identifiers: false)
+  def to_ingest_api_hash(include_structure = true, remove_identifiers: false, publish: false)
     {
       files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash(include_structure, remove_identifiers: remove_identifiers) },
       fields:
         {
           duration: duration,
           avalon_resource_type: avalon_resource_type.to_a,
-          avalon_publisher: avalon_publisher,
+          avalon_publisher: (publish ? avalon_publisher : nil),
           avalon_uploader: avalon_uploader,
           identifier: (remove_identifiers ? [] : identifier.to_a),
           title: title,

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -15,7 +15,7 @@
 module MediaObjectIntercom
   def to_ingest_api_hash(include_structure = true, remove_identifiers: false)
     {
-      files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash include_structure },
+      files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash(include_structure, remove_identifiers: remove_identifiers) },
       fields:
         {
           duration: duration,

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -54,7 +54,7 @@ module Avalon
     private
 
       def build_payload(media_object, collection_id, include_structure)
-        payload = media_object.to_ingest_api_hash(include_structure, remove_identifiers: @avalon['remove_identifiers'])
+        payload = media_object.to_ingest_api_hash(include_structure, remove_identifiers: @avalon['remove_identifiers'], publish: @avalon['publish'])
         payload[:collection_id] = collection_id
         payload[:import_bib_record] = @avalon['import_bib_record']
         payload[:publish] = @avalon['publish']

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -675,4 +675,21 @@ describe MasterFile do
       end
     end
   end
+
+  describe '#to_ingest_api_hash' do
+    let(:master_file) { FactoryBot.build(:master_file, identifier: ['ABCDE12345']) }
+
+    context 'remove_identifiers parameter' do
+      it 'removes identifiers if parameter is true' do
+        expect(master_file.identifier).not_to be_empty
+        expect(master_file.to_ingest_api_hash(false, remove_identifiers: true)[:other_identifier]).to be_empty
+      end
+
+      it 'does not remove identifiers if parameter is not present' do
+        expect(master_file.identifier).not_to be_empty
+        expect(master_file.to_ingest_api_hash(false, remove_identifiers: false)[:other_identifier]).not_to be_empty
+        expect(master_file.to_ingest_api_hash(false)[:other_identifier]).not_to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -895,9 +895,9 @@ describe MediaObject do
   end
 
   describe '#to_ingest_api_hash' do
-    let(:media_object) { FactoryBot.build(:fully_searchable_media_object, identifier: ['ABCDE12345']) }
-
     context 'remove_identifiers parameter' do
+      let(:media_object) { FactoryBot.build(:fully_searchable_media_object, identifier: ['ABCDE12345']) }
+
       it 'removes identifiers if parameter is true' do
         expect(media_object.identifier).not_to be_empty
         expect(media_object.to_ingest_api_hash(false, remove_identifiers: true)[:fields][:identifier]).to be_empty
@@ -907,6 +907,22 @@ describe MediaObject do
         expect(media_object.identifier).not_to be_empty
         expect(media_object.to_ingest_api_hash(false, remove_identifiers: false)[:fields][:identifier]).not_to be_empty
         expect(media_object.to_ingest_api_hash(false)[:fields][:identifier]).not_to be_empty
+      end
+    end
+
+    context 'publish parameter' do
+      let(:publisher) { 'admin@example.com' }
+      let(:media_object) { FactoryBot.build(:fully_searchable_media_object, avalon_publisher: publisher) }
+
+      it 'removes avalon_publisher when parameter is false' do
+        expect(media_object).to be_published
+        expect(media_object.to_ingest_api_hash(false, publish: false)[:fields][:avalon_publisher]).to be_blank
+        expect(media_object.to_ingest_api_hash(false)[:fields][:avalon_publisher]).to be_blank
+      end
+
+      it 'does not remove avalon_publisher when parameter is true' do
+        expect(media_object).to be_published
+        expect(media_object.to_ingest_api_hash(false, publish: true)[:fields][:avalon_publisher]).to eq publisher
       end
     end
   end


### PR DESCRIPTION
The work in #4021 was incomplete.  This PR finishes the work by adding two things:
1.  Identifiers are removed from master files as well.
1.  If publish flag is not set or false then remove the `avalon_publisher` from the intercom api hash.  Before it was still being included and I believe was causing the pushed object to be published and saved and thus get a permalink generated before it was marked as unpublished and resaved at the end of `MediaObjectsController#update_media_object`.

Resolves VOV-6019.