### PR TITLE
Changed the embeded_code display to trim spaces

### DIFF
--- a/app/views/media_objects/_embed_resource.html.erb
+++ b/app/views/media_objects/_embed_resource.html.erb
@@ -18,9 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="tab-pane" id="embed-tab">
       <% if @currentStream.present? %>
       <p class="muted">Copy the text below to embed this resource</p>
-      <textarea class="col-md-6" rows="3" id="embed-part" onClick="this.select();" readonly="readonly">
-        <%= @currentStream.embed_code(MasterFile::EMBED_SIZE[:medium], { urlappend: '/embed' }) %>
-      </textarea>
+      <textarea class="col-md-6" rows="3" id="embed-part" onClick="this.select();" readonly="readonly"><%= @currentStream.embed_code(MasterFile::EMBED_SIZE[:medium], { urlappend: '/embed' }) %></textarea>
       <% else %>
       <p class="muted"> <%= I18n.t('media_object.empty_share_link_notice') %> </p>
       <% end %>


### PR DESCRIPTION
Fixes #4090

Changed the textarea to remove extra white spaces from embed code section of the media object