### PR TITLE
Fix overwhelming Blacklight deprecation warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
   before_action :rewrite_v4_ids, if: proc{|c| request.method_symbol == :get && [params[:id], params[:content]].compact.any? { |i| i =~ /^[a-z]+:[0-9]+$/}}
   before_action :set_no_cache_headers, if: proc{|c| request.xhr? }
   prepend_before_action :remove_zero_width_chars
+  skip_after_action :discard_flash_if_xhr # Suppress overwhelming Blacklight deprecation warning
 
   def set_no_cache_headers
     response.headers["Cache-Control"] = "no-cache, no-store"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,6 +181,8 @@ class CatalogController < ApplicationController
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5
+
+    config.fetch_many_document_params = { fl: "*" }
   end
 
   private


### PR DESCRIPTION
They're needlessly filling up server logs.