### PR TITLE
Add identifier_in_use for noid-rails

### DIFF
--- a/config/initializers/noid-rails.rb
+++ b/config/initializers/noid-rails.rb
@@ -2,4 +2,8 @@ require 'noid-rails'
 
 Noid::Rails.configure do |config|
   config.minter_class = Noid::Rails::Minter::Db
+
+  config.identifier_in_use = lambda do |id|
+    ActiveFedora::Base.exists?(id) || ActiveFedora::Base.gone?(id)
+  end
 end


### PR DESCRIPTION
Added `identifier_in_use` for noid-rails to insure new identifiers don't exist or are gone in Fedora.

Fixes #4672 