### PR TITLE
Use official release of Blacklight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'rdf-rdfxml'
 gem 'rdf-vocab', '< 3.1.5'
 
 # Samvera version pins
-gem 'blacklight', '< 8', git: 'https://github.com/projectblacklight/blacklight.git', branch: 'release-7.x'
+gem 'blacklight', '~> 7.25'
 gem 'blacklight-access_controls', '>= 6.0.1' # ensure rails 6 support
 gem 'rdf', '~> 3.1'
 gem 'rsolr', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,21 +66,6 @@ GIT
       sidekiq (>= 4.2.1)
 
 GIT
-  remote: https://github.com/projectblacklight/blacklight.git
-  revision: e56e18796ddde72d6ea7ea8ecb48b3b5da11deb6
-  branch: release-7.x
-  specs:
-    blacklight (7.24.0)
-      deprecation
-      globalid
-      i18n (>= 1.7.0)
-      jbuilder (~> 2.7)
-      kaminari (>= 0.15)
-      ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7.1)
-      view_component (~> 2.43)
-
-GIT
   remote: https://github.com/samvera-labs/active_fedora-datastreams
   revision: 13eefc7bdc879fd6c3ad607a1ecc087898777d3d
   branch: rails6
@@ -267,6 +252,15 @@ GEM
       rubocop-performance
       rubocop-rails
       rubocop-rspec
+    blacklight (7.25.1)
+      deprecation
+      globalid
+      i18n (>= 1.7.0)
+      jbuilder (~> 2.7)
+      kaminari (>= 0.15)
+      ostruct (>= 0.3.2)
+      rails (>= 5.1, < 7.1)
+      view_component (~> 2.43)
     blacklight-access_controls (6.0.1)
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
@@ -627,7 +621,7 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.13.4)
+    nokogiri (1.13.5)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nom-xml (1.2.0)
@@ -658,7 +652,7 @@ GEM
       ruby-saml (~> 1.9)
     orm_adapter (0.5.0)
     os (1.1.4)
-    ostruct (0.5.3)
+    ostruct (0.5.5)
     parallel (1.21.0)
     paranoia (2.5.2)
       activerecord (>= 5.1, < 7.1)
@@ -951,7 +945,7 @@ GEM
     unicode-display_width (1.8.0)
     unicode-types (1.7.0)
     user_agent_parser (2.9.0)
-    view_component (2.50.0)
+    view_component (2.53.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -1019,7 +1013,7 @@ DEPENDENCIES
   aws-sdk-sqs
   aws-sigv4
   bixby
-  blacklight (< 8)!
+  blacklight (~> 7.25)
   blacklight-access_controls (>= 6.0.1)
   bootsnap
   bootstrap (~> 4.0)


### PR DESCRIPTION
Blacklight 7.25.1 was released with includes the fix for #4678 and makes the changes in #4688 unnecessary.