### PR TITLE
Switch to ActiveFedora13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'webpacker'
 
 # Core Samvera
 gem 'active-fedora', '~> 13.2'
-gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams', branch: 'af13'
+gem 'active_fedora-datastreams', '~> 0.3'
 gem 'fedora-migrate', git: 'https://github.com/avalonmediasystem/fedora-migrate.git', tag: 'avalon-r6.5'
 gem 'hydra-head', '~> 11.0'
 gem 'ldp', '~> 0.3' 

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'hydra-head', '~> 11.0'
 gem 'ldp', '~> 0.3' 
 gem 'noid-rails', '~> 3.0.1'
 gem 'rdf-rdfxml'
+gem 'rdf-vocab', '< 3.1.5'
 
 # Samvera version pins
 gem 'blacklight', '< 7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'webpacker'
 
 # Core Samvera
-gem 'active-fedora', git: 'https://github.com/apertome/active_fedora.git', branch: 'ruby2.7-fixes'
-gem 'active_fedora-datastreams', '~> 0.2.0'
+gem 'active-fedora', '~> 13.2'
+gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams', branch: 'af13'
 gem 'fedora-migrate', git: 'https://github.com/avalonmediasystem/fedora-migrate.git', tag: 'avalon-r6.5'
 gem 'hydra-head', '~> 11.0'
 gem 'ldp', '~> 0.3' 
@@ -36,7 +36,7 @@ gem 'rsolr', '~> 1.0'
 
 # Rails & Samvera Plugins
 gem 'about_page', git: 'https://github.com/avalonmediasystem/about_page.git', tag: 'avalon-r6.5'
-gem 'active_annotations', git: 'https://github.com/avalonmediasystem/active_annotations.git', branch: 'rails5.2'
+gem 'active_annotations', '~> 0.3'
 gem 'activerecord-session_store', '>= 2.0.0'
 gem 'acts_as_list'
 gem 'api-pagination'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,12 +696,11 @@ GEM
       rdf (~> 3.1)
     rdf-isomorphic (3.1.1)
       rdf (~> 3.1)
-    rdf-rdfa (3.1.3)
-      haml (~> 5.2)
+    rdf-rdfa (3.1.0)
+      haml (~> 5.1)
       htmlentities (~> 4.3)
-      rdf (~> 3.1, >= 3.1.13)
+      rdf (~> 3.1)
       rdf-aggregate-repo (~> 3.1)
-      rdf-vocab (~> 3.1, >= 3.1.11)
       rdf-xsd (~> 3.1)
     rdf-rdfxml (2.2.1)
       htmlentities (~> 4.3)
@@ -711,8 +710,8 @@ GEM
     rdf-turtle (3.1.3)
       ebnf (~> 2.1)
       rdf (~> 3.1, >= 3.1.8)
-    rdf-vocab (3.1.14)
-      rdf (~> 3.1, >= 3.1.12)
+    rdf-vocab (3.1.4)
+      rdf (~> 3.1)
     rdf-xsd (3.1.1)
       rdf (~> 3.1)
       rexml (~> 3.2)
@@ -1058,6 +1057,7 @@ DEPENDENCIES
   rb-readline
   rdf (~> 3.1)
   rdf-rdfxml
+  rdf-vocab (< 3.1.5)
   react-rails
   recaptcha
   redis-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,10 @@
 GIT
-  remote: https://github.com/apertome/active_fedora.git
-  revision: 9b6b0a9ccdc59398f32220aa46c86edd6d334d6f
-  branch: ruby2.7-fixes
-  specs:
-    active-fedora (12.2.3)
-      active-triples (>= 0.11.0, < 2.0.0)
-      activemodel (>= 4.2.10, < 5.3)
-      activesupport (>= 4.2.4, < 5.3)
-      deprecation
-      faraday (~> 0.12)
-      faraday-encoding (= 0.0.4)
-      ldp (>= 0.7.0, < 2)
-      rdf-vocab (< 3.1.5)
-      rsolr (>= 1.1.2, < 3)
-      ruby-progressbar (~> 1.0)
-
-GIT
   remote: https://github.com/avalonmediasystem/about_page.git
   revision: 1b920619cc54fdc99f1cb4da26c18818c1156070
   tag: avalon-r6.5
   specs:
     about_page (0.3.1)
       rails (>= 3.2)
-
-GIT
-  remote: https://github.com/avalonmediasystem/active_annotations.git
-  revision: c1f602779ac934aba1d4ff6d4fdab0145e6bf1d4
-  branch: rails5.2
-  specs:
-    active_annotations (0.2.2)
-      json-ld
-      rdf-vocab (>= 2.1.0)
 
 GIT
   remote: https://github.com/avalonmediasystem/avalon-about.git
@@ -104,6 +78,19 @@ GIT
       omniauth
 
 GIT
+  remote: https://github.com/samvera-labs/active_fedora-datastreams
+  revision: f3f4da60b17ce245053f50dbceba888235316a34
+  branch: af13
+  specs:
+    active_fedora-datastreams (0.2.0)
+      active-fedora (>= 11.0.0.pre, < 14)
+      activemodel (< 6.0)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (< 3.2)
+      rdf-rdfxml (~> 2.0)
+
+GIT
   remote: https://github.com/tawan/active-elastic-job.git
   revision: 7d210bdbcc9c465cc9704bc6b130882fe4c8eb9f
   specs:
@@ -137,19 +124,28 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active-fedora (13.2.4)
+      active-triples (>= 0.11.0, < 2.0.0)
+      activemodel (>= 5.1)
+      activesupport (>= 5.1)
+      deprecation
+      faraday (~> 0.12)
+      faraday-encoding (>= 0.0.5)
+      ldp (>= 0.7.0, < 2)
+      rsolr (>= 1.1.2, < 3)
+      ruby-progressbar (~> 1.0)
     active-triples (1.1.1)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
       rdf (>= 2.0.2, < 4.0)
       rdf-vocab (>= 2.0, < 4.0)
+    active_annotations (0.3.0)
+      json-ld
+      rails (~> 5.2)
+      rdf-vocab (>= 2.1.0)
     active_encode (0.8.2)
       rails
       sprockets (< 4)
-    active_fedora-datastreams (0.2.0)
-      active-fedora (>= 11.0.0.pre, < 13)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf-rdfxml (~> 2.0)
     activejob (5.2.6)
       activesupport (= 5.2.6)
       globalid (>= 0.3.6)
@@ -420,7 +416,7 @@ GEM
       i18n (>= 1.6, < 2)
     faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
-    faraday-encoding (0.0.4)
+    faraday-encoding (0.0.5)
       faraday
     fastimage (2.2.5)
     fcrepo_wrapper (0.9.0)
@@ -511,7 +507,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.1)
-    json-canonicalization (0.2.1)
+    json-canonicalization (0.3.0)
     json-ld (3.1.10)
       htmlentities (~> 4.3)
       json-canonicalization (~> 0.2)
@@ -578,7 +574,7 @@ GEM
     mime-types-data (3.2021.0901)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -700,11 +696,12 @@ GEM
       rdf (~> 3.1)
     rdf-isomorphic (3.1.1)
       rdf (~> 3.1)
-    rdf-rdfa (3.1.0)
-      haml (~> 5.1)
+    rdf-rdfa (3.1.3)
+      haml (~> 5.2)
       htmlentities (~> 4.3)
-      rdf (~> 3.1)
+      rdf (~> 3.1, >= 3.1.13)
       rdf-aggregate-repo (~> 3.1)
+      rdf-vocab (~> 3.1, >= 3.1.11)
       rdf-xsd (~> 3.1)
     rdf-rdfxml (2.2.1)
       htmlentities (~> 4.3)
@@ -714,8 +711,8 @@ GEM
     rdf-turtle (3.1.3)
       ebnf (~> 2.1)
       rdf (~> 3.1, >= 3.1.8)
-    rdf-vocab (3.1.4)
-      rdf (~> 3.1)
+    rdf-vocab (3.1.14)
+      rdf (~> 3.1, >= 3.1.12)
     rdf-xsd (3.1.1)
       rdf (~> 3.1)
       rexml (~> 3.2)
@@ -972,11 +969,11 @@ PLATFORMS
 
 DEPENDENCIES
   about_page!
-  active-fedora!
-  active_annotations!
+  active-fedora (~> 13.2)
+  active_annotations (~> 0.3)
   active_elastic_job!
   active_encode (~> 0.8.2)
-  active_fedora-datastreams (~> 0.2.0)
+  active_fedora-datastreams!
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,19 +78,6 @@ GIT
       omniauth
 
 GIT
-  remote: https://github.com/samvera-labs/active_fedora-datastreams
-  revision: f3f4da60b17ce245053f50dbceba888235316a34
-  branch: af13
-  specs:
-    active_fedora-datastreams (0.2.0)
-      active-fedora (>= 11.0.0.pre, < 14)
-      activemodel (< 6.0)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf (< 3.2)
-      rdf-rdfxml (~> 2.0)
-
-GIT
   remote: https://github.com/tawan/active-elastic-job.git
   revision: 7d210bdbcc9c465cc9704bc6b130882fe4c8eb9f
   specs:
@@ -146,6 +133,13 @@ GEM
     active_encode (0.8.2)
       rails
       sprockets (< 4)
+    active_fedora-datastreams (0.3.0)
+      active-fedora (>= 11.0.0.pre, < 14)
+      activemodel (< 6.0)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (< 3.2)
+      rdf-rdfxml (~> 2.0)
     activejob (5.2.6)
       activesupport (= 5.2.6)
       globalid (>= 0.3.6)
@@ -972,7 +966,7 @@ DEPENDENCIES
   active_annotations (~> 0.3)
   active_elastic_job!
   active_encode (~> 0.8.2)
-  active_fedora-datastreams!
+  active_fedora-datastreams (~> 0.3)
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)


### PR DESCRIPTION
This PR upgrades to ActiveFedora13 as a means of eventually getting a fix for the ruby 2.7 deprecation warning when it is released.  This is an alternative route than putting the fix in the 12.x stable branch and cutting a new 12 release of ActiveFedora.

This brings us up to the latest version of ActiveFedora.  I had to make changes to the `active_fedora-datastreams` gem to allow for the newer version of AF ~so this PR currently pins to a branch until a formal release of the gem happens~.
