### PR TITLE
Fixes #4224 Creates Dropbox directory when collection is created.

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -304,10 +304,9 @@ class Admin::Collection < ActiveFedora::Base
       end
 
       absolute_path = dropbox_absolute_path(name)
-
       unless File.directory?(absolute_path)
         begin
-          Dir.mkdir(absolute_path)
+          FileUtils.mkdir_p absolute_path
         rescue Exception => e
           Rails.logger.error "Could not create directory (#{absolute_path}): #{e.inspect}"
         end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -543,7 +543,7 @@ describe Admin::Collection do
       FakeFS.activate!
       FileUtils.mkdir_p(File.join(Settings.dropbox.path, 'african_art'))
       FileUtils.mkdir_p(File.join(Settings.dropbox.path, 'african_art_2'))
-      expect(Dir).to receive(:mkdir).with(File.join(Settings.dropbox.path, 'african_art_3'))
+      expect(FileUtils).to receive(:mkdir_p).with(File.join(Settings.dropbox.path, 'african_art_3'))
       collection.send(:create_dropbox_directory!)
       FakeFS.deactivate!
     end


### PR DESCRIPTION
Fixes #4224

Changed the make directory command to create dropbox directory when collection is created. This command creates all subfolders for the absolute path.