### PR TITLE
Adjust styling for search results

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -45,3 +45,7 @@
     background-color: $white;
   }
 }
+
+.dl-invert dt {
+  text-align: left;
+}

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -66,4 +66,15 @@ module Blacklight::LocalBlacklightHelper
     result
   end
 
+  # Override of blacklight helper to add row class
+  def render_document_class(document)
+    types = controller.helpers.document_presenter(document).display_type
+    return if types.blank?
+
+    classes = Array(types).compact.map do |t|
+      "#{controller.helpers.document_class_prefix}#{t.try(:parameterize) || t}"
+    end
+    classes << "row"
+    classes.join(' ')
+  end
 end

--- a/app/views/catalog/_index_header_media_object.html.erb
+++ b/app/views/catalog/_index_header_media_object.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <%# header bar for doc items in index view -%>
-<div class="documentHeader row">
+<div class="documentHeader row col-sm-12">
   <%# main title container for doc partial view
       How many bootstrap columns need to be reserved
       for bookmarks control depends on size.

--- a/app/views/catalog/_index_media_object.html.erb
+++ b/app/views/catalog/_index_media_object.html.erb
@@ -19,8 +19,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 <dl class="document-metadata row dl-invert col-md-9">
   <% doc_presenter.field_presenters.each do |field_presenter| %>
     <% if field_presenter.render_field? %>
-      <dt class="blacklight-<%= field_presenter.key %> col-sm-2"><%= field_presenter.label %>:</dt>
-      <dd class="blacklight-<%= field_presenter.key %> col-sm-10"><%= field_presenter.values.join(', ') %></dd>
+      <dt class="blacklight-<%= field_presenter.key %> col-sm-3"><%= field_presenter.label %>:</dt>
+      <dd class="blacklight-<%= field_presenter.key %> col-sm-9"><%= field_presenter.values.join(', ') %></dd>
     <% end %>
   <% end %>
 </dl>


### PR DESCRIPTION
This involved changing some css column size classes and adding the `row` class to the document result which required a blacklight helper override.  To avoid too many overrides we decided to change the styling slightly.  @joncameron what do you think about the change to the metadata styling?

Before:
![image](https://user-images.githubusercontent.com/1053603/165160153-cfaa131c-e9e0-4628-bd08-48f403162ec6.png)

After:
![image](https://user-images.githubusercontent.com/1053603/165159440-906ca0a5-7fe0-4497-8863-3f4214ce936e.png)
