### PR TITLE
Catch top-most Exception since LoadError can be thrown

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -37,7 +37,7 @@ class SupplementalFilesController < ApplicationController
     @supplemental_file = SupplementalFile.new(label: supplemental_file_params[:label])
     begin
       @supplemental_file.attach_file(supplemental_file_params[:file])
-    rescue Exception => e
+    rescue StandardError, LoadError => e
       raise Avalon::SaveError, "File could not be attached: #{e.full_message}"
     end
 

--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -37,7 +37,7 @@ class SupplementalFilesController < ApplicationController
     @supplemental_file = SupplementalFile.new(label: supplemental_file_params[:label])
     begin
       @supplemental_file.attach_file(supplemental_file_params[:file])
-    rescue StandardError => e
+    rescue Exception => e
       raise Avalon::SaveError, "File could not be attached: #{e.full_message}"
     end
 

--- a/spec/controllers/supplemental_files_controller_spec.rb
+++ b/spec/controllers/supplemental_files_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe SupplementalFilesController, type: :controller do
       let(:supplemental_file) { FactoryBot.build(:supplemental_file) }
       before do
         allow(SupplementalFile).to receive(:new).and_return(supplemental_file)
-        allow(supplemental_file).to receive(:attach_file).and_raise("ERROR!!!!")
+        allow(supplemental_file).to receive(:attach_file).and_raise(LoadError, "ERROR!!!!")
       end
 
       it 'does not create a SupplementalFile record' do


### PR DESCRIPTION
With spruce configured to use the minio storage configuration without minio setup, a LoadError is thrown when trying to upload a supplemental file.  `LoadError` is not a subclass of `StandardError` so we need to catch `Exception` instead.

Read and Delete also have errors but I'm not sure if we really need to handle them.