### PR TITLE
Upgrade oauth to 0.5.5 for MitM fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    oauth (0.5.4)
+    oauth (0.5.5)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)


### PR DESCRIPTION
Replaces https://github.com/avalonmediasystem/avalon/pull/4375 