### PR TITLE
Support Solr 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  samvera: samvera/circleci-orb@1.0.0
+  samvera: samvera/circleci-orb@1
 jobs:
   build:
     docker:
@@ -20,8 +20,12 @@ jobs:
       - image: ualbertalib/docker-fcrepo4:4.7
         environment:
           CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
-      - image: solr:7-alpine
-        command: bin/solr -cloud -noprompt -f -p <<parameters.solr_port>>
+      - image: zookeeper:3.4
+      - image: solr:8-slim
+        environment:
+          VERBOSE: yes
+          SECURITY_JSON: '{"authentication":{"blockUnknown": false, "class":"solr.BasicAuthPlugin", "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="}, "realm":"My Solr users", "forwardCredentials": false}, "authorization":{ "class":"solr.RuleBasedAuthorizationPlugin", "permissions":[{"name":"security-edit", "role":"admin"}], "user-role":{"solr":"admin"}}}'
+        command: sh -c "server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:2181 -cmd put /security.json \"${SECURITY_JSON}\" && solr-fg -cloud -noprompt  -p << parameters.solr_port >> -z localhost:2181"
       - image: redis:alpine
 
     parameters:
@@ -66,7 +70,8 @@ jobs:
           paths:
             - .cache/yarn
 
-      - samvera/install_solr_core
+      - samvera/install_solr_core:
+          solr_config_path: 'solr/conf'
 
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
       parallelism:
         type: integer
         default: 4
+      solr_config_path:
+        type: string
+        default: 'solr/conf'
+      core_name:
+        type: string
+        default: 'hydra-test'
 
     working_directory: /home/app/avalon
 
@@ -70,8 +76,29 @@ jobs:
           paths:
             - .cache/yarn
 
