### PR TITLE
Allow using different redis database than 0

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -26,7 +26,7 @@ ActiveJob::Uniqueness.configure do |config|
   # Array of redis servers for Redlock quorum.
   # Read more at https://github.com/leandromoreira/redlock-rb#redis-client-configuration
   #
-  config.redlock_servers = ["redis://#{Settings.redis.host}:#{Settings.redis.port}"]
+  config.redlock_servers = ["redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}"]
 
   # Custom options for Redlock.
   # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration

--- a/config/initializers/browse_everything.rb
+++ b/config/initializers/browse_everything.rb
@@ -1,7 +1,7 @@
 settings = if Settings.dropbox.google_drive
   { 'google_drive' => { client_id: Settings.dropbox.google_drive.client_id,
                         client_secret: Settings.dropbox.google_drive.client_secret,
-                        redis_token_store_url: Settings.dropbox.google_drive.redis_token_store_url || "redis://#{Settings.redis.host}:#{Settings.redis.port}" } }
+                        redis_token_store_url: Settings.dropbox.google_drive.redis_token_store_url || "redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}" } }
 elsif Settings.dropbox.path =~ %r{^s3://}
   obj = FileLocator::S3File.new(Settings.dropbox.path).object
   { 's3' => { name: 'AWS S3 Dropbox', bucket: obj.bucket_name, base: obj.key, response_type: :s3_uri } }

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -2,10 +2,11 @@ config = Rails.application.config
 
 redis_host = Settings.redis.host
 redis_port = Settings.redis.port || 6379
+redis_db = Settings.redis.db || 0
 config.cache_store = :redis_store, {
   host: redis_host,
   port: redis_port,
-  db: 0,
+  db: redis_db,
   namespace: 'avalon'
 }
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,4 @@
-redis_conn = { url: "redis://#{Settings.redis.host}:#{Settings.redis.port}/" }
+redis_conn = { url: "redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}" }
 Sidekiq.configure_server do |s|
   s.redis = redis_conn
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,6 +56,7 @@ streaming:
 redis:
   host: localhost
   port: 6379
+  db: 0
 groups:
   system_groups: [administrator, group_manager, manager]
 master_file_management:


### PR DESCRIPTION
Redis by default allows for up to 16 databases within a single redis instance.  To allow for multiple avalon instances on a single machine or other cases where redis is shared we need to allow configuring the selected database.

See https://redis.io/commands/select