### PR TITLE
Render component only when at least one section has transcript file(s)

### DIFF
--- a/app/javascript/components/ReactIIIFTranscript.jsx
+++ b/app/javascript/components/ReactIIIFTranscript.jsx
@@ -5,6 +5,8 @@ import "@samvera/iiif-react-media-player/dist/iiif-react-media-player.css";
 
 const ReactIIIFTranscript = ({ base_url, transcripts }) => {
   const [transcriptsProp, setTrancsriptProp] = React.useState([]);
+  // Check for at least one masterfile in the mediaobject has a transcript file
+  const [hasTranscript, setHasTranscript] = React.useState(false);
 
   React.useEffect(() => {
     buildTranscriptUrls();
@@ -14,33 +16,38 @@ const ReactIIIFTranscript = ({ base_url, transcripts }) => {
     let trProps = [];
     transcripts.forEach((tr, i) => {
       let transcriptItems = tr.transcripts;
+      let canvasTrs = { canvasId: i, items: [] }
+
       // construct URLs as expected within the transcript component
-      let canvasTrs = {
-        canvasId: i,
-        items: transcriptItems.length > 0
-                ? transcriptItems.map(
-                    t => (
-                      { title: t.label,
-                        url: `${base_url}/master_files/${tr.id}/transcript/${t.id}`
-                      }
-                    )
-                  )
-                : []
+      if(transcriptItems.length > 0) {
+        setHasTranscript(true)
+        canvasTrs.items = transcriptItems.map(
+          t => (
+            { title: t.label,
+              url: `${base_url}/master_files/${tr.id}/transcript/${t.id}`
+            }
+          )
+        )
       }
       trProps.push(canvasTrs)
     });    
     setTrancsriptProp(trProps)
   }
   
-  return (
-    <div className="IIIFMediaPlayer">
-      <Transcript
-        playerID="mejs-avalon-player"
-        transcripts={transcriptsProp}
-      />
-    </div>
-  );
-
+  // Render the transcript component if at least one masterfile (canvas in manifest)
+  // has a transcript file
+  if(hasTranscript) {
+    return (
+      <div className="IIIFMediaPlayer">
+        <Transcript
+          playerID="mejs-avalon-player"
+          transcripts={transcriptsProp}
+        />
+      </div>
+    );
+  } else {
+    return null;
+  }
 }
 
 export default ReactIIIFTranscript;


### PR DESCRIPTION
With this fix, for the transcript component to be rendered on the page at least one section (masterfile, i.e. canvas in the IIIF manifest) has to have a transcript file.