-      - samvera/install_solr_core:
-          solr_config_path: 'solr/conf'
+      # Copy solr 8 compliant step from unreleased version of orb
+      #- samvera/install_solr_core:
+      #    solr_config_path: << parameters.solr_config_path >>
+      - run:
+          name: Wait for Solr
+          command: dockerize -wait tcp://localhost:<< parameters.solr_port >> -timeout 1m
+      - run:
+          name: Create solr core
+          command: |
+            if [ -d << parameters.solr_config_path >> ]
+            then
+              cd << parameters.solr_config_path >>
+            else
+              if [ -d "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/conf" ]
+              then
+                cd "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/conf"
+              else
+                cd "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/config"
+              fi
+            fi
+            zip -1 -r solr_conf.zip ./*
+            curl -H "Content-type:application/octet-stream" --data-binary @solr_conf.zip "http://solr:SolrRocks@127.0.0.1:<< parameters.solr_port >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:<< parameters.solr_port >>/api/collections/ -d '{create: {name: << parameters.core_name >>, config: solrconfig, numShards: 1}}'
 
       - run:
           command: |

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,8 +1,8 @@
 # Place any default configuration for solr_wrapper here
-version: 7.7.2
-# port: 8983
+version: 8.11.1
+port: 8983
 instance_dir: tmp/solr-development
 collection:
   persist: true
-  dir: solr/config/
+  dir: solr/conf/
   name: hydra-development

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,8 +1,8 @@
 #config/solr_wrapper_test.yml
-# version: 6.0.0
+version: 8.11.1
 port: 8985
 instance_dir: tmp/solr-test
 collection:
     persist: false
-    dir: solr/config
+    dir: solr/conf
     name: hydra-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   db: &db-avalon
-    image: postgres:10-alpine
+    image: postgres:14-alpine
     volumes:
       - database:/data
     environment:
@@ -42,12 +42,11 @@ services:
     volumes: []
 
   solr: &solr
-    image: solr:6.6.4-alpine
+    image: solr:8-slim
     volumes:
-      - ./solr/config:/opt/solr/avalon_conf
+      - ./solr/conf:/opt/solr/avalon_conf
       - solr:/opt/solr/server/solr/mycores
-    entrypoint:
-      - docker-entrypoint.sh
+    command:
       - solr-precreate
       - avalon
       - /opt/solr/avalon_conf
@@ -56,7 +55,7 @@ services:
   solr-test:
     <<: *solr
     volumes:
-      - ./solr/config:/opt/solr/avalon_conf
+      - ./solr/conf:/opt/solr/avalon_conf
 
   hls:
     image: avalonmediasystem/nginx:minio

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,222 @@
+version: '3.4'
+
+volumes:
+  database:
+  fedora:
+  solr:
+  npms:
+  data:
+
+networks:
+  internal:
+  external:
+
+services:
+  db: &db-avalon
+    image: postgres:14-alpine
+    volumes:
+      - database:/data
+    environment:
+      - PGDATA=/data
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=avalon
+      - POSTGRES_PASSWORD=password
+    ports:
+      - '5432:5432'
+    networks:
+      internal:
+      external:
+  db-test:
+    <<: *db-avalon
+    volumes: []
+
+  fedora: &fedora
+    image: avalonmediasystem/fedora:4.7.5
+    depends_on:
+      - db
+    volumes:
+      - fedora:/data
+    environment:
+      - JAVA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json -Dfcrepo.home=/data
+    ports:
+      - '8080:8080'
+    networks:
+      internal:
+      external:
+  fedora-test:
+    <<: *fedora
+    volumes: []
+
+  solr: &solr
+    image: solr:8-slim
+    volumes:
+      - ./solr/conf:/opt/solr/avalon_conf
+      - solr:/opt/solr/server/solr/mycores
+    command:
+      - solr-precreate
+      - avalon
+      - /opt/solr/avalon_conf
+    ports:
+      - '8983:8983'
+    networks:
+      internal:
+      external:
+
+  solr-test:
+    <<: *solr
+    volumes:
+      - ./solr/conf:/opt/solr/avalon_conf
+
+  hls:
+    image: avalonmediasystem/nginx:minio
+    environment:
+      - AVALON_DOMAIN=http://avalon:3000
+      - AVALON_STREAMING_BUCKET_URL=http://minio:9000/derivatives/
+    depends_on:
+      - minio
+    ports:
+      - '8880:80'
+    networks:
+      internal:
+      external:
+
+  redis: &redis
+    image: redis:alpine
+    ports:
+      - '6379:6379'
+    networks:
+      internal:
+      external:
+  redis-test:
+    <<: *redis
+
+  avalon: &avalon
+    image: avalonmediasystem/avalon:7.3.0-dev
+    build:
+      context: .
+      target: dev
+    command: bash -c "/docker_init.sh && bundle exec rails server -b 0.0.0.0"
+    depends_on:
+      - db
+      - fedora
+      - solr
+      - redis
+      - hls
+      - minio
+    environment:
+      - APP_NAME=avalon
+      - SETTINGS__DOMAIN=http://localhost:3000
+      - BUNDLE_FLAGS=--with development postgres --without production test
+      - ENCODE_WORK_DIR=/tmp
+      - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
+      - DATABASE_URL=postgres://postgres:password@db/avalon
+      - FEDORA_NAMESPACE=avalon
+      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
+      - RAILS_ENV=development
+      - RAILS_ADDITIONAL_HOSTS=avalon
+      - SETTINGS__REDIS__HOST=redis
+      - SETTINGS__REDIS__PORT=6379
+      - SECRET_KEY_BASE=abcd
+      - SOLR_URL=http://solr:8983/solr/avalon
+      - AWS_REGION=us-east-1
+      - SETTINGS__ACTIVE_STORAGE__BUCKET=supplementalfiles
+      - SETTINGS__ACTIVE_STORAGE__SERVICE=generic_s3
+      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
+      - SETTINGS__MINIO__ENDPOINT=http://minio:9000
+      - SETTINGS__MINIO__PUBLIC_HOST=http://localhost:9000
+      - SETTINGS__MINIO__ACCESS=minio
+      - SETTINGS__MINIO__SECRET=minio123
+      - SETTINGS__ENCODING__MASTERFILE_BUCKET=masterfiles
+      - SETTINGS__ENCODING__DERIVATIVE_BUCKET=derivatives
+      - SETTINGS__DROPBOX__PATH=s3://masterfiles/dropbox/
+      - SETTINGS__DROPBOX__UPLOAD_URI=s3://masterfiles/dropbox/
+      - SETTINGS__MASTER_FILE_MANAGEMENT__PATH=s3://preserves/
+      - SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=MOVE
+      - SETTINGS__STREAMING__CONTENT_PATH=/
+      - SETTINGS__STREAMING__STREAM_DEFAULT_QUALITY=medium
+      - SETTINGS__STREAMING__HTTP_BASE=http://localhost:8880/avalon
+      # - STREAMING_HOST=localhost
+      - SETTINGS__STREAMING__SERVER=nginx
+      - SETTINGS__STREAMING__STREAM_TOKEN_TTL=20
+      - SYSTEM_GROUPS=administrator,group_manager,manager
+    volumes:
+      - .:/home/app/avalon
+      - npms:/home/app/avalon/node_modules
+    ports:
+      - '3000:3000'
+    networks:
+      internal:
+      external:
+    stdin_open: true
+    tty: true
+
+  test:
+    <<: *avalon
+    command: >
+      bash -c "/docker_init.sh && tail -f /dev/null"
+    depends_on:
+      - db-test
+      - fedora-test
+      - solr-test
+      - redis-test
+    environment:
+      - DATABASE_URL=postgresql://postgres:password@db-test/avalon
+      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
+      - SETTINGS__REDIS__HOST=redis-test
+      - SETTINGS__REDIS__PORT=6379
+      - FEDORA_URL=http://fedora-test:8080/fedora/rest
+      - SOLR_URL=http://solr-test:8983/solr/avalon
+      - RAILS_ENV=test
+      - BUNDLE_FLAGS=--with aws test postgres --without production
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+    ports: []
+
+  worker:
+    <<: *avalon
+    command: dumb-init -- bash -c "bundle install && bundle exec sidekiq -C config/sidekiq.yml"
+    ports: []
+
+  minio:
+    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    command: minio server /data
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    volumes:
+      - data:/data
+    ports:
+      - 9000:9000
+    networks:
+      internal:
+      external:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add myminio http://minio:9000 minio minio123;
+      /usr/bin/mc mb -p myminio/fcrepo myminio/masterfiles myminio/derivatives myminio/supplementalfiles;
+      /usr/bin/mc policy set download myminio/derivatives;
+      /usr/bin/mc policy set download myminio/supplementalfiles;
+      exit 0;
+      "
+    networks:
+      internal:
+
+  cypress:
+    network_mode: host
+    image: cypress/included:3.8.2
+    depends_on:
+      - avalon
+    entrypoint: cypress run -C spec/cypress/cypress.json
+    working_dir: /e2e
+    volumes:
+      - ./:/e2e
+      - npms:/e2e/node_modules

--- a/solr/conf/_rest_managed.json
+++ b/solr/conf/_rest_managed.json
@@ -1,0 +1,3 @@
+{
+  "initArgs":{},
+  "managedList":[]}

--- a/solr/conf/admin-extra.html
+++ b/solr/conf/admin-extra.html
@@ -1,0 +1,31 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- The content of this page will be statically included into the top
+of the admin page.  Uncomment this as an example to see there the content
+will show up.
+
+<hr>
+<i>This line will appear before the first table</i>
+<tr>
+<td colspan="2">
+This row will be appended to the end of the first table
+</td>
+</tr>
+<hr>
+
+-->

--- a/solr/conf/elevate.xml
+++ b/solr/conf/elevate.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- If this file is found in the config directory, it will only be
+     loaded once at startup.  If it is found in Solr's data
+     directory, it will be re-loaded every commit.
+-->
+
+<elevate>
+ <query text="foo bar">
+  <doc id="1" />
+  <doc id="2" />
+  <doc id="3" />
+ </query>
+ 
+ <query text="ipod">
+   <doc id="MA147LL/A" />  <!-- put the actual ipod at the top -->
+   <doc id="IW-02" exclude="true" /> <!-- exclude this cable -->
+ </query>
+ 
+</elevate>

--- a/solr/conf/mapping-ISOLatin1Accent.txt
+++ b/solr/conf/mapping-ISOLatin1Accent.txt
@@ -1,0 +1,246 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syntax:
+#   "source" => "target"
+#     "source".length() > 0 (source cannot be empty.)
+#     "target".length() >= 0 (target can be empty.)
+
+# example:
+#   "??" => "A"
+#   "\u00C0" => "A"
+#   "\u00C0" => "\u0041"
+#   "??" => "ss"
+#   "\t" => " "
+#   "\n" => ""
+
+# ?? => A
+"\u00C0" => "A"
+
+# ?? => A
+"\u00C1" => "A"
+
+# ?? => A
+"\u00C2" => "A"
+
+# ?? => A
+"\u00C3" => "A"
+
+# ?? => A
+"\u00C4" => "A"
+
+# ?? => A
+"\u00C5" => "A"
+
+# ?? => AE
+"\u00C6" => "AE"
+
+# ?? => C
+"\u00C7" => "C"
+
+# ?? => E
+"\u00C8" => "E"
+
+# ?? => E
+"\u00C9" => "E"
+
+# ?? => E
+"\u00CA" => "E"
+
+# ?? => E
+"\u00CB" => "E"
+
+# ?? => I
+"\u00CC" => "I"
+
+# ?? => I
+"\u00CD" => "I"
+
+# ?? => I
+"\u00CE" => "I"
+
+# ?? => I
+"\u00CF" => "I"
+
+# ?? => IJ
+"\u0132" => "IJ"
+
+# ?? => D
+"\u00D0" => "D"
+
+# ?? => N
+"\u00D1" => "N"
+
+# ?? => O
+"\u00D2" => "O"
+
+# ?? => O
+"\u00D3" => "O"
+
+# ?? => O
+"\u00D4" => "O"
+
+# ?? => O
+"\u00D5" => "O"
+
+# ?? => O
+"\u00D6" => "O"
+
+# ?? => O
+"\u00D8" => "O"
+
+# ?? => OE
+"\u0152" => "OE"
+
+# ??
+"\u00DE" => "TH"
+
+# ?? => U
+"\u00D9" => "U"
+
+# ?? => U
+"\u00DA" => "U"
+
+# ?? => U
+"\u00DB" => "U"
+
+# ?? => U
+"\u00DC" => "U"
+
+# ?? => Y
+"\u00DD" => "Y"
+
+# ?? => Y
+"\u0178" => "Y"
+
+# ?? => a
+"\u00E0" => "a"
+
+# ?? => a
+"\u00E1" => "a"
+
+# ?? => a
+"\u00E2" => "a"
+
+# ?? => a
+"\u00E3" => "a"
+
+# ?? => a
+"\u00E4" => "a"
+
+# ?? => a
+"\u00E5" => "a"
+
+# ?? => ae
+"\u00E6" => "ae"
+
+# ?? => c
+"\u00E7" => "c"
+
+# ?? => e
+"\u00E8" => "e"
+
+# ?? => e
+"\u00E9" => "e"
+
+# ?? => e
+"\u00EA" => "e"
+
+# ?? => e
+"\u00EB" => "e"
+
+# ?? => i
+"\u00EC" => "i"
+
+# ?? => i
+"\u00ED" => "i"
+
+# ?? => i
+"\u00EE" => "i"
+
+# ?? => i
+"\u00EF" => "i"
+
+# ?? => ij
+"\u0133" => "ij"
+
+# ?? => d
+"\u00F0" => "d"
+
+# ?? => n
+"\u00F1" => "n"
+
+# ?? => o
+"\u00F2" => "o"
+
+# ?? => o
+"\u00F3" => "o"
+
+# ?? => o
+"\u00F4" => "o"
+
+# ?? => o
+"\u00F5" => "o"
+
+# ?? => o
+"\u00F6" => "o"
+
+# ?? => o
+"\u00F8" => "o"
+
+# ?? => oe
+"\u0153" => "oe"
+
+# ?? => ss
+"\u00DF" => "ss"
+
+# ?? => th
+"\u00FE" => "th"
+
+# ?? => u
+"\u00F9" => "u"
+
+# ?? => u
+"\u00FA" => "u"
+
+# ?? => u
+"\u00FB" => "u"
+
+# ?? => u
+"\u00FC" => "u"
+
+# ?? => y
+"\u00FD" => "y"
+
+# ?? => y
+"\u00FF" => "y"
+
+# ??? => ff
+"\uFB00" => "ff"
+
+# ??? => fi
+"\uFB01" => "fi"
+
+# ??? => fl
+"\uFB02" => "fl"
+
+# ??? => ffi
+"\uFB03" => "ffi"
+
+# ??? => ffl
+"\uFB04" => "ffl"
+
+# ??? => ft
+"\uFB05" => "ft"
+
+# ??? => st
+"\uFB06" => "st"

--- a/solr/conf/protwords.txt
+++ b/solr/conf/protwords.txt
@@ -1,0 +1,21 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+# Use a protected word file to protect against the stemmer reducing two
+# unrelated words to the same base word.
+
+# Some non-words that normally won't be encountered,
+# just to test that they won't be stemmed.
+dontstems
+zwhacky
+

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ This is the Solr schema file. This file should be named "schema.xml" and
+ should be in the conf directory under the solr home
+ (i.e. ./solr/conf/schema.xml by default)
+ or located where the classloader for the Solr webapp can find it.
+
+ This example schema is the recommended starting point for users.
+ It should be kept correct and concise, usable out-of-the-box.
+
+ For more information, on how to customize this file, please see
+ http://wiki.apache.org/solr/SchemaXml
+
+ PERFORMANCE NOTE: this schema includes many optional features and should not
+ be used for benchmarking.  To improve performance one could
+  - set stored="false" for all fields possible (esp large fields) when you
+    only need to search on the field but don't need to return the original
+    value.
+  - set indexed="false" if you don't need to search on the field, but only
+    return the field as a result of searching on other indexed fields.
+  - remove all unneeded copyField statements
+  - for best index size and searching performance, set "index" to false
+    for all general text fields, use copyField to copy them to the
+    catchall "text" field, and use that for searching.
+  - For maximum indexing performance, use the StreamingUpdateSolrServer
+    java client.
+  - Remember to run the JVM in server mode, and use a higher logging level
+    that avoids logging every request
+-->
+
+<schema name="Hydra Demo Index" version="1.5">
+  <!-- attribute "name" is the name of this schema and is only used for display purposes.
+       Applications should change this to reflect the nature of the search collection.
+       version="1.5" is Solr's version number for the schema syntax and semantics.  It should
+       not normally be changed by applications.
+       1.0: multiValued attribute did not exist, all fields are multiValued by nature
+       1.1: multiValued attribute introduced, false by default
+       1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
+       1.3: removed optional field compress feature
+       1.4: default auto-phrase (QueryParser feature) to off
+       1.5: omitNorms defaults to true for primitive field types (int, float, boolean, string...)
+# TODO 1.6: useDocValuesAsStored defaults to true.
+# See https://github.com/samvera/active_fedora/issues/1346
+     -->
+
+  <types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
+
+    <!-- Default numeric field types.  -->
+    <fieldType name="int" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="float" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="long" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="double" class="solr.DoublePointField" docValues="true"/>
+
+    <!-- PointField numeric field types for faster range queries -->
+    <fieldType name="tint" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="tfloat" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="tlong" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="tdouble" class="solr.DoublePointField" docValues="true"/>
+
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
+      -->
+    <fieldType name="date" class="solr.DatePointField" docValues="true"/>
+    <!-- A PointField based date field for faster date range queries and date faceting. -->
+    <fieldType name="tdate" class="solr.DatePointField" docValues="true"/>
+    <!-- A DateRange based date field for truly faster date range queries. -->
+    <fieldType name="dateRange" class="solr.DateRangeField" omitNorms="true" omitTermFreqAndPositions="true"/>
+
+    <!-- This point type indexes the coordinates as separate fields (subFields)
+      If subFieldType is defined, it references a type, and a dynamic field
+      definition is created matching *___<typename>.  Alternately, if
+      subFieldSuffix is defined, that is used to create the subFields.
+      Example: if subFieldType="double", then the coordinates would be
+        indexed in fields myloc_0___double,myloc_1___double.
+      Example: if subFieldSuffix="_d" then the coordinates would be indexed
+        in fields myloc_0_d,myloc_1_d
+      The subFields are an implementation detail of the fieldType, and end
+      users normally should not need to know about them.
+     -->
+    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+
+    <!-- A geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
+      For more information about this and other Spatial fields new to Solr 4, see:
+      http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
+    -->
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
+
+    <fieldType name="text" class="solr.TextField" omitNorms="false">
+      <analyzer>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field that only splits on whitespace for exact matching of words -->
+    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
+    <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldtype>
+
+    <!-- A text field with defaults appropriate for English -->
+    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <!--
+        <filter class="solr.PorterStemFilterFactory"/>
+        -->
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- queries for paths match documents at that path, or in descendent paths -->
+    <fieldType name="descendent_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- queries for paths match documents at that path, or in ancestor paths -->
+    <fieldType name="ancestor_path" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+      </analyzer>
+    </fieldType>
+
+    <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+  </types>
+
+
+  <fields>
+    <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
+    or Solr won't start. _version_ and update log are required for SolrCloud
+    -->
+    <field name="_version_" type="long" indexed="true" stored="true"/>
+
+    <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
+    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+    <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+    <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+
+    <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
+
+    <!-- text (_t...) -->
+    <dynamicField name="*_ti" type="text" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tim" type="text" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ts" type="text" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+
+    <!-- English text (_te...) -->
+    <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_tes" type="text_en" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_tesm" type="text_en" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_tesi" type="text_en" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_tesim" type="text_en" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_teiv" type="text_en" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+
+    <!-- string (_s...) -->
+    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
+
+    <!-- integer (_i...) -->
+    <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_is" type="int" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- IntegerPointField (_it...) (for faster range queries) -->
+    <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_its" type="tint" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- date (_dt...) -->
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
+    <dynamicField name="*_dti" type="date" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtim" type="date" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dts" type="date" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- DatePointField (_dtt...) (for faster range queries) -->
+    <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dtts" type="tdate" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
+
+
+    <!-- date range (_dr...) (for faster AND better range queries) -->
+    <dynamicField name="*_dri" type="dateRange" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drim" type="dateRange" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_drsi" type="dateRange" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drsim" type="dateRange" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="true" multiValued="false"/> <!-- indexed anyway because DateRangeField errors otherwise -->
+    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="true" multiValued="true"/> <!-- indexed anyway because DateRangeField errors otherwise -->
+
+    <!-- long (_l...) -->
+    <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ls" type="long" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- LongPointField (_lt...) (for faster range queries) -->
+    <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_lts" type="tlong" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- double (_db...) -->
+    <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dbs" type="double" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- DoublePointField (_dbt...) (for faster range queries) -->
+    <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_dbts" type="tdouble" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- float (_f...) -->
+    <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_fs" type="float" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- FloatPointField (_ft...) (for faster range queries) -->
+    <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_fts" type="tfloat" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
+
+    <!-- boolean (_b...) -->
+    <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
+
+    <!-- Type used to index the lat and lon components for the "location" FieldType -->
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
+
+    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+
+    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
+    <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+
+
+  </fields>
+
+ <!-- Field to use to determine and enforce document uniqueness.
+      Unless this field is marked with required="false", it will be a required field
+   -->
+ <uniqueKey>id</uniqueKey>
+
+  <!-- copyField commands copy one field to another at the time a document
+        is added to the index.  It's used either to index the same field differently,
+        or to add multiple fields to the same field for easier/faster searching.  -->
+   <!-- Copy Fields -->
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+    Another way to map multiple source fields to the same
+    destination field is to use the dynamic field syntax.
+    copyField also supports a maxChars to copy setting.  -->
+
+   <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+   <!-- for suggestions -->
+   <copyField source="*_tesim" dest="suggest"/>
+   <copyField source="*_ssim" dest="suggest"/>
+
+ <!-- Similarity is the scoring routine for each document vs. a query.
+      A custom similarity may be specified here, but the default is fine
+      for most applications.  -->
+ <!-- <similarity class="org.apache.lucene.search.DefaultSimilarity"/> -->
+ <!-- ... OR ...
+      Specify a SimilarityFactory class name implementation
+      allowing parameters to be used.
+ -->
+ <!--
+ <similarity class="com.example.solr.CustomSimilarityFactory">
+   <str name="paramkey">param value</str>
+ </similarity>
+ -->
+
+</schema>

--- a/solr/conf/scripts.conf
+++ b/solr/conf/scripts.conf
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+user=
+solr_hostname=localhost
+solr_port=8983
+rsyncd_port=18983
+data_dir=
+webapp_name=solr
+master_host=
+master_data_dir=
+master_status_dir=

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
+-->
+<config>
+
+  <!-- Controls what version of Lucene various components of Solr
+       adhere to.  Generally, you want to use the latest version to
+       get all bug fixes and improvements. It is highly recommended
+       that you fully re-index after changing this setting as it can
+       affect both how text is indexed and queried.
+  -->
+  <luceneMatchVersion>5.0.0</luceneMatchVersion>
+
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
+
+  <directoryFactory name="DirectoryFactory"
+                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">
+  </directoryFactory>
+
+  <codecFactory class="solr.SchemaCodecFactory"/>
+
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+
+  <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
+
+  <requestDispatcher handleSelect="true" >
+    <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048000" />
+  </requestDispatcher>
+
+  <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
+
+  <!-- config for the admin interface -->
+  <admin>
+    <defaultQuery>*:*</defaultQuery>
+  </admin>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
+  <!-- SearchHandler
+
+       http://wiki.apache.org/solr/SearchHandler
+
+       For processing Search Queries, the primary Request Handler
+       provided with Solr is "SearchHandler" It delegates to a sequent
+       of SearchComponents (see below) and supports distributed
+       queries across multiple shards
+    -->
+  <requestHandler name="search" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+     <lst name="defaults">
+       <str name="defType">edismax</str>
+       <str name="echoParams">explicit</str>
+       <str name="q.alt">*:*</str>
+       <str name="q.op">OR</str>
+       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+       <int name="qs">1</int>
+       <int name="ps">2</int>
+       <float name="tie">0.01</float>
+       <!-- this qf and pf are used by default, if not otherwise specified by
+            client. The default blacklight_config will use these for the
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
+            below, which the default blacklight_config will specify for
+            those searches. You may also be interested in:
+            http://wiki.apache.org/solr/LocalParams
+       -->
+        <str name="qf">
+          id
+          title_tesi^10.0
+          section_label_tesim^5.0
+          creator_ssim^3.0
+          date_sim^3.0
+          all_text_timv^1.0
+          active_fedora_model_ssi
+          object_type_si
+        </str>
+        <str name="pf">
+          title_tesi^10.0
+          section_label_tesim^5.0
+          creator_ssim^3.0
+          date_sim^3.0
+          all_text_timv^1.0
+        </str>
+
+       <str name="author_qf">
+          author_tesim
+       </str>
+       <str name="author_pf">
+       </str>
+       <str name="title_qf">
+          title_tesim
+       </str>
+       <str name="title_pf">
+       </str>
+       <str name="subject_qf">
+          subject_tesim
+       </str>
+       <str name="subject_pf">
+       </str>
+
+       <str name="fl">
+         *,
+         score
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+
+       <str name="spellcheck">true</str>
+       <str name="spellcheck.dictionary">default</str>
+       <str name="spellcheck.onlyMorePopular">true</str>
+       <str name="spellcheck.extendedResults">true</str>
+       <str name="spellcheck.collate">false</str>
+       <str name="spellcheck.count">5</str>
+
+     </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <requestHandler name="permissions" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="facet">off</str>
+      <str name="echoParams">all</str>
+      <str name="rows">1</str>
+      <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+      <str name="fl">
+        id,
+        access_ssim,
+        discover_access_group_ssim,discover_access_person_ssim,
+        read_access_group_ssim,read_access_person_ssim,
+        edit_access_group_ssim,edit_access_person_ssim,
+        depositor_ti,
+        embargo_release_date_dtsi
+        inheritable_access_ssim,
+        inheritable_discover_access_group_ssim,inheritable_discover_access_person_ssim,
+        inheritable_read_access_group_ssim,inheritable_read_access_person_ssim,
+        inheritable_edit_access_group_ssim,inheritable_edit_access_person_ssim,
+        inheritable_embargo_release_date_dtsi
+      </str>
+    </lst>
+  </requestHandler>
+
+  <requestHandler name="standard" class="solr.SearchHandler">
+     <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <str name="defType">lucene</str>
+     </lst>
+  </requestHandler>
+
+  <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
+  <requestHandler name="document" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+      <str name="fl">*</str>
+      <str name="rows">1</str>
+      <str name="q">{!term f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+    </lst>
+  </requestHandler>
+
+<!-- Spell Check
+
+        The spell check component can return a list of alternative spelling
+        suggestions.
+
+        http://wiki.apache.org/solr/SpellCheckComponent
+     -->
+  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+
+    <str name="queryAnalyzerFieldType">textSpell</str>
+
+    <!-- Multiple "Spell Checkers" can be declared and used by this
+         component
+      -->
+
+    <!-- a spellchecker built from a field of the main index, and
+         written to disk
+      -->
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">spell</str>
+      <str name="spellcheckIndexDir">./spell</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">author</str>
+      <str name="field">author_spell</str>
+      <str name="spellcheckIndexDir">./spell_author</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">subject</str>
+      <str name="field">subject_spell</str>
+      <str name="spellcheckIndexDir">./spell_subject</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+    <lst name="spellchecker">
+      <str name="name">title</str>
+      <str name="field">title_spell</str>
+      <str name="spellcheckIndexDir">./spell_title</str>
+      <str name="accuracy">0.7</str>
+      <str name="buildOnOptimize">true</str>
+    </lst>
+
+    <!-- a spellchecker that uses a different distance measure -->
+    <!--
+       <lst name="spellchecker">
+         <str name="name">jarowinkler</str>
+         <str name="field">spell</str>
+         <str name="distanceMeasure">
+           org.apache.lucene.search.spell.JaroWinklerDistance
+         </str>
+         <str name="spellcheckIndexDir">spellcheckerJaro</str>
+       </lst>
+     -->
+
+    <!-- a spellchecker that use an alternate comparator
+
+         comparatorClass be one of:
+          1. score (default)
+          2. freq (Frequency first, then score)
+          3. A fully qualified class name
+      -->
+    <!--
+       <lst name="spellchecker">
+         <str name="name">freq</str>
+         <str name="field">lowerfilt</str>
+         <str name="spellcheckIndexDir">spellcheckerFreq</str>
+         <str name="comparatorClass">freq</str>
+         <str name="buildOnCommit">true</str>
+      -->
+
+    <!-- A spellchecker that reads the list of words from a file -->
+    <!--
+       <lst name="spellchecker">
+         <str name="classname">solr.FileBasedSpellChecker</str>
+         <str name="name">file</str>
+         <str name="sourceLocation">spellings.txt</str>
+         <str name="characterEncoding">UTF-8</str>
+         <str name="spellcheckIndexDir">spellcheckerFile</str>
+       </lst>
+      -->
+  </searchComponent>
+
+  <!--searchComponent name="suggest" class="solr.SuggestComponent">
+    <lst name="suggester">
+      <str name="name">mySuggester</str>
+      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="suggestAnalyzerFieldType">textSuggest</str>
+      <str name="buildOnCommit">true</str>
+      <str name="field">suggest</str>
+    </lst>
+  </searchComponent>
+
+  <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <str name="suggest">true</str>
+      <str name="suggest.count">5</str>
+      <str name="suggest.dictionary">mySuggester</str>
+    </lst>
+    <arr name="components">
+      <str>suggest</str>
+    </arr>
+  </requestHandler-->
+
+  <requestHandler name="/update/extract" class="org.apache.solr.handler.extraction.ExtractingRequestHandler">
+    <lst name="defaults">
+      <str name="fmap.Last-Modified">last_modified</str>
+      <str name="uprefix">ignored_</str>
+    </lst>
+    <!--Optional.  Specify a path to a tika configuration file. See the Tika docs for details.-->
+    <!-- <str name="tika.config">/my/path/to/tika.config</str> -->
+    <!-- Optional. Specify one or more date formats to parse. See DateUtil.DEFAULT_DATE_FORMATS
+         for default date formats -->
+    <!-- <lst name="date.formats"> -->
+    <!--   <str>yyyy&#45;MM&#45;dd</str> -->
+    <!-- </lst> -->
+  </requestHandler>
+</config>

--- a/solr/conf/spellings.txt
+++ b/solr/conf/spellings.txt
@@ -1,0 +1,2 @@
+pizza
+history

--- a/solr/conf/stopwords.txt
+++ b/solr/conf/stopwords.txt
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+# a couple of test stopwords to test that the words are really being
+# configured from this file:
+stopworda
+stopwordb
+
+#Standard english stop words taken from Lucene's StopAnalyzer
+a
+an
+and
+are
+as
+at
+be
+but
+by
+for
+if
+in
+into
+is
+it
+no
+not
+of
+on
+or
+s
+such
+t
+that
+the
+their
+then
+there
+these
+they
+this
+to
+was
+will
+with
+

--- a/solr/conf/stopwords_en.txt
+++ b/solr/conf/stopwords_en.txt
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+# a couple of test stopwords to test that the words are really being
+# configured from this file:
+stopworda
+stopwordb
+
+#Standard english stop words taken from Lucene's StopAnalyzer
+a
+an
+and
+are
+as
+at
+be
+but
+by
+for
+if
+in
+into
+is
+it
+no
+not
+of
+on
+or
+s
+such
+t
+that
+the
+their
+then
+there
+these
+they
+this
+to
+was
+will
+with
+

--- a/solr/conf/synonyms.txt
+++ b/solr/conf/synonyms.txt
@@ -1,0 +1,31 @@
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------------------------------------------------------
+#some test synonym mappings unlikely to appear in real input text
+aaa => aaaa
+bbb => bbbb1 bbbb2
+ccc => cccc1,cccc2
+a\=>a => b\=>b
+a\,a => b\,b
+fooaaa,baraaa,bazaaa
+
+# Some synonym groups specific to this example
+GB,gib,gigabyte,gigabytes
+MB,mib,megabyte,megabytes
+Television, Televisions, TV, TVs
+#notice we use "gib" instead of "GiB" so any WordDelimiterFilter coming
+#after us won't split it into two words.
+
+# Synonym mappings can be used for spelling correction too
+pixima => pixma
+

--- a/solr/conf/xslt/example.xsl
+++ b/solr/conf/xslt/example.xsl
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
+<!-- 
+  Simple transform of Solr query results to HTML
+ -->
+<xsl:stylesheet version='1.0'
+    xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+>
+
+  <xsl:output media-type="text/html; charset=UTF-8" encoding="UTF-8"/> 
+  
+  <xsl:variable name="title" select="concat('Solr search results (',response/result/@numFound,' documents)')"/>
+  
+  <xsl:template match='/'>
+    <html>
+      <head>
+        <title><xsl:value-of select="$title"/></title>
+        <xsl:call-template name="css"/>
+      </head>
+      <body>
+        <h1><xsl:value-of select="$title"/></h1>
+        <div class="note">
+          This has been formatted by the sample "example.xsl" transform -
+          use your own XSLT to get a nicer page
+        </div>
+        <xsl:apply-templates select="response/result/doc"/>
+      </body>
+    </html>
+  </xsl:template>
+  
+  <xsl:template match="doc">
+    <xsl:variable name="pos" select="position()"/>
+    <div class="doc">
+      <table width="100%">
+        <xsl:apply-templates>
+          <xsl:with-param name="pos"><xsl:value-of select="$pos"/></xsl:with-param>
+        </xsl:apply-templates>
+      </table>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="doc/*[@name='score']" priority="100">
+    <xsl:param name="pos"></xsl:param>
+    <tr>
+      <td class="name">
+        <xsl:value-of select="@name"/>
+      </td>
+      <td class="value">
+        <xsl:value-of select="."/>
+
+        <xsl:if test="boolean(//lst[@name='explain'])">
+          <xsl:element name="a">
+            <!-- can't allow whitespace here -->
+            <xsl:attribute name="href">javascript:toggle("<xsl:value-of select="concat('exp-',$pos)" />");</xsl:attribute>?</xsl:element>
+          <br/>
+          <xsl:element name="div">
+            <xsl:attribute name="class">exp</xsl:attribute>
+            <xsl:attribute name="id">
+              <xsl:value-of select="concat('exp-',$pos)" />
+            </xsl:attribute>
+            <xsl:value-of select="//lst[@name='explain']/str[position()=$pos]"/>
+          </xsl:element>
+        </xsl:if>
+      </td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="doc/arr" priority="100">
+    <tr>
+      <td class="name">
+        <xsl:value-of select="@name"/>
+      </td>
+      <td class="value">
+        <ul>
+        <xsl:for-each select="*">
+          <li><xsl:value-of select="."/></li>
+        </xsl:for-each>
+        </ul>
+      </td>
+    </tr>
+  </xsl:template>
+
+
+  <xsl:template match="doc/*">
+    <tr>
+      <td class="name">
+        <xsl:value-of select="@name"/>
+      </td>
+      <td class="value">
+        <xsl:value-of select="."/>
+      </td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="*"/>
+  
+  <xsl:template name="css">
+    <script>
+      function toggle(id) {
+        var obj = document.getElementById(id);
+        obj.style.display = (obj.style.display != 'block') ? 'block' : 'none';
+      }
+    </script>
+    <style type="text/css">
+      body { font-family: "Lucida Grande", sans-serif }
+      td.name { font-style: italic; font-size:80%; }
+      td { vertical-align: top; }
+      ul { margin: 0px; margin-left: 1em; padding: 0px; }
+      .note { font-size:80%; }
+      .doc { margin-top: 1em; border-top: solid grey 1px; }
+      .exp { display: none; font-family: monospace; white-space: pre; }
+    </style>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/solr/conf/xslt/example_atom.xsl
+++ b/solr/conf/xslt/example_atom.xsl
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
+<!-- 
+  Simple transform of Solr query results to Atom
+ -->
+
+<xsl:stylesheet version='1.0'
+    xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+
+  <xsl:output
+       method="xml"
+       encoding="utf-8"
+       media-type="text/xml; charset=UTF-8"
+  />
+
+  <xsl:template match='/'>
+    <xsl:variable name="query" select="response/lst[@name='responseHeader']/lst[@name='params']/str[@name='q']"/>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Example Solr Atom 1.0 Feed</title>
+      <subtitle>
+       This has been formatted by the sample "example_atom.xsl" transform -
+       use your own XSLT to get a nicer Atom feed.
+      </subtitle>
+      <author>
+        <name>Apache Solr</name>
+        <email>solr-user@lucene.apache.org</email>
+      </author>
+      <link rel="self" type="application/atom+xml" 
+            href="http://localhost:8983/solr/q={$query}&amp;wt=xslt&amp;tr=atom.xsl"/>
+      <updated>
+        <xsl:value-of select="response/result/doc[position()=1]/date[@name='timestamp']"/>
+      </updated>
+      <id>tag:localhost,2007:example</id>
+      <xsl:apply-templates select="response/result/doc"/>
+    </feed>
+  </xsl:template>
+    
+  <!-- search results xslt -->
+  <xsl:template match="doc">
+    <xsl:variable name="id" select="str[@name='id']"/>
+    <entry>
+      <title><xsl:value-of select="str[@name='name']"/></title>
+      <link href="http://localhost:8983/solr/select?q={$id}"/>
+      <id>tag:localhost,2007:<xsl:value-of select="$id"/></id>
+      <summary><xsl:value-of select="arr[@name='features']"/></summary>
+      <updated><xsl:value-of select="date[@name='timestamp']"/></updated>
+    </entry>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/solr/conf/xslt/example_rss.xsl
+++ b/solr/conf/xslt/example_rss.xsl
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!-- 
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
+<!-- 
+  Simple transform of Solr query results to RSS
+ -->
+
+<xsl:stylesheet version='1.0'
+    xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+
+  <xsl:output
+       method="xml"
+       encoding="utf-8"
+       media-type="text/xml; charset=UTF-8"
+  />
+  <xsl:template match='/'>
+    <rss version="2.0">
+       <channel>
+	 <title>Example Solr RSS 2.0 Feed</title>
+         <link>http://localhost:8983/solr</link>
+         <description>
+          This has been formatted by the sample "example_rss.xsl" transform -
+          use your own XSLT to get a nicer RSS feed.
+         </description>
+         <language>en-us</language>
+         <docs>http://localhost:8983/solr</docs>
+         <xsl:apply-templates select="response/result/doc"/>
+       </channel>
+    </rss>
+  </xsl:template>
+  
+  <!-- search results xslt -->
+  <xsl:template match="doc">
+    <xsl:variable name="id" select="str[@name='id']"/>
+    <xsl:variable name="timestamp" select="date[@name='timestamp']"/>
+    <item>
+      <title><xsl:value-of select="str[@name='name']"/></title>
+      <link>
+        http://localhost:8983/solr/select?q=id:<xsl:value-of select="$id"/>
+      </link>
+      <description>
+        <xsl:value-of select="arr[@name='features']"/>
+      </description>
+      <pubDate><xsl:value-of select="$timestamp"/></pubDate>
+      <guid>
+        http://localhost:8983/solr/select?q=id:<xsl:value-of select="$id"/>
+      </guid>
+    </item>
+  </xsl:template>
+</xsl:stylesheet>

--- a/solr/conf/xslt/luke.xsl
+++ b/solr/conf/xslt/luke.xsl
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+
+<!-- 
+  Display the luke request handler with graphs
+ -->
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://www.w3.org/1999/xhtml"
+    version="1.0"
+    >
+    <xsl:output
+        method="html"
+        encoding="UTF-8"
+        media-type="text/html; charset=UTF-8"
+        doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+    />
+
+    <xsl:variable name="title">Solr Luke Request Handler Response</xsl:variable>
+
+    <xsl:template match="/">
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+                <link rel="stylesheet" type="text/css" href="solr-admin.css"/>
+                <link rel="icon" href="favicon.ico" type="image/ico"/>
+                <link rel="shortcut icon" href="favicon.ico" type="image/ico"/>
+                <title>
+                    <xsl:value-of select="$title"/>
+                </title>
+                <xsl:call-template name="css"/>
+
+            </head>
+            <body>
+                <h1>
+                    <xsl:value-of select="$title"/>
+                </h1>
+                <div class="doc">
+                    <ul>
+                        <xsl:if test="response/lst[@name='index']">
+                            <li>
+                                <a href="#index">Index Statistics</a>
+                            </li>
+                        </xsl:if>
+                        <xsl:if test="response/lst[@name='fields']">
+                            <li>
+                                <a href="#fields">Field Statistics</a>
+                                <ul>
+                                    <xsl:for-each select="response/lst[@name='fields']/lst">
+                                        <li>
+                                            <a href="#{@name}">
+                                                <xsl:value-of select="@name"/>
+                                            </a>
+                                        </li>
+                                    </xsl:for-each>
+                                </ul>
+                            </li>
+                        </xsl:if>
+                        <xsl:if test="response/lst[@name='doc']">
+                            <li>
+                                <a href="#doc">Document statistics</a>
+                            </li>
+                        </xsl:if>
+                    </ul>
+                </div>
+                <xsl:if test="response/lst[@name='index']">
+                    <h2><a name="index"/>Index Statistics</h2>
+                    <xsl:apply-templates select="response/lst[@name='index']"/>
+                </xsl:if>
+                <xsl:if test="response/lst[@name='fields']">
+                    <h2><a name="fields"/>Field Statistics</h2>
+                    <xsl:apply-templates select="response/lst[@name='fields']"/>
+                </xsl:if>
+                <xsl:if test="response/lst[@name='doc']">
+                    <h2><a name="doc"/>Document statistics</h2>
+                    <xsl:apply-templates select="response/lst[@name='doc']"/>
+                </xsl:if>
+            </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="lst">
+        <xsl:if test="parent::lst">
+            <tr>
+                <td colspan="2">
+                    <div class="doc">
+                        <xsl:call-template name="list"/>
+                    </div>
+                </td>
+            </tr>
+        </xsl:if>
+        <xsl:if test="not(parent::lst)">
+            <div class="doc">
+                <xsl:call-template name="list"/>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="list">
+        <xsl:if test="count(child::*)>0">
+            <table>
+                <thead>
+                    <tr>
+                        <th colspan="2">
+                            <p>
+                                <a name="{@name}"/>
+                            </p>
+                            <xsl:value-of select="@name"/>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <xsl:choose>
+                        <xsl:when
+                            test="@name='histogram'">
+                            <tr>
+                                <td colspan="2">
+                                    <xsl:call-template name="histogram"/>
+                                </td>
+                            </tr>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:apply-templates/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </tbody>
+            </table>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="histogram">
+        <div class="doc">
+            <xsl:call-template name="barchart">
+                <xsl:with-param name="max_bar_width">50</xsl:with-param>
+                <xsl:with-param name="iwidth">800</xsl:with-param>
+                <xsl:with-param name="iheight">160</xsl:with-param>
+                <xsl:with-param name="fill">blue</xsl:with-param>
+            </xsl:call-template>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="barchart">
+        <xsl:param name="max_bar_width"/>
+        <xsl:param name="iwidth"/>
+        <xsl:param name="iheight"/>
+        <xsl:param name="fill"/>
+        <xsl:variable name="max">
+            <xsl:for-each select="int">
+                <xsl:sort data-type="number" order="descending"/>
+                <xsl:if test="position()=1">
+                    <xsl:value-of select="."/>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="bars">
+           <xsl:value-of select="count(int)"/>
+        </xsl:variable>
+        <xsl:variable name="bar_width">
+           <xsl:choose>
+             <xsl:when test="$max_bar_width &lt; ($iwidth div $bars)">
+               <xsl:value-of select="$max_bar_width"/>
+             </xsl:when>
+             <xsl:otherwise>
+               <xsl:value-of select="$iwidth div $bars"/>
+             </xsl:otherwise>
+           </xsl:choose>
+        </xsl:variable>
+        <table class="histogram">
+           <tbody>
+              <tr>
+                <xsl:for-each select="int">
+                   <td>
+                 <xsl:value-of select="."/>
+                 <div class="histogram">
+                  <xsl:attribute name="style">background-color: <xsl:value-of select="$fill"/>; width: <xsl:value-of select="$bar_width"/>px; height: <xsl:value-of select="($iheight*number(.)) div $max"/>px;</xsl:attribute>
+                 </div>
+                   </td> 
+                </xsl:for-each>
+              </tr>
+              <tr>
+                <xsl:for-each select="int">
+                   <td>
+                       <xsl:value-of select="@name"/>
+                   </td>
+                </xsl:for-each>
+              </tr>
+           </tbody>
+        </table>
+    </xsl:template>
+
+    <xsl:template name="keyvalue">
+        <xsl:choose>
+            <xsl:when test="@name">
+                <tr>
+                    <td class="name">
+                        <xsl:value-of select="@name"/>
+                    </td>
+                    <td class="value">
+                        <xsl:value-of select="."/>
+                    </td>
+                </tr>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="int|bool|long|float|double|uuid|date">
+        <xsl:call-template name="keyvalue"/>
+    </xsl:template>
+
+    <xsl:template match="arr">
+        <tr>
+            <td class="name">
+                <xsl:value-of select="@name"/>
+            </td>
+            <td class="value">
+                <ul>
+                    <xsl:for-each select="child::*">
+                        <li>
+                            <xsl:apply-templates/>
+                        </li>
+                    </xsl:for-each>
+                </ul>
+            </td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="str">
+        <xsl:choose>
+            <xsl:when test="@name='schema' or @name='index' or @name='flags'">
+                <xsl:call-template name="schema"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="keyvalue"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="schema">
+        <tr>
+            <td class="name">
+                <xsl:value-of select="@name"/>
+            </td>
+            <td class="value">
+                <xsl:if test="contains(.,'unstored')">
+                    <xsl:value-of select="."/>
+                </xsl:if>
+                <xsl:if test="not(contains(.,'unstored'))">
+                    <xsl:call-template name="infochar2string">
+                        <xsl:with-param name="charList">
+                            <xsl:value-of select="."/>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                </xsl:if>
+            </td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template name="infochar2string">
+        <xsl:param name="i">1</xsl:param>
+        <xsl:param name="charList"/>
+
+        <xsl:variable name="char">
+            <xsl:value-of select="substring($charList,$i,1)"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$char='I'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='I']"/> - </xsl:when>
+            <xsl:when test="$char='T'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='T']"/> - </xsl:when>
+            <xsl:when test="$char='S'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='S']"/> - </xsl:when>
+            <xsl:when test="$char='M'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='M']"/> - </xsl:when>
+            <xsl:when test="$char='V'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='V']"/> - </xsl:when>
+            <xsl:when test="$char='o'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='o']"/> - </xsl:when>
+            <xsl:when test="$char='p'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='p']"/> - </xsl:when>
+            <xsl:when test="$char='O'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='O']"/> - </xsl:when>
+            <xsl:when test="$char='L'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='L']"/> - </xsl:when>
+            <xsl:when test="$char='B'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='B']"/> - </xsl:when>
+            <xsl:when test="$char='C'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='C']"/> - </xsl:when>
+            <xsl:when test="$char='f'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='f']"/> - </xsl:when>
+            <xsl:when test="$char='l'">
+                <xsl:value-of select="/response/lst[@name='info']/lst/str[@name='l']"/> -
+            </xsl:when>
+        </xsl:choose>
+
+        <xsl:if test="not($i>=string-length($charList))">
+            <xsl:call-template name="infochar2string">
+                <xsl:with-param name="i">
+                    <xsl:value-of select="$i+1"/>
+                </xsl:with-param>
+                <xsl:with-param name="charList">
+                    <xsl:value-of select="$charList"/>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template name="css">
+        <style type="text/css">
+            <![CDATA[
+            td.name {font-style: italic; font-size:80%; }
+            .doc { margin: 0.5em; border: solid grey 1px; }
+            .exp { display: none; font-family: monospace; white-space: pre; }
+            div.histogram { background: none repeat scroll 0%; -moz-background-clip: -moz-initial; -moz-background-origin: -moz-initial; -moz-background-inline-policy: -moz-initial;}
+            table.histogram { width: auto; vertical-align: bottom; }
+            table.histogram td, table.histogram th { text-align: center; vertical-align: bottom; border-bottom: 1px solid #ff9933; width: auto; }
+            ]]>
+        </style>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Upgrade to solr 8 by using newest solr schema from Samvera community.  This was put in `solr/conf` along with a copy of the existing `solr/config` directory which is for solr 6.  This will require a reindex for existing installs so this probably will need to be a major release of Avalon.

- Upgrade CircleCI to use solr 8
- Upgrade docker-compose to use solr 8
- Configure solr_wrapper to use solr 8
- Add copy of docker-compose.yml modified slightly to work with podman-compose.yml (dev/test only)