### PR TITLE
Fix flappy MasterFile#hls_stream test

### DIFF
--- a/spec/models/derivative_spec.rb
+++ b/spec/models/derivative_spec.rb
@@ -63,6 +63,15 @@ describe Derivative do
     let(:audio_derivative) { Derivative.new(audio_codec: 'AAC').tap { |d| d.absolute_location = location } }
     let(:video_derivative) { Derivative.new(video_codec: 'AVC').tap { |d| d.absolute_location = location } }
 
+    around :each do |example|
+      old_value = Avalon::StreamMapper.streaming_server
+      begin
+        example.run
+      ensure
+        Avalon::StreamMapper.streaming_server = old_value
+      end
+    end
+
     describe "generic" do
       before :each do
         Avalon::StreamMapper.streaming_server = :generic


### PR DESCRIPTION
The streaming URL tests at the bottom of `derivative_spec.rb` change the configured streaming server. Depending on the order the tests run in, this can leave the wrong setting selected and cause other tests to fail. This PR introduces an `around :each { ... }` block to make sure the original value is preserved/reset after each test.