### PR TITLE
Simplify and avoid error handling by using safe_constantize

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -744,9 +744,8 @@ class MasterFile < ActiveFedora::Base
   end
 
   def find_encoder_class(klass_name)
-    return nil if klass_name.blank? || !Object.const_defined?(klass_name)
-    klass = Object.const_get(klass_name)
-    return klass if klass.ancestors.include?(ActiveEncode::Base)
+    klass = klass_name&.safe_constantize
+    klass if klass&.ancestors&.include?(ActiveEncode::Base)
   end
 
   def stop_processing!

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -22,9 +22,8 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
   end
 
   def find_encoder_class(klass_name)
-    return nil if klass_name.blank? || !Object.const_defined?(klass_name)
-    klass = Object.const_get(klass_name)
-    return klass if klass.ancestors.include?(ActiveEncode::Base)
+    klass = klass_name&.safe_constantize
+    klass if klass&.ancestors&.include?(ActiveEncode::Base)
   end
 
   def display_title

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -339,6 +339,11 @@ describe MasterFile do
       expect(subject.encoder_class).to eq(WatchedEncode)
     end
 
+    it "should fall back to Watched when a workflow class can't be resolved" do
+      subject.encoder_classname = 'my-awesomeEncode'
+      expect(subject.encoder_class).to eq(WatchedEncode)
+    end
+
     it "should resolve an explicitly named encoder class" do
       stub_const("EncoderModule::MyEncoder", Class.new(ActiveEncode::Base))
       subject.encoder_classname = 'EncoderModule::MyEncoder'

--- a/spec/presenters/speedy_af/proxy/master_file_spec.rb
+++ b/spec/presenters/speedy_af/proxy/master_file_spec.rb
@@ -41,6 +41,13 @@ describe SpeedyAF::Proxy::MasterFile do
         end
       end
 
+      context 'with invalid class name' do
+        let(:master_file) { FactoryBot.create(:master_file, encoder_classname: 'my-awesomeEncode') }
+        it "should fall back to Watched when a workflow class can't be resolved" do
+          expect(subject.encoder_class).to eq(WatchedEncode)
+        end
+      end
+
       context 'with encoder class name' do
         let(:master_file) { FactoryBot.create(:master_file, encoder_classname: 'EncoderModule::MyEncoder') }
         it "should resolve an explicitly named encoder class" do


### PR DESCRIPTION
This safely handles the case when the constant name being passed into `#find_encoder_class` is an invalid constant name (e.g. `Avalon-skip-transcodingEncode`).