### PR TITLE
Require Git SCM plugin for Capistrano

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,6 +3,8 @@ require "capistrano/setup"
 
 # Include default deployment tasks
 require "capistrano/deploy"
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 
 require 'capistrano/rvm'
 require 'capistrano/bundler'


### PR DESCRIPTION
To prevent deprecation warnings such as:

```
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:
    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git
```