### PR TITLE
Clean up initializers and wrap reloadable constants in #to_prepare blocks

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,13 +1,15 @@
-ActionMailer::MailDeliveryJob.rescue_from(StandardError) do |exception|
-  Rails.logger.error "Error delivering mail: #{exception}"
-end
+ActiveSupport.on_load(:action_mailer) do
+  ActionMailer::MailDeliveryJob.rescue_from(StandardError) do |exception|
+    Rails.logger.error "Error delivering mail: #{exception}"
+  end
 
-case Settings&.email&.mailer&.to_sym
-when :aws_sdk
-  require 'aws-sdk-rails'
-  Aws::Rails.add_action_mailer_delivery_method(:aws_sdk)
-  ActionMailer::Base.delivery_method = :aws_sdk
-when :smtp
-  ActionMailer::Base.delivery_method = :smtp
-  ActionMailer::Base.smtp_settings = Settings.email.config.to_h
+  case Settings&.email&.mailer&.to_sym
+  when :aws_sdk
+    require 'aws-sdk-rails'
+    Aws::Rails.add_action_mailer_delivery_method(:aws_sdk)
+    ActionMailer::Base.delivery_method = :aws_sdk
+  when :smtp
+    ActionMailer::Base.delivery_method = :smtp
+    ActionMailer::Base.smtp_settings = Settings.email.config.to_h
+  end
 end

--- a/config/initializers/active_encode.rb
+++ b/config/initializers/active_encode.rb
@@ -1,22 +1,24 @@
-ActiveEncode::Base.engine_adapter = Settings.encoding.engine_adapter.to_sym
-case Settings.encoding.engine_adapter.to_sym
-when :ffmpeg
-  MasterFile.default_encoder_class = FfmpegEncode
-when :matterhorn
-  Rubyhorn.init
-when :elastic_transcoder
-  require 'aws-sdk-elastictranscoder'
-  require 'avalon/elastic_transcoder_encode'
+Rails.application.config.to_prepare do
+  ActiveEncode::Base.engine_adapter = Settings.encoding.engine_adapter.to_sym
+  case Settings.encoding.engine_adapter.to_sym
+  when :ffmpeg
+    MasterFile.default_encoder_class = FfmpegEncode
+  when :matterhorn
+    Rubyhorn.init
+  when :elastic_transcoder
+    require 'aws-sdk-elastictranscoder'
+    require 'avalon/elastic_transcoder_encode'
 
-  MasterFile.default_encoder_class = ElasticTranscoderEncode
-  pipeline = Aws::ElasticTranscoder::Client.new.read_pipeline(id: Settings.encoding.pipeline)
-  # Set environment variables to guard against reloads
-  ENV['SETTINGS__ENCODING__MASTERFILE_BUCKET'] = Settings.encoding.masterfile_bucket = pipeline.pipeline.input_bucket
-  ENV['SETTINGS__ENCODING__DERIVATIVE_BUCKET'] = Settings.encoding.derivative_bucket = pipeline.pipeline.output_bucket
-  if Settings.dropbox.path.nil?
-    ENV['SETTINGS__DROPBOX__PATH'] = Settings.dropbox.path = "s3://#{Settings.encoding.masterfile_bucket}/dropbox/"
-  end
-  if Settings.dropbox.upload_uri.nil?
-    ENV['SETTINGS__DROPBOX__UPLOAD_URI'] = Settings.dropbox.upload_uri = "s3://#{Settings.encoding.masterfile_bucket}/dropbox/"
+    MasterFile.default_encoder_class = ElasticTranscoderEncode
+    pipeline = Aws::ElasticTranscoder::Client.new.read_pipeline(id: Settings.encoding.pipeline)
+    # Set environment variables to guard against reloads
+    ENV['SETTINGS__ENCODING__MASTERFILE_BUCKET'] = Settings.encoding.masterfile_bucket = pipeline.pipeline.input_bucket
+    ENV['SETTINGS__ENCODING__DERIVATIVE_BUCKET'] = Settings.encoding.derivative_bucket = pipeline.pipeline.output_bucket
+    if Settings.dropbox.path.nil?
+      ENV['SETTINGS__DROPBOX__PATH'] = Settings.dropbox.path = "s3://#{Settings.encoding.masterfile_bucket}/dropbox/"
+    end
+    if Settings.dropbox.upload_uri.nil?
+      ENV['SETTINGS__DROPBOX__UPLOAD_URI'] = Settings.dropbox.upload_uri = "s3://#{Settings.encoding.masterfile_bucket}/dropbox/"
+    end
   end
 end

--- a/config/initializers/avalon.rb
+++ b/config/initializers/avalon.rb
@@ -7,6 +7,5 @@ require 'avalon/errors'
 # out what is available. See lib/avalon/dropbox.rb for details on the API
 require 'avalon/dropbox'
 require 'avalon/batch'
