### PR TITLE
Check for player existence before getting duration

### DIFF
--- a/app/views/media_objects/_timeline.html.erb
+++ b/app/views/media_objects/_timeline.html.erb
@@ -54,7 +54,7 @@ $(document).ready(function() {
   timeCheck = setInterval(enableTimelineBtn, 500);
 
   function enableTimelineBtn() {
-    if(currentPlayer.duration > 0) {
+    if(currentPlayer && currentPlayer.duration > 0) {
       timelineBtn[0].disabled = false;
       clearInterval(timeCheck);
     }


### PR DESCRIPTION
When checking whether the media derivative is loaded before enabling the `Create Timeline` button on item page, the method keeps on firing on 500ms intervals infinitely when the player is not present.