### PR TITLE
Cast uri to a URI to ensure it responds to `#scheme` in WaveformService.get_waveform_json

### DIFF
--- a/app/jobs/waveform_job.rb
+++ b/app/jobs/waveform_job.rb
@@ -25,7 +25,7 @@ class WaveformJob < ActiveJob::Base
 
     service = WaveformService.new(8, SAMPLES_PER_FRAME)
     uri = derivative_file_uri(master_file) || file_uri(master_file) || playlist_url(master_file)
-    json = service.get_waveform_json(uri)
+    json = service.get_waveform_json(URI(uri))
     raise "No waveform generated for #{master_file.id}" if json.blank?
 
     master_file.waveform.content = Zlib::Deflate.deflate(json)

--- a/spec/jobs/waveform_job_spec.rb
+++ b/spec/jobs/waveform_job_spec.rb
@@ -107,7 +107,7 @@ describe WaveformJob do
     end
 
     context 'when MasterFile and Derivative are not retrievable' do
-      let(:secure_hls_url) { "https://path/to/mp4:video.mp4/playlist.m3u8?token=abc" }
+      let(:secure_hls_url) { URI("https://path/to/mp4:video.mp4/playlist.m3u8?token=abc") }
 
       before do
         allow(File).to receive(:exist?).and_call_original


### PR DESCRIPTION
This should fix the issue reported in VOV-6325.  I manually tested this in a rails console with an MDPI item and it successfully get wave normalized peaks data.