### PR TITLE
Move files not already in the dropbox into the dropbox prior to processing

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -659,7 +659,7 @@ class MasterFile < ActiveFedora::Base
     options
   end
 
-  def saveOriginal(file, original_name=nil, dropbox_dir=media_object.collection.dropbox_absolute_path)
+  def saveOriginal(file, original_name = nil, dropbox_dir = media_object.collection.dropbox_absolute_path)
     realpath = File.realpath(file.path)
 
     if original_name.present?
@@ -669,6 +669,11 @@ class MasterFile < ActiveFedora::Base
         # Move files which aren't under the collection's dropbox into the root of the dropbox
         parent_dir = dropbox_dir unless dropbox_dir.nil? || parent_dir.start_with?(dropbox_dir)
         path = File.join(parent_dir, original_name)
+        num = 1
+        while File.exist? path
+          path = File.join(parent_dir, duplicate_file_name(original_name, num))
+          num += 1
+        end
         FileUtils.move(realpath, path)
         realpath = path
       end
@@ -679,6 +684,11 @@ class MasterFile < ActiveFedora::Base
     self.file_size = file.size.to_s
   ensure
     file.close
+  end
+
+  def duplicate_file_name(filename, num)
+    extension = File.extname(filename)
+    File.basename(filename).sub(extension, "-#{num}#{extension}")
   end
 
   def saveDerivativesHash(derivative_hash)

--- a/app/services/master_file_builder.rb
+++ b/app/services/master_file_builder.rb
@@ -39,7 +39,7 @@ module MasterFileBuilder
       end
 
       master_file = MasterFile.new()
-      master_file.setContent(spec.content, file_name: spec.original_filename, file_size: spec.file_size, auth_header: spec.auth_header)
+      master_file.setContent(spec.content, file_name: spec.original_filename, file_size: spec.file_size, auth_header: spec.auth_header, dropbox_dir: media_object.collection.dropbox_absolute_path)
       master_file.set_workflow(spec.workflow)
 
       if 'Unknown' == master_file.file_format

--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -199,7 +199,7 @@ module Avalon
           # master_file.media_object = media_object
           files = self.class.gatherFiles(file_spec[:file])
           self.class.attach_datastreams_to_master_file(master_file, file_spec[:file])
-          master_file.setContent(files)
+          master_file.setContent(files, dropbox_dir: media_object.collection.dropbox_absolute_path)
 
           # Overwrite files hash with working file paths to pass to matterhorn
           if files.is_a?(Hash) && master_file.working_file_path.present?

--- a/spec/lib/avalon/batch/entry_spec.rb
+++ b/spec/lib/avalon/batch/entry_spec.rb
@@ -92,7 +92,7 @@ describe Avalon::Batch::Entry do
 
       it 'should call MasterFile.setContent with a hash of derivatives' do
       	allow_any_instance_of(MasterFile).to receive(:file_format).and_return('Moving image')
-      	expect_any_instance_of(MasterFile).to receive(:setContent).with(hash_match(derivative_hash))
+        expect_any_instance_of(MasterFile).to receive(:setContent).with(hash_match(derivative_hash), dropbox_dir: entry.media_object.collection.dropbox_absolute_path)
       	expect_any_instance_of(MasterFile).to receive(:process).with(hash_match(derivative_hash))
       	entry.process!
       end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -325,6 +325,19 @@ describe MasterFile do
           Settings.encoding.working_file_path = media_path
           expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
         end
+
+        context "when file with same name already exists in the collection's dropbox" do
+          let(:duplicate) { "videoshort-1.mp4" }
+
+          before do
+            FileUtils.cp fixture, File.join(collection.dropbox_absolute_path, original)
+          end
+
+          it "appends a numerical suffix" do
+            Settings.encoding.working_file_path = nil
+            expect(subject.file_location).to eq(File.realpath(File.join(collection.dropbox_absolute_path,duplicate)))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This attempts to resolve an issue where files that are web uploaded aren't available to be moved in post processing if background jobs are being run on a different server.  This also avoids issues with the globalness and temporalness of /tmp.