### PR TITLE
Delete dropbox directory when deleting a collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -215,9 +215,6 @@ class Admin::CollectionsController < ApplicationController
     authorize! :destroy, @collection
     @objects    = @collection.media_objects
     @candidates = get_user_collections.reject { |c| c == @collection }
-    @dropbox_objects = Aws::S3::Resource.new.bucket(
-      ENV['SETTINGS__ENCODING__MASTERFILE_BUCKET']).objects(
-        { prefix: "/dropbox/#{@collection.dropbox_directory_name}" }).to_a
   end
 
   # DELETE /collections/1

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -215,6 +215,9 @@ class Admin::CollectionsController < ApplicationController
     authorize! :destroy, @collection
     @objects    = @collection.media_objects
     @candidates = get_user_collections.reject { |c| c == @collection }
+    @dropbox_objects = Aws::S3::Resource.new.bucket(
+      ENV['SETTINGS__ENCODING__MASTERFILE_BUCKET']).objects(
+        { prefix: "/dropbox/#{@collection.dropbox_directory_name}" }).to_a
   end
 
   # DELETE /collections/1

--- a/app/jobs/delete_dropbox_job.rb
+++ b/app/jobs/delete_dropbox_job.rb
@@ -17,13 +17,8 @@ class DeleteDropboxJob < ActiveJob::Base
   queue_as :default
   def perform(path)
     Rails.logger.debug "Attempting to delete dropbox directory #{path}"
-    locator = FileLocator.new(path)
     begin