-require 'string_additions'
 
 I18n.config.enforce_available_locales = true

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -1,23 +1,25 @@
-server_options = Settings.domain
-server_options = case server_options
-when String
-  uri = URI.parse(server_options)
-  { host: uri.host, port: uri.port, protocol: uri.scheme }
-when Hash
-  server_options
-else
-  server_options.to_hash
-end
+Rails.application.config.to_prepare do
+  server_options = Settings.domain
+  server_options = case server_options
+  when String
+    uri = URI.parse(server_options)
+    { host: uri.host, port: uri.port, protocol: uri.scheme }
+  when Hash
+    server_options
+  else
+    server_options.to_hash
+  end
 
-if server_options
-  server_options.symbolize_keys!
-  server_options.slice!(:host, :port, :protocol)
+  if server_options
+    server_options.symbolize_keys!
+    server_options.slice!(:host, :port, :protocol)
 
-  Rails.application.routes.default_url_options.merge!( server_options )
-  ActionMailer::Base.default_url_options.merge!( server_options )
-  ApplicationController.default_url_options = server_options
+    Rails.application.routes.default_url_options.merge!( server_options )
+    ActionMailer::Base.default_url_options.merge!( server_options )
+    ApplicationController.default_url_options = server_options
 
-  # Required for rails 6+
-  # See https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks.html
-  Rails.application.config.hosts << server_options[:host]
+    # Required for rails 6+
+    # See https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks.html
+    Rails.application.config.hosts << server_options[:host]
+  end
 end

--- a/config/initializers/hydra_config.rb
+++ b/config/initializers/hydra_config.rb
@@ -7,32 +7,34 @@ require 'hydra/multiple_policy_aware_ability'
 # TODO: remove the next line after fix is made for this method in hydra-access-controls
 Hydra::AdminPolicyBehavior.send :remove_method, :default_permissions=
 
-Hydra.configure do |config|
-  silence_warnings do
-    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC = 'public'.freeze
-    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED = 'restricted'.freeze
-    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE = 'private'.freeze
-  end
+Rails.application.config.to_prepare do
+  Hydra.configure do |config|
+    silence_warnings do
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC = 'public'.freeze
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED = 'restricted'.freeze
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE = 'private'.freeze
+    end
 
-  # This specifies the solr field names of permissions-related fields.
-  # You only need to change these values if you've indexed permissions by some means other than the Hydra's built-in tooling.
-  # If you change these, you must also update the permissions request handler in your solrconfig.xml to return those values
-  #
-  # config.permissions.discover.group       = ActiveFedora::SolrQueryBuilder.solr_name("discover_access_group", :symbol)
-  # config.permissions.discover.individual  = ActiveFedora::SolrQueryBuilder.solr_name("discover_access_person", :symbol)
-  # config.permissions.read.group           = ActiveFedora::SolrQueryBuilder.solr_name("read_access_group", :symbol)
-  # config.permissions.read.individual      = ActiveFedora::SolrQueryBuilder.solr_name("read_access_person", :symbol)
-  # config.permissions.edit.group           = ActiveFedora::SolrQueryBuilder.solr_name("edit_access_group", :symbol)
-  # config.permissions.edit.individual      = ActiveFedora::SolrQueryBuilder.solr_name("edit_access_person", :symbol)
-  #
-  # config.permissions.embargo.release_date  = ActiveFedora::SolrQueryBuilder.solr_name("embargo_release_date", :stored_sortable, type: :date)
-  # config.permissions.lease.expiration_date = ActiveFedora::SolrQueryBuilder.solr_name("lease_expiration_date", :stored_sortable, type: :date)
-  #
-  #
-  # Specify the user model
-  # config.user_model = 'User'
-  config.permissions.policy_class = {Admin::Collection => {}, Lease => {clause: " AND begin_time_dtsi:[* TO NOW] AND end_time_dtsi:[NOW TO *]"}}
-  # config.permissions.policy_class = { Admin::Collection => {} }
+    # This specifies the solr field names of permissions-related fields.
+    # You only need to change these values if you've indexed permissions by some means other than the Hydra's built-in tooling.
+    # If you change these, you must also update the permissions request handler in your solrconfig.xml to return those values
+    #
+    # config.permissions.discover.group       = ActiveFedora::SolrQueryBuilder.solr_name("discover_access_group", :symbol)
+    # config.permissions.discover.individual  = ActiveFedora::SolrQueryBuilder.solr_name("discover_access_person", :symbol)
+    # config.permissions.read.group           = ActiveFedora::SolrQueryBuilder.solr_name("read_access_group", :symbol)
+    # config.permissions.read.individual      = ActiveFedora::SolrQueryBuilder.solr_name("read_access_person", :symbol)
+    # config.permissions.edit.group           = ActiveFedora::SolrQueryBuilder.solr_name("edit_access_group", :symbol)
+    # config.permissions.edit.individual      = ActiveFedora::SolrQueryBuilder.solr_name("edit_access_person", :symbol)
+    #
+    # config.permissions.embargo.release_date  = ActiveFedora::SolrQueryBuilder.solr_name("embargo_release_date", :stored_sortable, type: :date)
+    # config.permissions.lease.expiration_date = ActiveFedora::SolrQueryBuilder.solr_name("lease_expiration_date", :stored_sortable, type: :date)
+    #
+    #
+    # Specify the user model
+    # config.user_model = 'User'
+    config.permissions.policy_class = {Admin::Collection => {}, Lease => {clause: " AND begin_time_dtsi:[* TO NOW] AND end_time_dtsi:[NOW TO *]"}}
+    # config.permissions.policy_class = { Admin::Collection => {} }
+  end
 end
 
 module Hydra::RoleMapperBehavior::ClassMethods

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -1,21 +1,23 @@
-SpeedyAF::Base.tap do |sp|
-  sp.config MasterFile do
-    self.defaults = { permalink: nil }
-    include MasterFileBehavior
-    include Rails.application.routes.url_helpers
-  end
-
-  sp.config Derivative do
-    include DerivativeBehavior
-  end
-
-  sp.config StructuralMetadata do
-    def ng_xml
-      @ng_xml ||= Nokogiri::XML(content)
+Rails.application.config.to_prepare do
+  SpeedyAF::Base.tap do |sp|
+    sp.config MasterFile do
+      self.defaults = { permalink: nil }
+      include MasterFileBehavior
+      include Rails.application.routes.url_helpers
     end
 
