### PR TITLE
Fix locking_runner always returns exit code 255

### DIFF
--- a/script/locking_runner
+++ b/script/locking_runner
@@ -16,6 +16,7 @@ shift
 
 if ( set -o noclobber; echo "$$" > "$LOCKFILE") 2> /dev/null; 
 then
-  trap 'rm -f "$LOCKFILE"; exit 255' INT TERM EXIT
+  trap 'rm -f "$LOCKFILE"; exit 255' INT TERM
   "$@" || true #run the command
+  rm -f "$LOCKFILE"
 fi


### PR DESCRIPTION
As suggested by Brian Wheeler. It should only return 255 when killed by a signal.