### PR TITLE
Fix section edit reload

### DIFF
--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -19,9 +19,8 @@
 /* Show form to edit label */
 $('button[name="edit_label"]').on('click', e => {
   const $row = getHTMLInfo(e, '.row');
-  const fileId = $row.data('file-id');
-  const masterfileId = $row.data('masterfile-id');
-  $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]').html('');
+  const { masterfileId, fileId } = $row[0].dataset;
+
   $row.addClass('is-editing');
   $row.find('input[id="supplemental_file_input_' + masterfileId + '_'+ fileId +'"]').focus();
 });
@@ -37,22 +36,68 @@ $('button[name="save_label"]').on('click', e => {
   const $row = getHTMLInfo(e, '.row');
   const { fileId, masterfileId } = getHTMLInfo(e, 'form')[0].dataset;
 
-  const newLabel = $row.find('input[id="supplemental_file_input_' + masterfileId + '_'+ fileId +'"]').val();
-  // Set the label to the new value
-  $row.find('span[name="label_' + masterfileId + '_' + fileId + '"]').text(newLabel);
   $row.removeClass('is-editing');
+
   // Remove feedback message after 5 seconds
   setTimeout( function() { 
-    $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]').html('');
+    var alert = $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]')
+    alert.html('');
+    alert.removeClass();
+    alert.addClass('visible-inline');
 }, 5000);
 });
 
 /* Show feedback message inline after saving */
 $('.supplemental-file-form').on("ajax:success", (event, data, status, xhr) => {
-  $(event.currentTarget.parentElement).find('.visible-inline').html("Supplemental file successfully updated.")
+  var $row = $(event.currentTarget.parentElement);
+  const { masterfileId, fileId } = event.currentTarget.dataset;
+
+  // Set the label to the new value
+  var newLabel = $row.find('input[id="supplemental_file_input_' + masterfileId + '_' + fileId + '"]').val()
+  $row.find('span[name="label_' + masterfileId + '_' + fileId + '"]').text(newLabel);
+
+  // Show flash message for success
+  $row.find('.visible-inline').html("Supplemental file successfully updated.");
+  $row.find('.visible-inline').addClass('success-alert alert');
 }).on("ajax:error", (event, xhr, status, error) => {
-  $(event.currentTarget.parentElement).find('.visible-inline').html("Failed to update.")
+  var alert = $(event.currentTarget.parentElement).find('.visible-inline');
+
+  // Show flash warning for failed attempt
+  alert.html("Failed to update.");
+  alert.addClass('warning-alert alert');
 });
