### PR TITLE
Enable test results and historical timings in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,19 @@ jobs:
       - run:
           command: ./cc-test-reporter before-build
 
-      - samvera/parallel_rspec
+      # Pull in the parallel_rspec step and modify it to ensure that test results get stored
+      # - samvera/parallel_rspec
+      - run:
+          name: Run rspec in parallel
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec.xml $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
 
       - run:
           command: ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
 --color
 --require spec_helper
+--profile
+--format progress

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -161,6 +161,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.formatter = 'LdpCallProfileFormatter'
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
   # config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ControllerMacros, type: :controller

--- a/spec/support/ldp_call_profile_formatter.rb
+++ b/spec/support/ldp_call_profile_formatter.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# Taken from Hyrax and modified
+RSpec::Support.require_rspec_core "formatters/base_text_formatter"
+class LdpCallProfileFormatter < RSpec::Core::Formatters::ProfileFormatter
+  RSpec::Core::Formatters.register self, :example_started, :example_finished, :dump_profile
+  def initialize(output)
+    @output = output
+    @profile = []
+    reset!
+    ActiveSupport::Notifications.subscribe("http.ldp", method(:record_request))
+  end
+
+  def record_request(*_unused, data)
+    @request_count += 1
+    @request_count_by_name[data[:name]] += 1
+  end
+
+  def example_finished(notification)
+    @profile += [{ example: notification.example, count: @request_count, count_by_name: @request_count_by_name }]
+  end
+
+  def example_started(_notification)
+    reset!
+  end
+
+  def reset!
+    @request_count = 0
+    @request_count_by_name = { 'HEAD' => 0,
+                               'GET' => 0,
+                               'POST' => 0,
+                               'DELETE' => 0,
+                               'PUT' => 0,
+                               'PATCH' => 0 }
+  end
+
+  def dump_profile(profile)
+    @output.puts ""
+    dump_most_ldp_exampes(profile)
+    dump_slowest_examples(profile)
+  end
+
+  private
+
+  def dump_most_ldp_exampes(_prof)
+    @output.puts "Examples with the most LDP requests"
+    top = @profile.sort_by { |hash| hash[:count] }.last(10).reverse
+    top.each do |hash|
+      result = hash[:count_by_name].select { |_, v| v.positive? }
+      next if result.empty?
+      @output.puts "  #{hash[:example].full_description}"
+      @output.puts "    #{hash[:example].location}"
+      @output.puts "    Total LDP: #{hash[:count]} #{result}"
+    end
+  end
+
+  def dump_slowest_examples(profile)
+    RSpec::Core::Formatters::ProfileFormatter.new(@output).dump_profile(profile)
+  end
+end


### PR DESCRIPTION
This might speed up tests by allowing circleci to schedule them more efficiently between the 4 parallel rspec runs.

This PR also adds some logging at the end of the rspec tests which lists the slowest tests and the tests with the most calls to Fedora.