### PR TITLE
Add format property to Resources - IIIF Manifest Generation

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -51,6 +51,7 @@ class IiifCanvasPresenter
                                            height: master_file.height.to_i,
                                            duration: stream_info[:duration],
                                            type: 'Video',
+                                           format: 'application/x-mpegURL',
                                            auth_service: auth_service(quality))
     end
 
@@ -63,6 +64,7 @@ class IiifCanvasPresenter
                                            label: quality,
                                            duration: stream_info[:duration],
                                            type: 'Sound',
+                                           format: 'application/x-mpegURL',
                                            auth_service: auth_service(quality))
     end
 

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -37,6 +37,15 @@ FactoryBot.define do
       end
     end
 
+    trait :audio do
+      file_format { 'Sound' }
+      workflow_name { 'fullaudio' }
+      display_aspect_ratio { nil }
+      original_frame_size { nil }
+      width { nil }
+      height { nil }
+    end
+
     trait :with_media_object do
       association :media_object #, factory: :media_object
     end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -38,4 +38,22 @@ describe IiifCanvasPresenter do
       expect(logout_service[:@id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
     end
   end
+
+  describe '#display_content' do
+    subject { presenter.display_content.first }
+
+    context 'when audio file' do
+      let(:master_file) { FactoryBot.build(:master_file, :audio, media_object: media_object, derivatives: [derivative]) }
+
+      it 'has format' do
+        expect(subject.format).to eq "application/x-mpegURL"
+      end
+    end
+
+    context 'when video file' do
+      it 'has format' do
+        expect(subject.format).to eq "application/x-mpegURL"
+      end
+    end
+  end
 end


### PR DESCRIPTION
I looked around for a bit to see where/how the hls mimetype was brought in (i.e. as part of the master_file or stream_info, etc.). I found that it was hard coded as part of the _video_element and _audio_element partials. Since it didn't appear to be created on the fly, I have just hardcoded the format for the manifest generation as well.