### PR TITLE
Align player elements in embedded player

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -4656,6 +4656,11 @@ var MediaElementPlayer = function () {
 
 				siblingsWidth += totalMargin + (totalMargin === 0 ? railMargin * 2 : railMargin) + 1;
 
+				// Vertically align player elements in all embedded players when previous was set to 50px 
+				if (t.container.parentElement.offsetHeight == 50) {
+					t.container.style.bottom = '5px';
+				}
+
 				t.getElement(t.container).style.minWidth = siblingsWidth + 'px';
 
 				var event = (0, _general.createEvent)('controlsresize', t.getElement(t.container));


### PR DESCRIPTION
This aligns the embedded player elements for the old height of `50px` while keeping the player unchanged for the new height value of `40px`
![Screenshot from 2020-10-06 17-58-18](https://user-images.githubusercontent.com/1331659/95264567-8dad5780-07fd-11eb-8fe6-b23b90d61265.png)
