### PR TITLE
Simple model for supplemental files

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -1,0 +1,119 @@
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class SupplementalFilesController < ApplicationController
+  before_action :set_master_file
+  before_action :build_supplemental_file, only: [:create, :update]
+
+  rescue_from Avalon::SaveError do |exception|
+    message = "An error occurred when saving the supplemental file: #{exception.full_message}"
+    handle_error(message: message, status: 500)
+  end
+
+  rescue_from Avalon::BadRequest do |exception|
+    handle_error(message: exception.full_message, status: 400)
+  end
+
+  rescue_from Avalon::NotFound do |exception|
+    handle_error(message: exception.full_message, status: 404)
+  end
+
+  def create
+    authorize! :edit, @master_file
+    # FIXME: move filedata to permanent location
+    raise Avalon::BadRequest, "Missing required parameters" unless supplemental_file_params[:file]
+
+    absolute_path = supplemental_file_params[:file].path
+    @supplemental_file.absolute_path = absolute_path
+    @supplemental_file.label ||= supplemental_file_params[:file].original_filename
+    @supplemental_file.id = @master_file.next_supplemental_file_id
+    @master_file.supplemental_files += [@supplemental_file]
+    raise Avalon::SaveError, @master_file.errors[:supplemental_files_json].full_messages unless @master_file.save
+
+    flash[:success] = "Supplemental file successfully added."
+    respond_to do |format|
+      format.html { redirect_to edit_media_object_path(@master_file.media_object_id, step: 'structure') }
+      format.json { head :created, location: master_file_supplemental_file_path(id: @supplemental_file.id, master_file_id: @master_file.id) }
+    end
+  end
+
+  def show
+    # TODO: Use a master file presenter which reads from solr instead of loading the masterfile from fedora
+    authorize! :read, @master_file, message: "You do not have sufficient privileges"
+    matching_file = @master_file.supplemental_files.find { |file| file.id == params[:id] }
+    # FIXME: redirect or proxy the content instead of rails directly sending the file
+    send_file matching_file.absolute_path
+  end
+
+  # Update the label of the supplemental file
+  def update
+    authorize! :edit, @master_file
+    file_index = @master_file.supplemental_files.find_index { |file| file.id == @supplemental_file.id }
+    raise Avalon::NotFound, "Cannot update the supplemental file: #{@supplemental_file.id} not found" unless file_index.present?
+    raise Avalon::BadRequest, "Updating file contents not allowed" if supplemental_file_params[:file].present?
+
+    # Use the stored absolute path and not update from the user params
+    @supplemental_file.absolute_path = @master_file.supplemental_files[file_index].absolute_path
+    supplemental_files = @master_file.supplemental_files
+    supplemental_files[file_index] = @supplemental_file
+    @master_file.supplemental_files = supplemental_files
+    raise Avalon::SaveError, @master_file.errors[:supplemental_files_json].full_messages unless @master_file.save
+
+    flash[:success] = "Supplemental file successfully updated."
+    respond_to do |format|
+      format.html { redirect_to edit_media_object_path(@master_file.media_object_id, step: 'structure') }
+      format.json { head :ok, location: master_file_supplemental_file_path(id: @supplemental_file.id, master_file_id: @master_file.id) }
+    end
+  end
+
+  def destroy
+    authorize! :edit, @master_file
+    file = @master_file.supplemental_files.find { |f| f.id == params[:id] }
+    raise Avalon::NotFound, "Cannot update the supplemental file: #{params[:id]} not found" unless file.present?
+    @master_file.supplemental_files -= [file]
+
+    raise Avalon::SaveError, "An error occurred when deleting the supplemental file: #{@master_file.errors[:supplemental_files_json].full_messages}" unless @master_file.save
+
+    flash[:success] = "Supplemental file successfully deleted."
+    respond_to do |format|
+      format.html { redirect_to edit_media_object_path(@master_file.media_object_id, step: 'structure') }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    def set_master_file
+      @master_file = MasterFile.find(params[:master_file_id])
+    end
+
+    def build_supplemental_file
+      # Note that built supplemental file does not have an absolute_path
+      @supplemental_file = MasterFile::SupplementalFile.new(id: params[:id], label: supplemental_file_params[:label])
+    end
+
+    def supplemental_file_params
+      # TODO: Add parameters for minio and s3
+      params.fetch(:supplemental_file, {}).permit(:label, :file)
+    end
+
+    def handle_error(message:, status:)
+      if request.format == :json
+        render json: { errors: message }, status: status
+      else
+        flash[:error] = message
+        redirect_to edit_media_object_path(@master_file.media_object_id, step: 'structure')
+      end
+    end
+end

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -34,6 +34,7 @@ module Avalon
 
     class MasterFile < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/master_file#")
       property :posterOffset,        "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
