### PR TITLE
Run rails with bundle exec to fix an error in some environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     build:
       context: .
       target: dev
-    command: bash -c "/docker_init.sh && rails server -b 0.0.0.0"
+    command: bash -c "/docker_init.sh && bundle exec rails server -b 0.0.0.0"
     depends_on:
       - db
       - fedora


### PR DESCRIPTION
Some users (me) were seeing an error in the avalon container "rails not found." This fixes that issue.