### PR TITLE
Add avalon:user:admin rake task

### DIFF
--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -290,6 +290,26 @@ EOC
 
       puts "Updated password for user #{username}"
     end
+
+    desc "Assign user an an administrator"
+    task admin: :environment do
+      puts "Assign user as an administrator"
+      print "Email address for user: "
+      email_address = $stdin.gets.chomp
+      begin
+        new_administrator = User.find_by_email(email_address).user_key
+      rescue NoMethodError
+        abort "User with email address #{email_address} not found"
+      end
+      admin_group = Admin::Group.find('administrator')
+      if admin_group.users.any? new_administrator
+        puts "User with email address #{email_address} is already an administrator"
+      else
+        admin_group.users = admin_group.users + [new_administrator]
+        admin_group.save
+        puts "Successfully assigned #{new_administrator} as an administrator"
+      end
+    end
   end
 
   namespace :test do


### PR DESCRIPTION
When using an omniauth provider such as google, it is helpful to be able
to assign initial administrators to an Avalon application. This commit
adds a rake task to prompt the user for an email address of a user to
assign the administrator role.

Usage:
```
[avalon@lib-avalon-dev current]$ bundle exec rake avalon:user:admin
Assign user as an administrator
Email address for user: mcritchlow@ucsd.edu
Successfully assigned mcritchlow as an administrator
```

If a user does not exist in the system:
```
[avalon@lib-avalon-dev current]$ bundle exec rake avalon:user:admin
Assign user as an administrator
Email address for user: notauser@example.com
User with email address notauser@example.com not found
```