### PR TITLE
Stop player when it reaches last playlist item's end time

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -292,6 +292,9 @@ class MEJSPlayer {
 
     this.reInitializeCaptions();
 
+    // Build time rail highlight based on structure
+    this.buildTimeRailHighlight();
+
     this.player.load();
     this.player.play();
   }
@@ -311,6 +314,25 @@ class MEJSPlayer {
       // Clear captions object
       delete this.player.tracks;
       this.player.cleartracks(this.player);
+    }
+  }
+
+  /**
+   * Build time rail highlight when intializing the player instance
+   * and advancing to the next section/playlist item
+   */
+  buildTimeRailHighlight() {
+    if (this.highlightRail) {
+      const t = this.mejsTimeRailHelper.calculateSegmentT(
+        this.segmentsMap[this.activeSegmentId],
+        this.currentStreamInfo
+      );
+
+      // Create our custom time rail highlighter element
+      this.highlightSpanEl = this.mejsTimeRailHelper.createTimeHighlightEl(
+        document.getElementById('content')
+      );
+      this.highlightTimeRail(t, this.activeSegmentId);
     }
   }
 
@@ -467,18 +489,7 @@ class MEJSPlayer {
     );
 
     // Show highlighted time in time rail
-    if (this.highlightRail) {
-      const t = this.mejsTimeRailHelper.calculateSegmentT(
-        this.segmentsMap[this.activeSegmentId],
-        this.currentStreamInfo
-      );
-
-      // Create our custom time rail highlighter element
-      this.highlightSpanEl = this.mejsTimeRailHelper.createTimeHighlightEl(
-        document.getElementById('content')
-      );
-      this.highlightTimeRail(t, this.activeSegmentId);
-    }
+    this.buildTimeRailHighlight();
 
     // Filter playlist item player from handling MEJS's time update event
     if (Object.keys(this.playlistItem).length === 0) {

--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_playlist_items.es6
@@ -288,7 +288,7 @@ Object.assign(MediaElementPlayer.prototype, {
     getNextItem() {
       let nextItem = this.$nowPlayingLi.next('li');
       // When next item is not a valid playlist item (e.g. from a deleted item) get the item after that
-      if(nextItem[0].className !== 'queue') {
+      if(nextItem[0] && nextItem[0].className !== 'queue') {
         nextItem = nextItem.next('li');
       }
       return nextItem;


### PR DESCRIPTION
This PR contains a fix for updating time rail highlight (displaying structure in the player) when media sources switch. 