### PR TITLE
Add an intermediate page when accessing restricted content

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,11 +156,9 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     if request.format == :json
       head :unauthorized
-    elsif current_user
-      redirect_to root_path, flash: { notice: 'You are not authorized to perform this action.' }
     else
       session[:previous_url] = request.fullpath unless request.xhr?
-      redirect_to new_user_session_path(url: request.url), flash: { notice: 'You are not authorized to perform this action. Try logging in.' }
+      render '/errors/restricted_pid'
     end
   end
 

--- a/app/views/errors/restricted_pid.html.erb
+++ b/app/views/errors/restricted_pid.html.erb
@@ -1,0 +1,26 @@
+<%#
+Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+<div id="main_content_container" class="container-fluid">
+  <div class="content" class="col-md-8">
+    <h2>Restricted Content</h2>
+    <% if current_user.nil? %>
+      <p>You're not signed in. You may be able to view this item after signing in.</p>
+      <%= link_to 'Sign in', main_app.new_user_session_path, class: "btn btn-info" %>
+    <% else %>
+      <p>You are not authorized to access this content.</p>
+    <% end %>
+  </div>
+</div>

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -42,22 +42,22 @@ describe Admin::CollectionsController, type: :controller do
         before do
           login_as :user
         end
-        #New is isolated here due to issues caused by the controller instance not being regenerated
-        it "should redirect to /" do
-          expect(get :new).to redirect_to(root_path)
+        # New is isolated here due to issues caused by the controller instance not being regenerated
+        it "should redirect to restricted content page" do
+          expect(get :new).to render_template('errors/restricted_pid')
         end
