### PR TITLE
Make Upload/Replace button in structure appear as a button in Safari

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -583,6 +583,11 @@ div.status-detail {
     span.tool_label {
       font-weight: bold;
     }
+
+    label.file-upload-label {
+      float: left;
+      cursor: pointer;
+    }
   }
 }
 

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -64,12 +64,11 @@ Unless required by applicable law or agreed to in writing, software distributed
           <div class="tool_actions">
             <span class="tool_label">Structure</span>
             <%= form_for section, :url => attach_structure_master_file_path(section.id), html: {method: "post"} do |form| %>
-            <%= form.file_field :structure, class: "filedata", style: "height:0px;width:0px;" %>
+            <%= form.file_field :structure, id: "structure_#{index}_filedata", class: "filedata", style: "display:none;" %>
             <% item_label=html_escape(stream_label_for(section)) %>
             <% stream_url=hls_manifest_master_file_url(section.id, quality: 'auto') %>
             <div class="btn-toolbar">
-              <input type="button" class="btn btn-primary btn-xs"
-                onclick="$('#structure_<%= index %> .filedata').click();" value="<%= section.structuralMetadata.present? ? 'Replace' : 'Upload'%>" />
+              <label class="btn btn-primary btn-xs file-upload-label" for="structure_<%= index %>_filedata"><%= section.structuralMetadata.present? ? 'Replace' : 'Upload'%></label>
               <div class="btn-group">
                 <% if section.structuralMetadata.valid? %>
                 <%= react_component("ReactButtonContainer", {sectionIndex: index, masterFileID: section.id, baseURL: request.protocol+request.host_with_port, streamDuration: section.duration, audioStreamURL: stream_url, initStructure: section.structuralMetadata.as_json}) %>


### PR DESCRIPTION
In Safari the file upload button doesn't behaves identical to the other buttons in structure edit step. This PR introduces changes that make `Upload/Replace` button behaves similar (color change and cursor change to pointer on hover) to the other buttons in the group.

In Safari 13.1 on macOS Catalina (in Browserstack):
![Screenshot from 2020-12-14 13-39-22](https://user-images.githubusercontent.com/1331659/102121937-c297e500-3e12-11eb-85ec-ab1295ff8f63.jpg)

IMPORTANT: This doesn't fix the issue with file upload not working in Safari 14.0.1.