### PR TITLE
Fix missing svg files for jumforward/skipback icons in ME.js

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,7 +38,6 @@
  * Exclude MediaElement4 CSS in /vendor as it collides w/ MEJS2 styles
  *= stub mediaelement/mediaelementplayer.css
  *= stub mediaelement/plugins/quality.css
- *= stub mediaelement/plugins/seekmedia.css
 
  *= require_self
 */

--- a/app/assets/stylesheets/mejs4_player.scss
+++ b/app/assets/stylesheets/mejs4_player.scss
@@ -23,5 +23,5 @@
  *= require mejs4/mejs4_plugin_create_thumbnail.scss
  *= require mejs4/mejs4_plugin_track_scrubber.scss
  *= require mejs4/mejs4_link_back.scss
- *= require mediaelement/plugins/seekmedia.css
+ *= require mediaelement/plugins/seekmedia.scss
  */

--- a/vendor/assets/stylesheets/mediaelement/plugins/seekmedia.scss
+++ b/vendor/assets/stylesheets/mediaelement/plugins/seekmedia.scss
@@ -1,7 +1,7 @@
 /* Jump forward button styles */
 .mejs__jump-forward-button > button,
 .mejs-jump-forward-button > button {
-    background: url('jumpforward.svg') no-repeat 0 0;
+    background: image-url('./jumpforward.svg') no-repeat 0 0;
     color: #fff;
     font-size: 8px;
     line-height: normal;
@@ -11,7 +11,7 @@
 /* Skip back button styles */
 .mejs__skip-back-button > button,
 .mejs-skip-back-button > button {
-    background: url('skipback.svg') no-repeat 0 -1px;
+    background: image-url('./skipback.svg') no-repeat 0 -1px;
     color: #fff;
     font-size: 8px;
     line-height: normal;


### PR DESCRIPTION
The error was that the CSS file that references the 2 SVG files was excluded in the assets. Therefore when assets are compiled the SVG files are not added to `public/assets`. This PR fixes this issue.
I was not able to start up the container and see this in localhost in the browser, but when building the container with `docker-compose build avalon` the logs shows that the 2 files are added to `/public/assets/` folder as follows;

![Screenshot from 2020-07-01 16-12-55](https://user-images.githubusercontent.com/1331659/86287303-f90bdb80-bbb5-11ea-8f7c-548d8ee45d7a.png)
