### PR TITLE
Add sanitization of post-processing filenames

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -470,9 +470,9 @@ class MasterFile < ActiveFedora::Base
   def self.post_processing_move_filename(oldpath, options = {})
     prefix = options[:id].tr(':', '_')
     if File.basename(oldpath).start_with?(prefix)
-      File.basename(oldpath)
+      Avalon::Configuration.sanitize_filename.call(File.basename(oldpath))
     else
-      "#{prefix}-#{File.basename(oldpath)}"
+      Avalon::Configuration.sanitize_filename.call("#{prefix}-#{File.basename(oldpath)}")
     end
   end
 

--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -28,6 +28,16 @@ module Avalon
       @config.send(sym, *args, &block)
     end
 
+    def sanitize_filename
+      @sanitize_filename = lambda do |filename|
+        if filename.include? ' '
+          filename.gsub(/\s+/, '_')
+        else
+          filename
+        end
+      end
+    end
+
     private
     class << self
       def coerce(value, method)

--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -28,13 +28,10 @@ module Avalon
       @config.send(sym, *args, &block)
     end
 
+    attr_writer :sanitize_filename
     def sanitize_filename
-      @sanitize_filename = lambda do |filename|
-        if filename.include? ' '
-          filename.gsub(/\s+/, '_')
-        else
-          filename
-        end
+      @sanitize_filename ||= lambda do |filename|
+        filename.gsub(/\s+/, '_')
       end
     end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -559,6 +559,12 @@ describe MasterFile do
       path = '/path/to/avalon_12345-video.mp4'
       expect(MasterFile.post_processing_move_filename(path, id: id).include?(id_prefix + '-' + id_prefix)).to be_falsey
     end
+    context 'path contains spaces' do
+      path = '/path/to/video file.mp4'
+      it 'removes spaces' do
+        expect(MasterFile.post_processing_move_filename(path, id: id)).not_to include(' ')
+      end
+    end
   end
 
   context 'with a working directory' do
@@ -775,7 +781,7 @@ describe MasterFile do
 
     context 'without derivative' do
       let(:master_file) { FactoryBot.build(:master_file) }
-    
+
       it 'returns false' do
         expect(master_file.has_audio?).to eq false
       end
@@ -786,7 +792,7 @@ describe MasterFile do
 
       context 'with audio track' do
         let(:derivative) { FactoryBot.build(:derivative, audio_codec: 'aac') }
-        
+
         it 'returns true' do
           expect(master_file.has_audio?).to eq true
         end
@@ -794,7 +800,7 @@ describe MasterFile do
 
       context 'without audio track' do
         let(:derivative) { FactoryBot.build(:derivative, audio_codec: nil) }
-        
+
         it 'returns false' do
           expect(master_file.has_audio?).to eq false
         end


### PR DESCRIPTION
This PR adds a configuration method to sanitize filenames. Default behavior is to replace spaces with underscores.