+      property :supplementalFiles,   "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
       property :thumbnailOffset,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
       property :workingFilePath,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
     end

--- a/config/initializers/avalon.rb
+++ b/config/initializers/avalon.rb
@@ -1,3 +1,4 @@
+require 'avalon/errors'
 # Loads configuration information from the YAML file and then sets up the
 # dropbox
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,9 @@ Rails.application.routes.draw do
       delete 'structure', to: 'master_files#delete_structure', constraints: { format: 'json' }
       post 'move'
     end
+
+    # Supplemental Files
+    resources :supplemental_files, except: [:new, :index, :edit]
   end
 
   match "iiif_auth_token/:id", to: 'master_files#iiif_auth_token', via: [:get], as: :iiif_auth_token

--- a/lib/avalon/errors.rb
+++ b/lib/avalon/errors.rb
@@ -1,0 +1,20 @@
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module Avalon
+  class AvalonError < StandardError; end
+  class BadRequest < AvalonError; end
+  class NotFound < AvalonError; end
+  class SaveError < AvalonError; end
+end

--- a/spec/controllers/supplemental_files_controller_spec.rb
+++ b/spec/controllers/supplemental_files_controller_spec.rb
@@ -1,0 +1,264 @@
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+RSpec.describe SupplementalFilesController, type: :controller do
+
+  # This should return the minimal set of attributes required to create a valid
+  # SupplementalFile.
+  let(:valid_create_attributes) {
+    { file: uploaded_file, label: 'label' }
+  }
+
+  let(:invalid_create_attributes) {
+    {}
+  }
+
+  let(:valid_update_attributes) { 
+    { label: 'new label' }
+  }
+
+  let(:invalid_update_attributes) { 
+    { file: uploaded_file }
+  }
+
+  let(:uploaded_file) { fixture_file_upload('/collection_poster.png', 'image/png') }
+  let(:master_file) { FactoryBot.create(:master_file) }
+  let(:supplemental_file) { MasterFile::SupplementalFile.new(id: '1', absolute_path: '/path/to/file.pdf') }
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # SupplementalFilesController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  describe 'security' do
+    context 'with unauthenticated user' do
+      it "all routes should redirect to sign in" do
+        expect(post :create, params: { master_file_id: master_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      end
+    end
+    context 'with end-user' do
+      before do
+        login_as :user
+      end
+      it "all routes should redirect to /" do
+        expect(post :create, params: { master_file_id: master_file.id }).to redirect_to(root_path)
+        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
+        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
+        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "GET #show" do
+    let(:master_file) { FactoryBot.create(:master_file, media_object: public_media_object) }
+    let(:public_media_object) { FactoryBot.create(:fully_searchable_media_object) }
+    let(:supplemental_file) { MasterFile::SupplementalFile.new(id: '1', absolute_path: uploaded_file.path) }
+
+    before do
+      master_file.supplemental_files = [supplemental_file]
+      master_file.save!
+    end
+
+    it "returns the supplemental file content" do
+      get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to eq uploaded_file.read
+    end
+  end
+
+  describe "POST #create" do
+    before do
+      login_as :administrator
+    end
+
+    context 'json request' do
+      context "with valid params" do
+        it "updates the SupplementalFile" do
+          expect {
+            post :create, params: { master_file_id: master_file.id, supplemental_file: valid_create_attributes, format: :json }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.size }.by(1)
+          expect(response).to have_http_status(:created)
+          expect(response.location).to eq master_file_supplemental_file_path(id: assigns(:supplemental_file).id, master_file_id: master_file.id)
+
+          expect(master_file.supplemental_files.first.id).to eq '1'
+          expect(master_file.supplemental_files.first.label).to eq 'label'
+          expect(master_file.supplemental_files.first&.absolute_path).to be_present
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a 400" do
+          post :create, params: { master_file_id: master_file.id, supplemental_file: invalid_create_attributes, format: :json }, session: valid_session
+          expect(response).to have_http_status(400)
+        end
+      end
+    end
+
+    context 'html request' do
+      let(:media_object) { FactoryBot.create(:media_object) }
+      let(:master_file) { FactoryBot.create(:master_file, media_object_id: media_object.id) }
+
+      context "with valid params" do
+        it "updates the SupplementalFile" do
+          expect {
+            post :create, params: { master_file_id: master_file.id, supplemental_file: valid_create_attributes, format: :html }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.size }.by(1)
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:success]).to be_present
+
+          expect(master_file.supplemental_files.first.id).to eq '1'
+          expect(master_file.supplemental_files.first.label).to eq 'label'
+          expect(master_file.supplemental_files.first&.absolute_path).to be_present
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a 400" do
+          post :create, params: { master_file_id: master_file.id, supplemental_file: invalid_create_attributes, format: :html }, session: valid_session
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:error]).to be_present
+        end
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    let(:master_file) { FactoryBot.create(:master_file, supplemental_files: [supplemental_file]) }
+    let(:supplemental_file) { MasterFile::SupplementalFile.new(id: '1', label: 'label', absolute_path: uploaded_file.path) }
+
+    before do
+      login_as :administrator
+    end
+
+    context 'json request' do
+      context "with valid params" do
+        it "creates a new SupplementalFile" do
+          expect {
+            put :update, params: { master_file_id: master_file.id, id: supplemental_file.id, supplemental_file: valid_update_attributes, format: :json }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.first.label }.from('label').to('new label')
+          .and not_change { master_file.supplemental_files.first.absolute_path }
+          .and not_change { master_file.supplemental_files.first.id }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.location).to eq master_file_supplemental_file_path(id: assigns(:supplemental_file).id, master_file_id: master_file.id)
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a 400" do
+          put :update, params: { master_file_id: master_file.id, id: supplemental_file.id, supplemental_file: invalid_update_attributes, format: :json }, session: valid_session
+          expect(response).to have_http_status(400)
+        end
+      end
+
+      context "with missing id" do
+        it "returns a 404" do
+          put :update, params: { master_file_id: master_file.id, id: 'missing-id', supplemental_file: valid_update_attributes, format: :json }, session: valid_session
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'html request' do
+      let(:media_object) { FactoryBot.create(:media_object) }
+      let(:master_file) { FactoryBot.create(:master_file, media_object_id: media_object.id, supplemental_files: [supplemental_file]) }
+
+      context "with valid params" do
+        it "creates a new SupplementalFile" do
+          expect {
+            put :update, params: { master_file_id: master_file.id, id: supplemental_file.id, supplemental_file: valid_update_attributes, format: :html }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.first.label }.from('label').to('new label')
+          .and not_change { master_file.supplemental_files.first.absolute_path }
+          .and not_change { master_file.supplemental_files.first.id }
+
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:success]).to be_present
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a 400" do
+          put :update, params: { master_file_id: master_file.id, id: supplemental_file.id, supplemental_file: invalid_update_attributes, format: :html }, session: valid_session
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:error]).to be_present
+        end
+      end
+
+      context "with missing id" do
+        it "returns a 404" do
+          put :update, params: { master_file_id: master_file.id, id: 'missing-id', supplemental_file: valid_update_attributes, format: :html }, session: valid_session
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:error]).to be_present
+        end
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:master_file) { FactoryBot.create(:master_file, supplemental_files: [supplemental_file]) }
+    let(:supplemental_file) { MasterFile::SupplementalFile.new(id: '1', label: 'label', absolute_path: uploaded_file.path) }
+
+    before do
+      login_as :administrator
+    end
+
+    context 'json request' do
+      context "with valid params" do
+        it "deletes the SupplementalFile" do
+          expect {
+            delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id, format: :json }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.count }.by(-1)
+          expect(response).to have_http_status(:no_content)
+          # TODO: expect file contents to have been removed
+        end
+      end
+
+      context "with missing id" do
+        it "returns a 404" do
+          delete :destroy, params: { master_file_id: master_file.id, id: 'missing-id', format: :json }, session: valid_session
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'html request' do
+      let(:media_object) { FactoryBot.create(:media_object) }
+      let(:master_file) { FactoryBot.create(:master_file, media_object_id: media_object.id, supplemental_files: [supplemental_file]) }
+  
+      context "with valid params" do
+        it "deletes the SupplementalFile" do
+          expect {
+            delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id, format: :html }, session: valid_session
+          }.to change { master_file.reload.supplemental_files.count }.by(-1)
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:success]).to be_present
+          # TODO: expect file contents to have been removed
+        end
+      end
+  
+      context "with missing id" do
+        it "returns a 404" do
+          delete :destroy, params: { master_file_id: master_file.id, id: 'missing-id', format: :html }, session: valid_session
+          expect(response).to redirect_to(edit_media_object_path(media_object.id, step: 'structure'))
+          expect(flash[:error]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -692,4 +692,36 @@ describe MasterFile do
       end
     end
   end
+
+  describe 'Supplemental Files' do
+    let(:master_file) { FactoryBot.build(:master_file) }
+    let(:supplemental_file) { MasterFile::SupplementalFile.new(id: '1', label: 'Transcript', absolute_path: '/path/to/file/transcript.doc') }
+    let(:supplemental_files) { [supplemental_file] }
+
+    context 'supplemental_files=' do
+      it 'stores the supplemental files as a json string in a property' do
+        expect { master_file.supplemental_files = supplemental_files }.to change { master_file.supplemental_files_json }.from(nil).to(supplemental_files.to_json)
+      end
+    end
+
+    context 'supplemental_files' do
+      let(:master_file) { FactoryBot.build(:master_file, supplemental_files_json: supplemental_files.to_json) }
+
+      it 'reifies the supplemental files from the stored json string' do
+        expect(master_file.supplemental_files).to eq supplemental_files
+      end
+    end
+
+    context 'next_supplemental_file_id' do
+      it 'calclates the next id to use' do
+        master_file.supplemental_files = supplemental_files
+        expect(master_file.next_supplemental_file_id).to eq '2'
+      end
+
+      it 'calculates the first id to use' do
+        master_file.supplemental_files = []
+        expect(master_file.next_supplemental_file_id).to eq '1'
+      end
+    end
+  end
 end

--- a/spec/routing/supplemental_files_routing_spec.rb
+++ b/spec/routing/supplemental_files_routing_spec.rb
@@ -1,0 +1,32 @@
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require "rails_helper"
+
+RSpec.describe MasterFilesController, type: :routing do
+  describe "routing" do
+    it "routes to #show" do
+      expect(:get => "/master_files/abc1234/supplemental_files/edf567").to route_to("supplemental_files#show", master_file_id: 'abc1234', id: 'edf567')
+    end
+    it "routes to #delete" do
+      expect(:delete => "/master_files/abc1234/supplemental_files/edf567").to route_to("supplemental_files#destroy", master_file_id: 'abc1234', id: 'edf567')
+    end
+    it "routes to #create" do
+      expect(:post => "/master_files/abc1234/supplemental_files").to route_to("supplemental_files#create", master_file_id: 'abc1234')
+    end
+    it "routes to #update" do
+      expect(:put => "/master_files/abc1234/supplemental_files/edf567").to route_to("supplemental_files#update", master_file_id: 'abc1234', id: 'edf567')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,3 +116,5 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
Supplemental files model implemented as a json string stored in a single RDF triple to avoid overhead of new object while still retaining order.  New controller created to provide RESTful JS and html with flash message responses.

This PR also creates new avalon error classes to simplify the controller.