+
+/* Store collapsed section ids in localStorage */
+$('button[id^=edit_section').on('click', e => {
+  // Active sections
+  var activeSections = JSON.parse(localStorage.getItem('activeSections')) || [];
+
+  var currentSection = e.target.dataset['sectionId'];
+  var isCollapsed = e.target.getAttribute('aria-expanded') == "true";
+  if(isCollapsed) {
+    for (var i = 0; i < activeSections.length; i++) {
+      if (activeSections[i] == currentSection) {
+        activeSections.splice(i, 1);
+      }
+    }
+  } else {
+    activeSections.push(currentSection);
+  }
+  localStorage.setItem('activeSections', JSON.stringify(activeSections));
+});
+
+/* On page reload; collapse sections which were collapsed previously */
+$(document).ready(function() {
+  var activeSections = JSON.parse(localStorage.getItem('activeSections')) || [];
+
+  // Collapse active sections on page
+  activeSections.forEach(section => {
+    const sectionDiv = $("#collapseExample" + section);
+    if(sectionDiv) {
+      sectionDiv.collapse();
+    }
+  })
+})
 
 function getHTMLInfo(e, element) {
   return $(e.target).parents(element);

--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -12,69 +12,87 @@
  *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
  *   specific language governing permissions and limitations under the License.
  * ---  END LICENSE_HEADER BLOCK  ---
-*/
+ */
 
 /** Includes JS functions related to editing the supplemental file labels */
 
 /* Show form to edit label */
-$('button[name="edit_label"]').on('click', e => {
+$('button[name="edit_label"]').on('click', (e) => {
   const $row = getHTMLInfo(e, '.row');
   const { masterfileId, fileId } = $row[0].dataset;
 
   $row.addClass('is-editing');
-  $row.find('input[id="supplemental_file_input_' + masterfileId + '_'+ fileId +'"]').focus();
+  $row
+    .find(
+      'input[id="supplemental_file_input_' + masterfileId + '_' + fileId + '"]'
+    )
+    .focus();
 });
 
 /* Hide form when form is cancelled */
-$('button[name="cancel_edit_label"]').on('click', e => {
+$('button[name="cancel_edit_label"]').on('click', (e) => {
   const $row = getHTMLInfo(e, '.row');
   $row.removeClass('is-editing');
-  });
+});
 
 /* After editing, close the form and show the new label */
-$('button[name="save_label"]').on('click', e => {
+$('button[name="save_label"]').on('click', (e) => {
   const $row = getHTMLInfo(e, '.row');
   const { fileId, masterfileId } = getHTMLInfo(e, 'form')[0].dataset;
 
   $row.removeClass('is-editing');
 
   // Remove feedback message after 5 seconds
-  setTimeout( function() { 
-    var alert = $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]')
+  setTimeout(function () {
+    var alert = $row.find(
+      'small[name="flash-message-' + masterfileId + '-' + fileId + '"]'
+    );
     alert.html('');
     alert.removeClass();
     alert.addClass('visible-inline');
-}, 5000);
+  }, 5000);
 });
 
 /* Show feedback message inline after saving */
-$('.supplemental-file-form').on("ajax:success", (event, data, status, xhr) => {
-  var $row = $(event.currentTarget.parentElement);
-  const { masterfileId, fileId } = event.currentTarget.dataset;
+$('.supplemental-file-form')
+  .on('ajax:success', (event, data, status, xhr) => {
+    var $row = $(event.currentTarget.parentElement);
+    const { masterfileId, fileId } = event.currentTarget.dataset;
 
-  // Set the label to the new value
-  var newLabel = $row.find('input[id="supplemental_file_input_' + masterfileId + '_' + fileId + '"]').val()
-  $row.find('span[name="label_' + masterfileId + '_' + fileId + '"]').text(newLabel);
+    // Set the label to the new value
+    var newLabel = $row
+      .find(
+        'input[id="supplemental_file_input_' +
+          masterfileId +
+          '_' +
+          fileId +
+          '"]'
+      )
+      .val();
+    $row
+      .find('span[name="label_' + masterfileId + '_' + fileId + '"]')
+      .text(newLabel);
 
-  // Show flash message for success
-  $row.find('.visible-inline').html("Supplemental file successfully updated.");
-  $row.find('.visible-inline').addClass('success-alert alert');
-}).on("ajax:error", (event, xhr, status, error) => {
-  var alert = $(event.currentTarget.parentElement).find('.visible-inline');
+    // Show flash message for success
+    $row.find('.visible-inline').html('Successfully updated.');
+    $row.find('.visible-inline').addClass('alert');
+  })
+  .on('ajax:error', (event, xhr, status, error) => {
+    var alert = $(event.currentTarget.parentElement).find('.visible-inline');
 
-  // Show flash warning for failed attempt
-  alert.html("Failed to update.");
-  alert.addClass('warning-alert alert');
-});
+    // Show flash warning for failed attempt
+    alert.html('Failed to update.');
+    alert.addClass('alert');
+  });
 
 /* Store collapsed section ids in localStorage */
-$('button[id^=edit_section').on('click', e => {
+$('button[id^=edit_section').on('click', (e) => {
   // Active sections
   var activeSections = JSON.parse(localStorage.getItem('activeSections')) || [];
 
   var currentSection = e.target.dataset['sectionId'];
-  var isCollapsed = e.target.getAttribute('aria-expanded') == "true";
-  if(isCollapsed) {
+  var isCollapsed = e.target.getAttribute('aria-expanded') == 'true';
+  if (isCollapsed) {
     for (var i = 0; i < activeSections.length; i++) {
       if (activeSections[i] == currentSection) {
         activeSections.splice(i, 1);
@@ -87,17 +105,17 @@ $('button[id^=edit_section').on('click', e => {
 });
 
 /* On page reload; collapse sections which were collapsed previously */
-$(document).ready(function() {
+$(document).ready(function () {
   var activeSections = JSON.parse(localStorage.getItem('activeSections')) || [];
 
   // Collapse active sections on page
-  activeSections.forEach(section => {
-    const sectionDiv = $("#collapseExample" + section);
-    if(sectionDiv) {
+  activeSections.forEach((section) => {
+    const sectionDiv = $('#collapseExample' + section);
+    if (sectionDiv) {
       sectionDiv.collapse();
     }
-  })
-})
+  });
+});
 
 function getHTMLInfo(e, element) {
   return $(e.target).parents(element);

--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -1,40 +1,59 @@
+/*
+ * Copyright 2011-2020, The Trustees of Indiana University and Northwestern
+ *   University.  Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ *   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ---  END LICENSE_HEADER BLOCK  ---
+*/
 
+/** Includes JS functions related to editing the supplemental file labels */
+
+/* Show form to edit label */
 $('button[name="edit_label"]').on('click', e => {
-  const { $row, fileId, masterFileId } = getHTMLInfo(e);
-  const inputField = $row.find('input[name="label_' + masterFileId + '_' + fileId + '"]');
-  inputField.val($row.data('file-label'));
+  const $row = getHTMLInfo(e, '.row');
+  const fileId = $row.data('file-id');
+  const masterfileId = $row.data('masterfile-id');
+  $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]').html('');
   $row.addClass('is-editing');
-  inputField.focus();
+  $row.find('input[id="supplemental_file_input_' + masterfileId + '_'+ fileId +'"]').focus();
 });
 
+/* Hide form when form is cancelled */
 $('button[name="cancel_edit_label"]').on('click', e => {
-  const { $row, fileId, masterFileId } = getHTMLInfo(e);
-  $row.find('input[name="label_' + masterFileId + '_' + fileId + '"]');
+  const $row = getHTMLInfo(e, '.row');
   $row.removeClass('is-editing');
   });
 
+/* After editing, close the form and show the new label */
 $('button[name="save_label"]').on('click', e => {
-  const {  $row, fileId, masterFileId } = getHTMLInfo(e);
-  const newLabel = $row.find('input[name="label_' + masterFileId + '_' + fileId + '"]').val();
-  $row.find('span[name="label_' + masterFileId + '_' + fileId + '"]').text(newLabel);
+  const $row = getHTMLInfo(e, '.row');
+  const { fileId, masterfileId } = getHTMLInfo(e, 'form')[0].dataset;
 
-  let formData = new FormData();
-  formData.append('supplemental_file[label]', newLabel);
-  formData.append('authenticity_token', $('input[name=authenticity_token]').val());
-
-  fetch('/master_files/' + masterFileId + '/supplemental_files/' + fileId, {
-    method: "PUT",
-    body: formData
-  }).then(() => {
-    $row.removeClass('is-editing');
-    // Page reload to show the flash message
-    location.reload();
-  });
+  const newLabel = $row.find('input[id="supplemental_file_input_' + masterfileId + '_'+ fileId +'"]').val();
+  // Set the label to the new value
+  $row.find('span[name="label_' + masterfileId + '_' + fileId + '"]').text(newLabel);
+  $row.removeClass('is-editing');
+  // Remove feedback message after 5 seconds
+  setTimeout( function() { 
+    $row.find('small[name="flash-message-' + masterfileId + '-' + fileId + '"]').html('');
+}, 5000);
 });
 
-function getHTMLInfo(e) {
-  const $row = $(e.target).parents('.row');
-  const fileId = $row.data('file-id');
-  const masterFileId = $row.data('masterfile-id');
-  return {  $row, fileId, masterFileId };
+/* Show feedback message inline after saving */
+$('.supplemental-file-form').on("ajax:success", (event, data, status, xhr) => {
+  $(event.currentTarget.parentElement).find('.visible-inline').html("Supplemental file successfully updated.")
+}).on("ajax:error", (event, xhr, status, error) => {
+  $(event.currentTarget.parentElement).find('.visible-inline').html("Failed to update.")
+});
+
+function getHTMLInfo(e, element) {
+  return $(e.target).parents(element);
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -876,6 +876,28 @@ h5.panel-title {
         }
       }
       margin-top: 5px;
+      
+      .visible-inline {
+        margin-left: 30px;
+        display: none;
+      }
+
+      .alert {
+        display: inline;
+        color: white;
+        padding: 5px;
+        border-radius: 4px;
+      }
+
+      .success-alert {
+        background-color: $alert-success-bg;
+        border-color: $success;
+      }
+
+      .warning-alert {
+        background-color: $state-warning-bg;
+        border-color: $warning;
+      }
     }
 
     .supplemental-file-form {
@@ -895,10 +917,6 @@ h5.panel-title {
 
     .form-control {
       height: 25px;
-    }
-
-    .visible-inline {
-      margin-left: 30px;
     }
   }
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -764,10 +764,6 @@ h5.panel-title {
     background: #efefef;
     margin-bottom: 15px;
     padding: 10px 15px 0px 15px;
-
-    .visible-inline {
-      display: inline-block;
-    }
   }
 
   .associated-files-top-row {
@@ -882,6 +878,12 @@ h5.panel-title {
       margin-top: 5px;
     }
 
+    .supplemental-file-form {
+      float: left;
+      width: 100%;
+      height: 25px;
+    }
+
     .btn-toolbar {
       display: flex;
       float: right;
@@ -893,6 +895,10 @@ h5.panel-title {
 
     .form-control {
       height: 25px;
+    }
+
+    .visible-inline {
+      margin-left: 30px;
     }
   }
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -786,7 +786,7 @@ h5.panel-title {
   }
 
   .associated-files-wrapper {
-    input[type=text] {
+    input[type='text'] {
       @extend .form-control;
       padding: 3px 6px;
       height: auto;
@@ -798,7 +798,8 @@ h5.panel-title {
   }
 }
 
-#associated_files, #supplemental_files {
+#associated_files,
+#supplemental_files {
   div.section-files {
     width: 100%;
     padding: 5px 0 15px 5px;
@@ -823,7 +824,8 @@ h5.panel-title {
       float: right;
     }
 
-    input[type=button], input[type=submit] {
+    input[type='button'],
+    input[type='submit'] {
       @extend .btn-xs;
     }
 
@@ -847,7 +849,7 @@ h5.panel-title {
       font-weight: bold;
     }
   }
-  
+
   div.file_view {
     margin: 15px 0 0 20px;
 
@@ -876,7 +878,7 @@ h5.panel-title {
         }
       }
       margin-top: 5px;
-      
+
       .visible-inline {
         margin-left: 30px;
         display: none;
@@ -884,19 +886,6 @@ h5.panel-title {
 
       .alert {
         display: inline;
-        color: white;
-        padding: 5px;
-        border-radius: 4px;
-      }
-
-      .success-alert {
-        background-color: $alert-success-bg;
-        border-color: $success;
-      }
-
-      .warning-alert {
-        background-color: $state-warning-bg;
-        border-color: $warning;
       }
     }
 
@@ -909,6 +898,7 @@ h5.panel-title {
     .btn-toolbar {
       display: flex;
       float: right;
+      padding-right: 7px;
     }
 
     .edit-item {

--- a/app/models/supplemental_file.rb
+++ b/app/models/supplemental_file.rb
@@ -17,7 +17,8 @@
 class SupplementalFile < ApplicationRecord
   has_one_attached :file
 
-  validates :tags, array_inclusion: %w[transcript caption]
+  # TODO: the empty tag should represent a generic supplemental file
+  validates :tags, array_inclusion: ['transcript', 'caption', '', nil]
 
   serialize :tags, Array
 

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -161,7 +161,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                   <!-- transcripts -->
                   <%= render partial: "supplemental_files_upload", locals: { section: section, label: 'Transcripts', tag: 'transcript' } %>
                   <!-- supplemental files -->
-                  <%= render partial: "supplemental_files_upload", locals: { section: section, label: 'Section Supplemental Files', tag: "" } %>
+                  <%= render partial: "supplemental_files_upload", locals: { section: section, label: 'Section Supplemental Files' } %>
                 </div>
               </div>
             </div><!-- end associated-files-block -->
@@ -273,7 +273,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <h3 class="panel-title">Item supplemental files</h3>
     </div>
     <div class="panel-body">
-      <%= render partial: "supplemental_files_upload", locals: { section: @media_object, index: 0, label: 'Files', tag: "" } %>
+      <%= render partial: "supplemental_files_upload", locals: { section: @media_object, index: 0, label: 'Files' } %>
     </div>
   </div>
 </div>

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -79,8 +79,8 @@ Unless required by applicable law or agreed to in writing, software distributed
                       </button>
                     </span>
                     <span>
-                      <button id="edit_section" class="btn btn-xs btn-primary" onclick="return false;" data-toggle="collapse" 
-                              data-target="<%="#collapseExample#{section.id}"%>" aria-expanded="false" aria-controls="collapseExample">
+                      <button id="<%="edit_section_#{section.id}"%>" class="btn btn-xs btn-primary" onclick="return false;" data-toggle="collapse" 
+                              data-target="<%="#collapseExample#{section.id}"%>" data-section-id="<%= section.id %>" aria-expanded="false" aria-controls="collapseExample">
                         Edit
                       </button>
                     </span>
@@ -144,7 +144,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                    <!-- captions -->
                    <div id="captions_<%= section.id %>" class="section-captions section_files_tool">
                     <span class="tool_label">Captions</span>
-                    <%= form_with model: section, :url => attach_captions_master_file_path(section.id), html: {method: "post"} do |form| %>
+                    <%= form_with model: section, :url => attach_captions_master_file_path(section.id), html: {method: "post", class: "caption-file-form" } do |form| %>
                       <%= form.file_field :captions, class: "filedata" %>
                       <input type="button" class="btn btn-primary" onclick="$('#captions_<%= section.id %> .filedata').click();"
                         value="<%= section.captions.present? ? 'Replace' : 'Upload' %>" />

--- a/app/views/media_objects/_supplemental_files_list.html.erb
+++ b/app/views/media_objects/_supplemental_files_list.html.erb
@@ -1,27 +1,37 @@
+          <% if section.supplemental_files.present? %>
+            <% files=tag.empty? ? supplemental_files.select { |sf| sf.tags.empty? } : supplemental_files.select { |sf| sf.tags.include?(tag) } %>
             <div class="file_view">
               <% files.each do |file| %>
-                <div class="row" data-file-id="<%= file.id %>" data-masterfile-id="<%= section.id %>" data-file-label="<%= file.label %>">
-                  <div class="col-sm-6">
+                <div class="row" data-file-id="<%= file.id %>" data-masterfile-id="<%= section.id %>" >
                     <span name="label_<%= section.id + "_" + file.id.to_s %>" class="display-item"><%= file.label %></span>
-                    <input name="label_<%= section.id + "_" + file.id.to_s %>" type="text" class="form-control edit-item outline_on" value="<%= file.label %>">
-                  </div>
-                  <div class="col-sm-6">
+                    <%= form_for :supplemental_file, url: object_supplemental_file_path(section, file), remote: true,
+                          html: { method: "put", class: "supplemental-file-form edit-item", id: "form-#{file.id}" },
+                          data: { file_id: file.id, masterfile_id: section.id } do |form| %>
+                        <div class="col-sm-6 col-xs-6">
+                          <div class="form-group">
+                            <%= form.text_field :label, id: "supplemental_file_input_#{section.id}_#{file.id}", value: file.label %>
+                          </div>
+                        </div>
+                        <div class="col-sm-6 col-xs-6">
+                          <div class="btn-toolbar">
+                            <%= button_tag name: 'save_label', :class => "btn btn-default btn-xs edit-item" do %>
+                              <i class="fa fa-check" title="Save"></i> <span class="sm-hidden">Save</span>
+                            <% end %>
+                            <%= button_tag name: 'cancel_edit_label', class:'btn btn-danger btn-xs edit-item outline_on', type: 'button' do%>
+                              <i class="fa fa-times" title="Cancel"></i> <span class="sm-hidden">Cancel</span>
+                            <% end %>
+                          </div>
+                        </div>
+                    <% end %>
+                    <small class="visible-inline" name="flash-message-<%= section.id %>-<%= file.id %>"></small>
                     <div class="btn-toolbar">
                       <%# Update button %>
                       <%= button_tag name: 'edit_label', class:'btn btn-default btn-xs edit_label display-item outline_on pull-right', type: 'button' do %>
                         <i class="fa fa-edit" title="Edit"></i> <span class="sm-hidden">Edit</span>
                       <% end %>
-                      <%# Save button %>
-                      <%= button_tag name: 'save_label', class:'btn btn-default btn-xs edit-item outline_on pull-right', type: 'button' do%>
-                        <i class="fa fa-check" title="Save"></i> <span class="sm-hidden">Save</span>
-                      <% end %>
-                      <%# Cancel button %>
-                      <%= button_tag name: 'cancel_edit_label', class:'btn btn-danger btn-xs edit-item outline_on', type: 'button' do%>
-                        <i class="fa fa-times" title="Cancel"></i> <span class="sm-hidden">Cancel</span>
-                      <% end %>
                       <%= link_to("Remove", object_supplemental_file_path(section, file), title: 'Remove', method: :delete, class: "btn btn-danger btn-xs file-remove") %>
                     </div>
-                  </div>
                 </div>
               <% end %>
             </div>
+          <% end %>

--- a/app/views/media_objects/_supplemental_files_upload.html.erb
+++ b/app/views/media_objects/_supplemental_files_upload.html.erb
@@ -1,13 +1,11 @@
       <% file_section=tag.empty? ? "supplemental_#{section.id}" : "#{tag}_#{section.id}" %>
       <div id="<%= file_section %>" class="section_files_tool">
         <span class="tool_label"><%= label %></span>
-        <%= form_for :supplemental_file, :url => object_supplemental_files_path(section), html: {method: "post"} do |form| %>
-          <%= form.hidden_field :tags, multiple: true, value: tag %>
+        <%= form_for :supplemental_file, :url => object_supplemental_files_path(section), html: { method: "post" } do |form| %>
+          <%= form.hidden_field(:tags, multiple: true, value: tag) if tag.present? %>
           <%= form.file_field :file, class: "filedata" %>
           <input type="button" class="btn btn-primary btn-xs" onclick="$('#<%= file_section %> .filedata').click();"
             value="Upload" />
         <% end %>
-          <% if section.supplemental_files.present? %>
-            <%= render partial: "supplemental_files_list", locals: { section: section, files: section.supplemental_files.select { |sf| sf.tags.include?(tag) } } %>
-          <% end %>
+        <%= render partial: "supplemental_files_list", locals: { section: section, tag: tag, supplemental_files: section.supplemental_files } %>
       </div>


### PR DESCRIPTION
Editing the supplemental file labels the flash messages are shown inline:

When successfully saved,
![Screencast from 02-16-2021 10_55_55 AM](https://user-images.githubusercontent.com/1331659/108088303-4d30d680-7046-11eb-84d3-8ac7a0c14ada.gif)

When saving fails,
![Screencast from 02-16-2021 10_59_33 AM](https://user-images.githubusercontent.com/1331659/108088297-4bffa980-7046-11eb-833e-d7e80e3aa1a2.gif)

Uploading new supplemental/caption files reloads the page. The browser remembers the previously opened section accordions and collapse them after page reload:
![Screencast from 02-16-2021 10_57_15 AM](https://user-images.githubusercontent.com/1331659/108088311-4efa9a00-7046-11eb-91c6-babab699621d.gif)