-        it "all routes should redirect to /" do
-          expect(get :index).to redirect_to(root_path)
-          expect(get :show, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :edit, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
-          expect(post :create).to redirect_to(root_path)
-          expect(put :update, params: { id: collection.id }).to redirect_to(root_path)
-          expect(patch :update, params: { id: collection.id }).to redirect_to(root_path)
-          expect(delete :destroy, params: { id: collection.id }).to redirect_to(root_path)
-          expect(post :attach_poster, params: { id: collection.id }).to redirect_to(root_path)
-          expect(delete :remove_poster, params: { id: collection.id }).to redirect_to(root_path)
-          expect(get :poster, params: { id: collection.id }).to redirect_to(root_path)
+        it "all routes should redirect to restricted content page" do
+          expect(get :index).to render_template('errors/restricted_pid')
+          expect(get :show, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :edit, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :remove, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(post :create).to render_template('errors/restricted_pid')
+          expect(put :update, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(patch :update, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(delete :destroy, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(post :attach_poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(delete :remove_poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
         end
       end
     end
@@ -369,11 +369,10 @@ describe Admin::CollectionsController, type: :controller do
   describe "#remove" do
     let!(:collection) { FactoryBot.create(:collection) }
 
-    it "redirects with message when user does not have ability to delete collection" do
+    it "redirects to restricted content page when user does not have ability to delete collection" do
       login_as :user
       expect(controller.current_ability.can? :destroy, collection).to be_falsey
-      expect(get :remove, params: { id: collection.id }).to redirect_to(root_path)
-      expect(flash[:notice]).not_to be_empty
+      expect(get :remove, params: { id: collection.id }).to render_template('errors/restricted_pid')
     end
     it "displays confirmation form for managers" do
       login_user collection.managers.first

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -23,16 +23,16 @@ describe CollectionsController, type: :controller do
       before do
         login_as :user
       end
-      it "all routes should redirect to /" do
-        expect(get :show, params: { id: collection.id }).to redirect_to(root_path)
-        expect(get :poster, params: { id: collection.id }).to redirect_to(root_path)
+      it "all routes should redirect to restricted content page" do
+        expect(get :show, params: { id: collection.id }).to render_template('errors/restricted_pid')
+        expect(get :poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
       end
     end
 
     context 'with unauthenticated user' do
-      it "all routes should redirect to sign in" do
-        expect(get :show, params: { id: collection.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :poster, params: { id: collection.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      it "all routes should redirect to restricted content page" do
+        expect(get :show, params: { id: collection.id }).to render_template('errors/restricted_pid')
+        expect(get :poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
       end
     end
   end

--- a/spec/controllers/dropbox_controller_spec.rb
+++ b/spec/controllers/dropbox_controller_spec.rb
@@ -46,7 +46,7 @@ describe DropboxController do
     it "should not allow #{group} to delete" do
       login_as group
       delete :bulk_delete, params: { :collection_id => @collection.id, :filenames => @temp_files.map{|f| f[:name]} }
-      expect(response.status).to redirect_to(root_path)
+      expect(response).to render_template('errors/restricted_pid')
     end
   end
 end

--- a/spec/controllers/encode_records_controller_spec.rb
+++ b/spec/controllers/encode_records_controller_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe EncodeRecordsController, type: :controller do
     context 'when not administrator' do
       let(:user) { FactoryBot.create(:user) }
 
-      it "redirects" do
+      it "redirects to restricted content page" do
         get :index, params: {}, session: valid_session
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('errors/restricted_pid')
       end
     end
   end
@@ -74,9 +74,9 @@ RSpec.describe EncodeRecordsController, type: :controller do
     context 'when not administrator' do
       let(:user) { FactoryBot.create(:user) }
 
-      it "redirects" do
+      it "redirects to restricted content page" do
         get :index, params: {}, session: valid_session
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('errors/restricted_pid')
       end
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -21,46 +21,40 @@ describe Admin::GroupsController do
   test_group_new = "rspec_test_group_new"
 
   describe 'index' do
-    it "index should redirect to sign in page with a notice when unauthenticated" do
+    it "index should redirect to restricted content page when unauthenticated" do
       get 'index'
-      expect(flash[:notice]).not_to be_nil
-      expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      expect(response).to render_template('errors/restricted_pid')
     end
 
-    it "index new should redirect to home page with a notice when authenticated but unauthorized" do
+    it "index new should redirect to restricted content page when authenticated but unauthorized" do
       login_as('student')
       get 'index'
-      expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).not_to be_nil
+      expect(response).to render_template('errors/restricted_pid')
     end
   end
 
   describe "creating a new group" do
-    it "new should redirect to sign in page with a notice when unauthenticated" do
+    it "new should redirect to restricted content page when unauthenticated" do
   	  expect { get 'new' }.not_to change { Admin::Group.all.count }
-  	  expect(flash[:notice]).not_to be_nil
-  	  expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+  	  expect(response).to render_template('errors/restricted_pid')
   	end
 
-    it "new should redirect to home page with a notice when authenticated but unauthorized" do
+    it "new should redirect to restricted content page when authenticated but unauthorized" do
       login_as('student')
       expect { get 'new' }.not_to change {Admin::Group.all.count}
-      expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).not_to be_nil
+      expect(response).to render_template('errors/restricted_pid')
     end
 
-    it "create should redirect to sign in page with a notice on when unauthenticated" do
+    it "create should redirect to restricted content page when unauthenticated" do
       expect { post 'create', params: { admin_group: test_group } }.not_to change {Admin::Group.all.count }
-      expect(flash[:notice]).not_to be_nil
-      expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      expect(response).to render_template('errors/restricted_pid')
     end
 
-    it "create should redirect to home page with a notice when authenticated but unauthorized" do
+    it "create should redirect to restricted content page when authenticated but unauthorized" do
       login_as('student')
 
       expect { post 'create', params: { admin_group: test_group } }.not_to change {Admin::Group.all.count }
-      expect(flash[:notice]).not_to be_nil
-      expect(response).to redirect_to(root_path)
+      expect(response).to render_template('errors/restricted_pid')
     end
 
     it "create should redirect to group index page with a notice when group name is already taken" do
@@ -91,34 +85,30 @@ describe Admin::GroupsController do
     let!(:group) {Admin::Group.find(FactoryBot.create(:group).name)}
 
     context "editing a group" do
-      it "edit should redirect to sign in page with a notice on when unauthenticated" do
+      it "edit should redirect to restricted content page when unauthenticated" do
         get 'edit', params: { id: group.name }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
-      it "edit should redirect to home page with a notice when authenticated but unauthorized" do
+      it "edit should redirect to restricted content page when authenticated but unauthorized" do
         login_as('student')
 
         get 'edit', params: { id: group.name }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
-      it "update should redirect to sign in page with a notice on when unauthenticated" do
+      it "update should redirect to restricted content page when unauthenticated" do
         new_user = FactoryBot.build(:user).user_key
         put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
-      it "update should redirect to home page with a notice when authenticated but unauthorized" do
+      it "update should redirect to restricted content page when authenticated but unauthorized" do
         login_as('student')
         new_user = FactoryBot.build(:user).user_key
 
         put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
       it "should be able to change group users when authenticated and authorized" do
@@ -203,19 +193,17 @@ describe Admin::GroupsController do
     end
 
     context "Deleting a group" do
-      it "should redirect to sign in page with a notice on when unauthenticated" do
+      it "should redirect to restricted content page when unauthenticated" do
 
         expect { put 'update_multiple', params: { group_ids: [group.name] } }.not_to change { Avalon::RoleControls.users(group.name) }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
-      it "should redirect to home page with a notice when authenticated but unauthorized" do
+      it "should redirect to restricted content page when authenticated but unauthorized" do
         login_as('student')
 
         expect { put 'update_multiple', params: { group_ids: [group.name] } }.not_to change { Avalon::RoleControls.users(group.name) }
-        expect(flash[:notice]).not_to be_nil
-        expect(response).to redirect_to(root_path)
+        expect(response).to render_template('errors/restricted_pid')
       end
 
       it "should be able to change group users when authenticated and authorized" do

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -202,11 +202,10 @@ describe MasterFilesController do
       expect(master_file.media_object.reload.ordered_master_files.to_a).not_to include master_file
     end
 
-    it "redirects with a flash warning for end users" do
+    it "redirect to restricted content page for end users" do
       login_as :user
       expect(controller.current_ability.can?(:destroy, master_file)).to be_falsey
-      expect(post(:destroy, params: { id: master_file.id })).to redirect_to(root_path)
-      expect(flash[:notice]).not_to be_empty
+      expect(post(:destroy, params: { id: master_file.id })).to render_template('errors/restricted_pid')
     end
   end
 
@@ -264,14 +263,14 @@ describe MasterFilesController do
   describe "#set_frame" do
     subject(:mf) { FactoryBot.create(:master_file, :with_thumbnail, :with_media_object) }
 
-    it "redirects to sign in when not logged in" do
+    it "redirects to restricted content page when not logged in" do
       get(:set_frame, params: { id: mf.id })
-      expect(request).to redirect_to new_user_session_path(url: request.url)
+      expect(request).to render_template('errors/restricted_pid')
     end
 
-    it "redirects to home when logged in and not authorized" do
+    it "redirects to restricted content page when logged in and not authorized" do
       login_as :user
-      expect(get(:set_frame, params: { id: mf.id })).to redirect_to root_path
+      expect(get(:set_frame, params: { id: mf.id })).to render_template('errors/restricted_pid')
     end
 
     context "authorized" do
@@ -295,14 +294,14 @@ describe MasterFilesController do
     subject(:mf) { FactoryBot.create(:master_file, :with_thumbnail, :with_media_object) }
 
     context "not authorized" do
-      it "redirects to sign in when not logged in" do
+      it "redirects to restricted content page when not logged in" do
         get(:get_frame, params: { id: mf.id })
-        expect(request).to redirect_to new_user_session_path(url: request.url)
+        expect(request).to render_template('errors/restricted_pid')
       end
 
-      it "redirects to home when logged in and not authorized" do
+      it "redirects to restricted content page when logged in and not authorized" do
         login_as :user
-        expect(get(:get_frame, params: { id: mf.id })).to redirect_to root_path
+        expect(get(:get_frame, params: { id: mf.id })).to render_template('errors/restricted_pid')
       end
 
     end
@@ -580,28 +579,28 @@ describe MasterFilesController do
 
     context 'security' do
       context 'as anonymous' do
-        it 'redirects to home page' do
+        it 'redirects to restricted content page' do
           post('move', params: { id: master_file.id, target: target_media_object.id })
-          expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(response).to render_template('errors/restricted_pid')
         end
       end
       context 'as an end user' do
         before do
           login_as :student
         end
-        it 'redirects to home page' do
+        it 'redirects to restricted content page' do
           post('move', params: { id: master_file.id, target: target_media_object.id })
-          expect(response).to redirect_to root_path
+          expect(response).to render_template('errors/restricted_pid')
         end
       end
       context 'when only have update permissions on one media object' do
-        it 'redirects to home page' do
+        it 'redirects to restricted content page' do
           login_user master_file.media_object.collection.managers.first
           post('move', params: { id: master_file.id, target: target_media_object.id })
-          expect(response).to redirect_to root_path
+          expect(response).to render_template('errors/restricted_pid')
           login_user target_media_object.collection.managers.first
           post('move', params: { id: master_file.id, target: target_media_object.id })
-          expect(response).to redirect_to root_path
+          expect(response).to render_template('errors/restricted_pid')
         end
       end
     end

--- a/spec/controllers/migration_status_controller_spec.rb
+++ b/spec/controllers/migration_status_controller_spec.rb
@@ -21,11 +21,11 @@ describe MigrationStatusController do
 
   describe 'security' do
     context 'not logged in' do
-      it "all routes should redirect to sign in" do
-        expect(get :index).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :show, params: { class: 'MediaObject' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :detail, params: { id: 'avalon:12345' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :report, params: { id: 'avalon:12345' }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      it "all routes should redirect to restricted content page" do
+        expect(get :index).to render_template('errors/restricted_pid')
+        expect(get :show, params: { class: 'MediaObject' }).to render_template('errors/restricted_pid')
+        expect(get :detail, params: { id: 'avalon:12345' }).to render_template('errors/restricted_pid')
+        expect(get :report, params: { id: 'avalon:12345' }).to render_template('errors/restricted_pid')
       end
     end
 
@@ -34,11 +34,11 @@ describe MigrationStatusController do
         login_as :user
       end
 
-      it "all routes should redirect to /" do
-        expect(get :index).to redirect_to(root_path)
-        expect(get :show, params: { class: 'MediaObject' }).to redirect_to(root_path)
-        expect(get :detail, params: { id: 'avalon:12345' }).to redirect_to(root_path)
-        expect(get :report, params: { id: 'avalon:12345' }).to redirect_to(root_path)
+      it "all routes should redirect to restricted content page" do
+        expect(get :index).to render_template('errors/restricted_pid')
+        expect(get :show, params: { class: 'MediaObject' }).to render_template('errors/restricted_pid')
+        expect(get :detail, params: { id: 'avalon:12345' }).to render_template('errors/restricted_pid')
+        expect(get :report, params: { id: 'avalon:12345' }).to render_template('errors/restricted_pid')
       end
     end
   end

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe PlaylistsController, type: :controller do
       it "should redirect to sign in" do
         expect(get :new).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
+      # Show is isolated because it does not require authorization before the action
+      it "playlist view page should redirect to restricted content page" do
+        expect(get :show, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+        expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to render_template('errors/restricted_pid')
+      end
       it "all routes should redirect to sign in" do
         expect(get :index).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         expect(get :edit, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
@@ -70,7 +75,6 @@ RSpec.describe PlaylistsController, type: :controller do
         expect(put :update, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         expect(put :update_multiple, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
         expect(delete :destroy, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
       end
       context 'with a public playlist' do
         let(:playlist) { FactoryBot.create(:playlist, visibility: Playlist::PUBLIC, items: [playlist_item]) }
@@ -82,8 +86,8 @@ RSpec.describe PlaylistsController, type: :controller do
       end
       context 'with a private playlist' do
         it "should NOT return the playlist view page" do
-          expect(get :show, params: { id: playlist.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-          expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :show, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+          expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to render_template('errors/restricted_pid')
         end
       end
       context 'with a private playlist and token' do
@@ -99,12 +103,12 @@ RSpec.describe PlaylistsController, type: :controller do
       before do
         login_as :user
       end
-      it "all routes should redirect to /" do
-        expect(get :edit, params: { id: playlist.id }).to redirect_to(root_path)
-        expect(put :update, params: { id: playlist.id }).to redirect_to(root_path)
-        expect(put :update_multiple, params: { id: playlist.id }).to redirect_to(root_path)
-        expect(delete :destroy, params: { id: playlist.id }).to redirect_to(root_path)
-        expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to redirect_to(root_path)
+      it "all routes should redirect to restricted content page" do
+        expect(get :edit, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+        expect(put :update, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+        expect(put :update_multiple, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+        expect(delete :destroy, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+        expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to render_template('errors/restricted_pid')
       end
       context 'with a public playlist' do
         let(:playlist) { FactoryBot.create(:playlist, visibility: Playlist::PUBLIC, items: [playlist_item]) }
@@ -115,9 +119,9 @@ RSpec.describe PlaylistsController, type: :controller do
         end
       end
       context 'with a private playlist' do
-        it "should NOT return the playlist view page" do
-          expect(get :show, params: { id: playlist.id }).to redirect_to(root_path)
-          expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to redirect_to(root_path)
+        it "should NOT return the pdfslaylist view page" do
+          expect(get :show, params: { id: playlist.id }).to render_template('errors/restricted_pid')
+          expect(get :refresh_info, params: { id: playlist.id, position: 1 }, xhr: true).to render_template('errors/restricted_pid')
         end
       end
       context 'with a private playlist and token' do

--- a/spec/controllers/supplemental_files_controller_spec.rb
+++ b/spec/controllers/supplemental_files_controller_spec.rb
@@ -45,22 +45,22 @@ RSpec.describe SupplementalFilesController, type: :controller do
 
   describe 'security' do
     context 'with unauthenticated user' do
-      it "all routes should redirect to sign in" do
-        expect(post :create, params: { master_file_id: master_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
-        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+      it "all routes should redirect to restricted content page" do
+        expect(post :create, params: { master_file_id: master_file.id }).to render_template('errors/restricted_pid')
+        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
+        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
+        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
       end
     end
     context 'with end-user' do
       before do
         login_as :user
       end
-      it "all routes should redirect to /" do
-        expect(post :create, params: { master_file_id: master_file.id }).to redirect_to(root_path)
-        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
-        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
-        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to redirect_to(root_path)
+      it "all routes should redirect to restricted content page" do
+        expect(post :create, params: { master_file_id: master_file.id }).to render_template('errors/restricted_pid')
+        expect(put :update, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
+        expect(delete :destroy, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
+        expect(get :show, params: { master_file_id: master_file.id, id: supplemental_file.id }).to render_template('errors/restricted_pid')
       end
     end
   end

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe TimelinesController, type: :controller do
       end
       context 'with a private timeline' do
         it "should NOT return the timeline view page" do
-          expect(get :show, params: { id: timeline.id }).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+          expect(get :show, params: { id: timeline.id }).to render_template('errors/restricted_pid')
           expect(get :manifest, params: { id: timeline.id, format: :json }).to be_unauthorized
         end
       end
@@ -100,10 +100,10 @@ RSpec.describe TimelinesController, type: :controller do
       before do
         login_as :user
       end
-      it "all routes should redirect to /" do
-        expect(get :edit, params: { id: timeline.id }).to redirect_to(root_path)
-        expect(put :update, params: { id: timeline.id }).to redirect_to(root_path)
-        expect(delete :destroy, params: { id: timeline.id }).to redirect_to(root_path)
+      it "all routes should redirect to restriced content page" do
+        expect(get :edit, params: { id: timeline.id }).to render_template('errors/restricted_pid')
+        expect(put :update, params: { id: timeline.id }).to render_template('errors/restricted_pid')
+        expect(delete :destroy, params: { id: timeline.id }).to render_template('errors/restricted_pid')
       end
       context 'with a public timeline' do
         let(:timeline) { FactoryBot.create(:timeline, visibility: Timeline::PUBLIC) }
@@ -114,7 +114,7 @@ RSpec.describe TimelinesController, type: :controller do
       end
       context 'with a private timeline' do
         it "should NOT return the timeline view page" do
-          expect(get :show, params: { id: timeline.id }).to redirect_to(root_path)
+          expect(get :show, params: { id: timeline.id }).to render_template('errors/restricted_pid')
           expect(get :manifest, params: { id: timeline.id, format: :json }).to be_unauthorized
         end
       end

--- a/spec/requests/redirect_spec.rb
+++ b/spec/requests/redirect_spec.rb
@@ -18,7 +18,7 @@ describe 'redirect', type: :request do
   it 'stores url to redirect to when unauthorized and needing to authenticate (#authorize!)' do
     get '/admin/migration_report'
     expect(request.env['rack.session']['previous_url']).to eq '/admin/migration_report'
-    expect(response).to redirect_to(/#{Regexp.quote(new_user_session_path)}\?url=.*/)
+    expect(response).to render_template('errors/restricted_pid')
   end
 
   it 'stores url to redirect to when needing to authenticate (#authenticate_user!)' do


### PR DESCRIPTION
Co-authored-by: Sumith Reddi Baddam <sumith.reddy2@gmail.com>

When user is not logged in:
![Screenshot from 2020-07-23 15-12-24](https://user-images.githubusercontent.com/1331659/88328785-f1dc7700-ccf6-11ea-9bc8-7dccd13b6ee8.png)

After logging in and the user is still not authorized to access the content:
![Screenshot from 2020-07-23 15-11-46](https://user-images.githubusercontent.com/1331659/88328814-fe60cf80-ccf6-11ea-9398-084451372beb.png)

@joncameron When the user is not logged in the page has 2 `Sign in` buttons, do you think maybe we should make the `Sign in` in the text just a link?

