### PR TITLE
Fix sorting of the last access column on manage users page

### DIFF
--- a/app/views/samvera/persona/users/index.html.erb
+++ b/app/views/samvera/persona/users/index.html.erb
@@ -56,6 +56,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     </thead>
     <tbody>
       <% @presenter.users.each do |user| %>
+        <% last_accessed=@presenter.last_accessed(user).getutc.iso8601 %>
         <tr>
           <td><%= link_to user.username, main_app.edit_persona_user_path(user) %></td>
           <td><%= link_to user.email, main_app.edit_persona_user_path(user) %></td>
@@ -65,9 +66,9 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <% end %>
               </ul>
           </td>
-          <td>
+          <td data-order=<%= last_accessed %>>
             <%# in the case that a user is created who never signs in, this is necessary %>
-            <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+            <relative-time datetime="<%= last_accessed %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
               <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
             </relative-time>
           </td>


### PR DESCRIPTION
The `Last Access` column now sorts in chronological order instead of alpabetical order;

![desc](https://user-images.githubusercontent.com/1331659/139886618-24a5f4a7-5f78-44bf-b3a2-b7f37046ead8.png)
![asc](https://user-images.githubusercontent.com/1331659/139886628-790f045a-53cd-4196-8fef-826b7cb04b86.png)
