### PR TITLE
Links to Non-existent Fedora 3 Identifiers Return 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,11 +51,11 @@ class ApplicationController < ActionController::Base
     return if params[:controller] =~ /migration/
 
     params.permit!
-    new_id = ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:id]}"}, rows: 1, fl: 'id')
-    if new_id.size == 0
+    query_result = ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:id]}"}, rows: 1, fl: 'id')
+    if query_result.size == 0
       raise ActiveFedora::ObjectNotFoundError
     else
-      new_id = new_id.first['id']
+      new_id = query_result.first['id']
       new_content_id = params[:content] ? ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:content]}"}, rows: 1, fl: 'id').first['id'] : nil
       redirect_to(url_for(params.merge(id: new_id, content: new_content_id)))
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,9 +51,14 @@ class ApplicationController < ActionController::Base
     return if params[:controller] =~ /migration/
 
     params.permit!
-    new_id = ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:id]}"}, rows: 1, fl: 'id').first['id']
-    new_content_id = params[:content] ? ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:content]}"}, rows: 1, fl: 'id').first['id'] : nil
-    redirect_to(url_for(params.merge(id: new_id, content: new_content_id)))
+    new_id = ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:id]}"}, rows: 1, fl: 'id')
+    if new_id.size == 0
+      raise ActiveFedora::ObjectNotFoundError
+    else
+      new_id = new_id.first['id']
+      new_content_id = params[:content] ? ActiveFedora::SolrService.query(%{identifier_ssim:"#{params[:content]}"}, rows: 1, fl: 'id').first['id'] : nil
+      redirect_to(url_for(params.merge(id: new_id, content: new_content_id)))
+    end
   end
 
   def store_location


### PR DESCRIPTION
Fixes #3566 #4310 
Added a condition to throw ObjectNotFound exception when NIL is returned by the query.