-    def xpath(*args)
-      ng_xml.xpath(*args)
+    sp.config Derivative do
+      include DerivativeBehavior
+    end
+
+    sp.config StructuralMetadata do
+      def ng_xml
+	@ng_xml ||= Nokogiri::XML(content)
+      end
+
+      def xpath(*args)
+	ng_xml.xpath(*args)
+      end
     end
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,13 +13,15 @@ require 'sidekiq/web'
 Sidekiq::Web.disable(:sessions)
 
 require 'sidekiq/cron/web'
-begin
-  # Only create cron jobs if Sidekiq can connect to Redis
-  Sidekiq.redis(&:info)
-  Sidekiq::Cron::Job.create(name: 'Scan for batches - every 1min', cron: '*/1 * * * *', class: 'BatchScanJob')
-  Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification of Existing Batches - every 15min', cron: '*/15 * * * *', class: 'IngestBatchStatusEmailJobs::IngestFinished')
-  Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification for Stalled Batches - every 1day', cron: '0 1 * * *', class: 'IngestBatchStatusEmailJobs::StalledJob')
-  Sidekiq::Cron::Job.create(name: 'Clean out user sessions older than 7 days - every 6hour', cron: '0 */6 * * *', class: 'CleanupSessionJob')
-rescue Redis::CannotConnectError => e
-  Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"
+Rails.application.config.to_prepare do
+  begin
+    # Only create cron jobs if Sidekiq can connect to Redis
+    Sidekiq.redis(&:info)
+    Sidekiq::Cron::Job.create(name: 'Scan for batches - every 1min', cron: '*/1 * * * *', class: 'BatchScanJob')
+    Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification of Existing Batches - every 15min', cron: '*/15 * * * *', class: 'IngestBatchStatusEmailJobs::IngestFinished')
+    Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification for Stalled Batches - every 1day', cron: '0 1 * * *', class: 'IngestBatchStatusEmailJobs::StalledJob')
+    Sidekiq::Cron::Job.create(name: 'Clean out user sessions older than 7 days - every 6hour', cron: '0 */6 * * *', class: 'CleanupSessionJob')
+  rescue Redis::CannotConnectError => e
+    Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"
+  end
 end

--- a/config/initializers/workflow_steps.rb
+++ b/config/initializers/workflow_steps.rb
@@ -1,4 +1,6 @@
-HYDRANT_STEPS = Avalon::Workflow::Workflow.new(FileUploadStep.new, 
-						ResourceDescriptionStep.new, 
-						StructureStep.new, 
-						AccessControlStep.new)
+Rails.application.config.to_prepare do
+  HYDRANT_STEPS = Avalon::Workflow::Workflow.new(FileUploadStep.new,
+                                                 ResourceDescriptionStep.new,
+                                                 StructureStep.new,
+                                                 AccessControlStep.new)
+end


### PR DESCRIPTION
This handles the deprecation warnings which were coming up on avalon-dev.  See https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots

The basic idea is that any classes or modules which are in the set of reloadable constants (mostly anything in `app/`) needs to be wrapped in a `#to_prepare` block so that if the constant gets reloaded then this block will rerun to pick up the new class/module.

Since a lot of code got touched by indentation it is probably easiest to review this PR with the hide whitespace option in github enabled.