### PR TITLE
Restore rendering of search constraints breadcrumbs

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -46,3 +46,10 @@
     }
   }
 }
+
+// Search constraint remove button
+// Needed to override btn-secondary-outline
+.applied-filter .remove:hover {
+  color: white !important;
+  background-color: #f44336 !important;
+}

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -62,6 +62,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     </div>
 
     <div id="content" class="<%= main_content_classes %>">
+      <%= render 'constraints' %>
       <%= render 'search_results' %>
     </div>
   </div>


### PR DESCRIPTION
I first tried to override another partial to change the remove button's class from `btn-secondary-outline` to `btn-outline` to ensure the button turns red when hovered over.  But I decided to do the override in CSS instead of overriding another blacklight partial.

Fixes #4689 