### PR TITLE
Move timeline configuration from abilities to view

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,7 @@ class Ability
   include Hydra::MultiplePolicyAwareAbility
 
   self.ability_logic += [ :playlist_permissions, :playlist_item_permissions, :marker_permissions, :encode_dashboard_permissions ]
-  self.ability_logic += [ :timeline_permissions ] if Settings['timeliner'].present?
+  self.ability_logic += [ :timeline_permissions ]
 
   def encode_dashboard_permissions
     can :read, :encode_dashboard if is_administrator?

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -27,7 +27,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= link_to 'Playlists', main_app.playlists_path, id:'playlists_nav' %>
   </li>
   <% end %>
-  <% if current_ability.can? :create, Timeline %>
+  <% if (current_ability.can? :create, Timeline) && Settings['timeliner'].present? %>
   <li class=<%= active_for_controller('timelines') %>>
     <%= link_to 'Timelines', main_app.timelines_path, id:'timelines_nav' %>
   </li>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -29,7 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%# Partial view for MEJS4 Add To Playlist plugin %>
     <%= render partial: 'mejs4_add_to_playlist' if current_user.present? && is_mejs_4? %>
     <%= render 'workflow_progress' %>
-    <%= render partial: 'timeline' if current_ability.can? :create, Timeline %>
+    <%= render partial: 'timeline' if (current_ability.can? :create, Timeline) && Settings['timeliner'].present? %>
     <%= render 'share' if will_partial_list_render? :share %>
 
     <!-- Sections -->

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -20,7 +20,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div id="main_content_container" class="container-fluid">
     <div class="content" class="col-md-8">
       <h2>Timelines</h2>
-      <p>Timelines feature is not-configured. Please contact your system administrator.</p>
+      <p>The Timelines feature is not configured. Please contact your system administrator to enable Timelines.</p>
     </div>
   </div>
 <% end %>

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -16,7 +16,15 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% if current_user.nil? %>
   <%= link_to 'Please login to view your timelines.', new_user_session_path %>
 <% end %>
-<% unless current_user.nil? %>
+<% if Settings['timeliner'].blank? %>
+  <div id="main_content_container" class="container-fluid">
+    <div class="content" class="col-md-8">
+      <h2>Timelines</h2>
+      <p>Timelines feature is not-configured. Please contact your system administrator.</p>
+    </div>
+  </div>
+<% end %>
+<% unless current_user.nil? || Settings['timeliner'].blank? %>
   <% timelines = Timeline.where(user_id: current_user.id) %>
   <div class="container-fluid">
     <div class="row">

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,6 @@
 domain:
   port: 3000
-timeliner: 
+timeliner:
   timeliner_url: http://localhost:3000/timeliner
 supplemental_files:
   proxy: true


### PR DESCRIPTION
When timeline configuration is not in place, the user can still type in the address bar `/timelines` and use that route. Because when we move configuration check from abilities the route is not restricted to the other (not admin) users anymore, and this doesn't take them to the restricted content page. So I put in a piece of code that will show something like below;

![Screenshot from 2020-09-30 15-08-07](https://user-images.githubusercontent.com/1331659/94729296-723eda00-032f-11eb-834f-4923754543e4.png)

This is what I came up with, but there must be better ways to do this :)
@joncameron @phuongdh What do you think?