-      if Settings.dropbox.path.match? %r{^s3://}
-        locator.destroy_s3_dropbox_directory(path)
-      else
-        locator.destroy_fs_dropbox_directory(path)
-      end
+      FileLocator.remove_dir(path)
     rescue StandardError => err
       Rails.logger.warn "Error deleting dropbox directory #{path}: #{err.message}"
     end

--- a/app/jobs/delete_dropbox_job.rb
+++ b/app/jobs/delete_dropbox_job.rb
@@ -17,10 +17,6 @@ class DeleteDropboxJob < ActiveJob::Base
   queue_as :default
   def perform(path)
     Rails.logger.debug "Attempting to delete dropbox directory #{path}"
-    begin
-      FileLocator.remove_dir(path)
-    rescue StandardError => err
-      Rails.logger.warn "Error deleting dropbox directory #{path}: #{err.message}"
-    end
+    FileLocator.remove_dir(path)
   end
 end

--- a/app/jobs/delete_dropbox_job.rb
+++ b/app/jobs/delete_dropbox_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class DeleteDropboxJob < ActiveJob::Base
+  queue_as :default
+  def perform(path)
+    Rails.logger.debug "Attempting to delete dropbox directory #{path}"
+    locator = FileLocator.new(path)
+    begin
+      if Settings.dropbox.path.match? %r{^s3://}
+        locator.destroy_s3_dropbox_directory(path)
+      else
+        locator.destroy_fs_dropbox_directory(path)
+      end
+    rescue StandardError => err
+      Rails.logger.warn "Error deleting dropbox directory #{path}: #{err.message}"
+    end
+  end
+end

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -212,9 +212,8 @@ class Admin::Collection < ActiveFedora::Base
 
   def dropbox_object_count
     if Settings.dropbox.path =~ %r(^s3://)
-      # Build the prefix with dropbox directory name and collection name
-      obj_prefix = dropbox_absolute_path.split('/').last(2).join('/')
-      response = Aws::S3::Client.new.list_objects(bucket: Settings.encoding.masterfile_bucket, max_keys: 10, prefix: "#{obj_prefix}/")
+      dropbox_path = URI.parse(dropbox_absolute_path)
+      response = Aws::S3::Client.new.list_objects(bucket: Settings.encoding.masterfile_bucket, max_keys: 10, prefix: "#{dropbox_path.path}/")
       response.contents.size
     else
       Dir["#{dropbox_absolute_path}/*"].count

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -338,10 +338,16 @@ class Admin::Collection < ActiveFedora::Base
     end
 
     def destroy_fs_dropbox_directory!
-      if File.directory?(dropbox_absolute_path)
-        FileUtils.remove_dir(dropbox_absolute_path)
+      name = calculate_dropbox_directory_name do |n|
+        File.exist? dropbox_absolute_path(n)
+      end
+
+      absolute_path = dropbox_absolute_path(name)
+
+      if File.directory?(absolute_path)
+        FileUtils.remove_dir(absolute_path)
       else
-        Rails.logger.error "Could not delete directory #{dropbox_absolute_path}. Directory not found"
+        Rails.logger.error "Could not delete directory #{absolute_path}. Directory not found"
       end
     end
 

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -70,6 +70,8 @@ class Admin::Collection < ActiveFedora::Base
   around_save :reindex_members, if: Proc.new{ |c| c.name_changed? or c.unit_changed? }
   before_create :create_dropbox_directory!
 
+  before_destroy :destroy_s3_dropbox_directory!
+
   def self.units
     Avalon::ControlledVocabulary.find_by_name(:units, sort: true) || []
   end
@@ -298,6 +300,13 @@ class Admin::Collection < ActiveFedora::Base
       self.dropbox_directory_name = name
     end
 
+    def destroy_s3_dropbox_directory!
+      objects = Aws::S3::Resource.new.bucket(
+        ENV['SETTINGS__ENCODING__MASTERFILE_BUCKET']).objects(
+          { prefix: "/dropbox/#{self.dropbox_directory_name}" })
+      objects.batch_delete!
+    end
+
     def create_fs_dropbox_directory!
       name = calculate_dropbox_directory_name do |n|
         File.exist? dropbox_absolute_path(n)
@@ -313,6 +322,10 @@ class Admin::Collection < ActiveFedora::Base
       end
       self.dropbox_directory_name = name
     end
+
+    # def destroy_fs_dropbox_directory!
+      
+    # end
 
     # Override represented_visibility if you want to add another visibility that is
     # represented as a read group (e.g. on-campus)

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -212,7 +212,10 @@ class Admin::Collection < ActiveFedora::Base
 
   def dropbox_object_count
     if Settings.dropbox.path =~ %r(^s3://)
-      Aws::S3::Bucket.new(name: Settings.encoding.masterfile_bucket).objects(prefix: "/dropbox/#{dropbox_directory_name}").to_a.size
+      # Build the prefix with dropbox directory name and collection name
+      obj_prefix = dropbox_absolute_path.split('/').last(2).join('/')
+      response = Aws::S3::Client.new.list_objects(bucket: Settings.encoding.masterfile_bucket, max_keys: 10, prefix: "#{obj_prefix}/")
+      response.contents.size
     else
       Dir["#{dropbox_absolute_path}/*"].count
     end
@@ -282,11 +285,7 @@ class Admin::Collection < ActiveFedora::Base
     end
 
     def destroy_dropbox_directory!
-      if Settings.dropbox.path =~ %r(^s3://)
-        destroy_s3_dropbox_directory!
-      else
-        destroy_fs_dropbox_directory!
-      end
+      DeleteDropboxJob.perform_later(dropbox_absolute_path)
     end
 
     def calculate_dropbox_directory_name
@@ -316,11 +315,6 @@ class Admin::Collection < ActiveFedora::Base
       self.dropbox_directory_name = name
     end
 
-    def destroy_s3_dropbox_directory!
-      objects = Aws::S3::Bucket.new(name: Settings.encoding.masterfile_bucket).objects(prefix: "/dropbox/#{dropbox_directory_name}")
-      objects.batch_delete!
-    end
-
     def create_fs_dropbox_directory!
       name = calculate_dropbox_directory_name do |n|
         File.exist? dropbox_absolute_path(n)
@@ -335,20 +329,6 @@ class Admin::Collection < ActiveFedora::Base
         end
       end
       self.dropbox_directory_name = name
-    end
-
-    def destroy_fs_dropbox_directory!
-      name = calculate_dropbox_directory_name do |n|
-        File.exist? dropbox_absolute_path(n)
-      end
-
-      absolute_path = dropbox_absolute_path(name)
-
-      if File.directory?(absolute_path)
-        FileUtils.remove_dir(absolute_path)
-      else
-        Rails.logger.error "Could not delete directory #{absolute_path}. Directory not found"
-      end
     end
 
     # Override represented_visibility if you want to add another visibility that is

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -128,9 +128,13 @@ class FileLocator
   def destroy_s3_dropbox_directory(dropbox_path)
     # Build the prefix with dropbox directory name and collection name
     obj_prefix = dropbox_path.split('/').last(2).join('/')
+
     bucket = Aws::S3::Resource.new.bucket(Settings.encoding.masterfile_bucket)
-    objects = bucket.objects(prefix: "#{obj_prefix}/")
-    objects.batch_delete!
+    bucket.objects(prefix: "#{obj_prefix}/").batch_delete!
+
+    # When collection's dropbox directory is empty
+    dropbox_dir = bucket.object("#{obj_prefix}/")
+    dropbox_dir.delete if dropbox_dir.exists?
   end
 
   def destroy_fs_dropbox_directory(dropbox_path)

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -124,4 +124,20 @@ class FileLocator
       location
     end
   end
+
+  def destroy_s3_dropbox_directory(dropbox_path)
+    # Build the prefix with dropbox directory name and collection name
+    obj_prefix = dropbox_path.split('/').last(2).join('/')
+    bucket = Aws::S3::Resource.new.bucket(Settings.encoding.masterfile_bucket)
+    objects = bucket.objects(prefix: "#{obj_prefix}/")
+    objects.batch_delete!
+  end
+
+  def destroy_fs_dropbox_directory(dropbox_path)
+    if File.directory?(dropbox_path)
+      FileUtils.remove_dir(dropbox_path)
+    else
+      Rails.logger.error "Could not delete directory #{dropbox_path}. Directory not found"
+    end
+  end
 end

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -28,10 +28,10 @@ Unless required by applicable law or agreed to in writing, software distributed
     content_pronoun = @objects.count > 1 ? 'them' : 'it'
   %>
 
-    <% if @dropbox_objects.count > 0 %>
+    <% if @collection.dropbox_object_count > 0 %>
       <div class="alert alert-warning">
         <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-        <span>There are <%= @dropbox_objects.count %> files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
+        <span>There are <%= @collection.dropbox_object_count %> files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
       </div>
     <% end %>
 

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -31,7 +31,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% if @collection.dropbox_object_count > 0 %>
       <div class="alert alert-warning">
         <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-        <span>There are files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
+        <span>There are saved files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
       </div>
     <% end %>
 

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -27,27 +27,34 @@ Unless required by applicable law or agreed to in writing, software distributed
     item_count = "#{@objects.count} #{'item'.pluralize(@objects.count)}"
     content_pronoun = @objects.count > 1 ? 'them' : 'it'
   %>
-    <% if @collection.media_objects.count == 0 or @candidates.count > 0 %>
-    <div class="alert alert-danger">
-      <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-      <span>Are you certain you want to remove the collection <b><%=@collection.name%></b>?</span>
-    </div>
 
-    <%= bootstrap_form_for @collection, method: :delete do |f| %>
-    <% if @objects.count > 0 %>
-
-    <h2>Reassign Existing Items</h2>
-    <p>
-      <b><%=@collection.name%></b> currently contains <%=item_count%>. Before you can
-      delete it, you must select a new collection to move <%=content_pronoun%>
-      into.
-    </p>
-    <div class="form-group">
-      <%= select_tag :target_collection_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control" %>
-    </div>
-
-
+    <% if @dropbox_objects.count > 0 %>
+      <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+        <span>There are <%= @dropbox_objects.count %> files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
+      </div>
     <% end %>
+
+    <% if @collection.media_objects.count == 0 or @candidates.count > 0 %>
+      <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+        <span>Are you certain you want to remove the collection <b><%=@collection.name%></b>?</span>
+      </div>
+
+      <%= bootstrap_form_for @collection, method: :delete do |f| %>
+      <% if @objects.count > 0 %>
+
+      <h2>Reassign Existing Items</h2>
+      <p>
+        <b><%=@collection.name%></b> currently contains <%=item_count%>. Before you can
+        delete it, you must select a new collection to move <%=content_pronoun%>
+        into.
+      </p>
+      <div class="form-group">
+        <%= select_tag :target_collection_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control" %>
+      </div>
+    <% end %>
+
     <div class="form-group">
       <%= f.submit 'Yes, I am sure', class: 'btn btn-danger' %>
       <%= link_to 'No, go back', admin_collections_path, class: 'btn btn-default' %>

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -31,7 +31,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% if @collection.dropbox_object_count > 0 %>
       <div class="alert alert-warning">
         <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-        <span>There are <%= @collection.dropbox_object_count %> files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
+        <span>There are files in this collection's <b>Dropbox</b> that will be deleted when this collection is deleted.</span>
       </div>
     <% end %>
 

--- a/spec/jobs/delete_dropbox_job_spec.rb
+++ b/spec/jobs/delete_dropbox_job_spec.rb
@@ -27,20 +27,20 @@ describe DeleteDropboxJob do
       allow(FileLocator).to receive(:new).and_return(fs_locator)
     end
 
-    context 'fs dropbox directory' do
-      it 'dir gets deleted' do
+    context 'using filesystem' do
+      it 'calls destroy_fs_dropbox_directory' do
         expect(fs_locator).to receive(:destroy_fs_dropbox_directory).with(fs_dropbox).once
         DeleteDropboxJob.perform_now(fs_dropbox)
       end
     end
 
-    context 's3 dropbox directory' do
+    context 'using s3' do
       before do
         Settings.dropbox.path = "s3://temp/dropbox"
         allow(FileLocator).to receive(:new).and_return(s3_locator)
       end
 
-      it 'dir gets deleted' do
+      it 'calls destroy_s3_dropbox_directory' do
         expect(s3_locator).to receive(:destroy_s3_dropbox_directory).with(s3_dropbox).once
         DeleteDropboxJob.perform_now(s3_dropbox)
       end

--- a/spec/jobs/delete_dropbox_job_spec.rb
+++ b/spec/jobs/delete_dropbox_job_spec.rb
@@ -16,8 +16,7 @@ require 'rails_helper'
 require 'aws-sdk-s3'
 
 describe DeleteDropboxJob do
-  let(:old_path) { Settings.dropbox.path }
-  let(:fs_dropbox) { '/temp/dropbox/test_collection' }
+  let(:fs_dropbox) { 'file://temp/dropbox/test_collection' }
   let(:s3_dropbox) { 's3://temp/dropbox/test_collection' }
 
   describe "perform" do
@@ -26,19 +25,9 @@ describe DeleteDropboxJob do
       DeleteDropboxJob.perform_now(fs_dropbox)
     end
 
-    context 'using s3' do
-      before do
-        Settings.dropbox.path = "s3://temp/dropbox"
-      end
-
-      it 'deletes s3 dir' do
-        expect(FileLocator).to receive(:remove_dir).with(s3_dropbox).once
-        DeleteDropboxJob.perform_now(s3_dropbox)
-      end
-
-      after do
-        Settings.dropbox.path = old_path
-      end
+    it 'deletes s3 dir' do
+      expect(FileLocator).to receive(:remove_dir).with(s3_dropbox).once
+      DeleteDropboxJob.perform_now(s3_dropbox)
     end
   end
 end

--- a/spec/jobs/delete_dropbox_job_spec.rb
+++ b/spec/jobs/delete_dropbox_job_spec.rb
@@ -16,32 +16,23 @@ require 'rails_helper'
 require 'aws-sdk-s3'
 
 describe DeleteDropboxJob do
-  let(:fs_dropbox) { '/temp/dropbox/test_collection' }
-  let(:fs_locator) { FileLocator.new(fs_dropbox) }
-  let(:s3_dropbox) { 's3://temp/dropbox/test_collection' }
-  let(:s3_locator) { FileLocator.new(s3_dropbox) }
   let(:old_path) { Settings.dropbox.path }
+  let(:fs_dropbox) { '/temp/dropbox/test_collection' }
+  let(:s3_dropbox) { 's3://temp/dropbox/test_collection' }
 
   describe "perform" do
-    before do
-      allow(FileLocator).to receive(:new).and_return(fs_locator)
-    end
-
-    context 'using filesystem' do
-      it 'calls destroy_fs_dropbox_directory' do
-        expect(fs_locator).to receive(:destroy_fs_dropbox_directory).with(fs_dropbox).once
-        DeleteDropboxJob.perform_now(fs_dropbox)
-      end
+    it 'deletes filesystem dir' do
+      expect(FileLocator).to receive(:remove_dir).with(fs_dropbox).once
+      DeleteDropboxJob.perform_now(fs_dropbox)
     end
 
     context 'using s3' do
       before do
         Settings.dropbox.path = "s3://temp/dropbox"
-        allow(FileLocator).to receive(:new).and_return(s3_locator)
       end
 
-      it 'calls destroy_s3_dropbox_directory' do
-        expect(s3_locator).to receive(:destroy_s3_dropbox_directory).with(s3_dropbox).once
+      it 'deletes s3 dir' do
+        expect(FileLocator).to receive(:remove_dir).with(s3_dropbox).once
         DeleteDropboxJob.perform_now(s3_dropbox)
       end
 

--- a/spec/jobs/delete_dropbox_job_spec.rb
+++ b/spec/jobs/delete_dropbox_job_spec.rb
@@ -1,0 +1,53 @@
+# Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+require 'aws-sdk-s3'
+
+describe DeleteDropboxJob do
+  let(:fs_dropbox) { '/temp/dropbox/test_collection' }
+  let(:fs_locator) { FileLocator.new(fs_dropbox) }
+  let(:s3_dropbox) { 's3://temp/dropbox/test_collection' }
+  let(:s3_locator) { FileLocator.new(s3_dropbox) }
+  let(:old_path) { Settings.dropbox.path }
+
+  describe "perform" do
+    before do
+      allow(FileLocator).to receive(:new).and_return(fs_locator)
+    end
+
+    context 'fs dropbox directory' do
+      it 'dir gets deleted' do
+        expect(fs_locator).to receive(:destroy_fs_dropbox_directory).with(fs_dropbox).once
+        DeleteDropboxJob.perform_now(fs_dropbox)
+      end
+    end
+
+    context 's3 dropbox directory' do
+      before do
+        Settings.dropbox.path = "s3://temp/dropbox"
+        allow(FileLocator).to receive(:new).and_return(s3_locator)
+      end
+
+      it 'dir gets deleted' do
+        expect(s3_locator).to receive(:destroy_s3_dropbox_directory).with(s3_dropbox).once
+        DeleteDropboxJob.perform_now(s3_dropbox)
+      end
+
+      after do
+        Settings.dropbox.path = old_path
+      end
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -549,15 +549,15 @@ describe Admin::Collection do
     end
   end
 
-  # describe '#destroy_dropbox_directory!' do
-  #   let(:collection){ FactoryBot.build(:collection)}
+  describe '#destroy_dropbox_directory!' do
+    let(:collection){ FactoryBot.build(:collection)}
 
-  #   it 'deletes S3 dropbox directory' do
-  #     collection.name = 'black history'
-  #     collection.send(:destroy_s3_dropbox_directory!)
-  #     expect(File.directory?(File.join(Settings.dropbox.path, 'black_history')).to_be falsey)
-  #   end
-  # end
+    it 'deletes collection\'s dropbox directory' do
+      collection.name = 'black history'
+      collection.send(:destroy_dropbox_directory!)
+      expect(File.directory?(File.join(Settings.dropbox.path, 'black_history'))).to be_falsey
+    end
+  end
 
   describe 'Unicode' do
     let(:collection_name) { "Collections & Favorites / \u6211\u7684\u6536\u85cf / \u03a4\u03b1 \u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1 \u03bc\u03bf\u03c5" }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -549,6 +549,16 @@ describe Admin::Collection do
     end
   end
 
+  # describe '#destroy_dropbox_directory!' do
+  #   let(:collection){ FactoryBot.build(:collection)}
+
+  #   it 'deletes S3 dropbox directory' do
+  #     collection.name = 'black history'
+  #     collection.send(:destroy_s3_dropbox_directory!)
+  #     expect(File.directory?(File.join(Settings.dropbox.path, 'black_history')).to_be falsey)
+  #   end
+  # end
+
   describe 'Unicode' do
     let(:collection_name) { "Collections & Favorites / \u6211\u7684\u6536\u85cf / \u03a4\u03b1 \u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1 \u03bc\u03bf\u03c5" }
     let(:collection_dir)  { "Collections___Favorites___\u6211\u7684\u6536\u85cf___\u03a4\u03b1_\u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1_\u03bc\u03bf\u03c5" }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -549,16 +549,6 @@ describe Admin::Collection do
     end
   end
 
-  describe '#destroy_dropbox_directory!' do
-    let(:collection){ FactoryBot.build(:collection)}
-
-    it 'deletes collection\'s dropbox directory' do
-      collection.name = 'black history'
-      collection.send(:destroy_dropbox_directory!)
-      expect(File.directory?(File.join(Settings.dropbox.path, 'black_history'))).to be_falsey
-    end
-  end
-
   describe 'Unicode' do
     let(:collection_name) { "Collections & Favorites / \u6211\u7684\u6536\u85cf / \u03a4\u03b1 \u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1 \u03bc\u03bf\u03c5" }
     let(:collection_dir)  { "Collections___Favorites___\u6211\u7684\u6536\u85cf___\u03a4\u03b1_\u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1_\u03bc\u03bf\u03c5" }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -549,6 +549,19 @@ describe Admin::Collection do
     end
   end
 
+  describe "#destroy_dropbox_directory!" do
+    let(:collection){ FactoryBot.build(:collection) }
+
+    before do
+      collection.send(:create_dropbox_directory!)
+    end
+
+    it 'should queue a delete dropbox job' do
+      collection.send(:destroy_dropbox_directory!)
+      expect(DeleteDropboxJob).to have_been_enqueued.with(collection.dropbox_absolute_path)
+    end
+  end
+
   describe 'Unicode' do
     let(:collection_name) { "Collections & Favorites / \u6211\u7684\u6536\u85cf / \u03a4\u03b1 \u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1 \u03bc\u03bf\u03c5" }
     let(:collection_dir)  { "Collections___Favorites___\u6211\u7684\u6536\u85cf___\u03a4\u03b1_\u03b1\u03b3\u03b1\u03c0\u03b7\u03bc\u03ad\u03bd\u03b1_\u03bc\u03bf\u03c5" }

--- a/spec/services/file_locator_spec.rb
+++ b/spec/services/file_locator_spec.rb
@@ -127,7 +127,7 @@ describe FileLocator, type: :service do
       let(:file_path) { "/tmp/dropbox/test/mykey.mp4" }
       let(:locator) { FileLocator.new(file_path) }
   
-      it 'deletes collection\'s fs dropbox dir' do
+      it 'deletes fs dir' do
         allow(File).to receive(:exist?).with(file_path) { true }
         expect(locator.exist?).to be_truthy
         FileLocator.remove_dir("file://tmp/dropbox/test")
@@ -151,7 +151,6 @@ describe FileLocator, type: :service do
 
       before do
         Settings.encoding.masterfile_bucket = test_bucket
-        Settings.dropbox.path = "s3://test_bucket/dropbox"
 
         allow(Aws::S3::Resource).to receive(:new).and_return(s3_res)
         allow(s3_res).to receive(:bucket).and_return(s3_bucket)
@@ -170,18 +169,17 @@ describe FileLocator, type: :service do
         expect(s3_bucket).to receive(:object).with(dropbox_prefix)
         expect(s3_directory).to receive(:exists?)
         expect(s3_directory).to receive(:delete).once
-        FileLocator.remove_dir(dropbox_path)
+        FileLocator.remove_s3_dir(dropbox_path)
       end
 
-      it 'deletes dir with its content' do
+      it 'when there\'s files inside' do
         expect(s3_bucket).to receive(:objects).with(prefix: dropbox_prefix)
         expect(s3_contents).to receive(:batch_delete!).once
-        FileLocator.remove_dir(dropbox_path)
+        FileLocator.remove_s3_dir(dropbox_path)
       end
 
       after do
         Settings.encoding.masterfile_bucket = old_bucket
-        Settings.dropbox.path = old_path
       end
     end
   end


### PR DESCRIPTION
Deletes collection's dropbox on S3 bucket/file system based on the settings when the collection is deleted. And shows the user the following warning when deleting the collection.

![Screenshot from 2020-07-29 15-05-26](https://user-images.githubusercontent.com/1331659/88842090-f4cee000-d1ac-11ea-9d17-fae372b10ad4.png)

I'm not sure whether we should add something to the reassign note to make sure the user is aware that the dropbox files are not re-assigned but deleted permanently. @joncameron what do you think?