### PR TITLE
Fix dropbox (browse everything) for bootstrap 4 and remove warning banner

### DIFF
--- a/app/assets/javascripts/file_browse.js.coffee
+++ b/app/assets/javascripts/file_browse.js.coffee
@@ -19,13 +19,6 @@ $ ->
   initialized = false
   $('#browse-btn').browseEverything()
     .show ->
-      alertMsg = $('<div>')
-        .html('Warning! Uploading too many files at once can lead to ingest failures.')
-        .addClass('alert')
-        .addClass('alert-danger')
-        .css('margin','3px')
-        .css('text-align','center')
-      $('.ev-body').prepend(alertMsg)
       unless $('#browse-everything input[name=workflow]').length > 0
         skip_box = $('#web_upload input[name=workflow]').closest('span')
           .clone().removeClass().css('margin-right','10px')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,7 +46,7 @@
 @import 'bootstrap';
 @import 'bootstrap-toggle';
 @import 'font-awesome';
-@import 'browse_everything';
+@import 'browse_everything/browse_everything_bootstrap4';
 
 @import 'cropperjs/dist/cropper.min';
 

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -367,10 +367,6 @@ span.constraints-label {
   }
 }
 
-.ev-browser {
-  background-color: $white;
-}
-
 a[data-trigger='submit'] {
   text-decoration: none;
   color: $dark;

--- a/config/initializers/browse_everything.rb
+++ b/config/initializers/browse_everything.rb
@@ -5,7 +5,7 @@ settings = if Settings.dropbox.google_drive
   }
 elsif Settings.dropbox.path =~ %r{^s3://}
   obj = FileLocator::S3File.new(Settings.dropbox.path).object
-  { 's3' => { name: 'AWS S3 Dropbox', bucket: obj.bucket_name, base: obj.key, response_type: :s3_uri } }
+  { 's3' => { name: 'AWS S3 Dropbox', bucket: obj.bucket_name, base: obj.key, response_type: :s3_uri, region: obj.client.config.region } }
 else
   { 'file_system' => { name: 'File Dropbox', home: Settings.dropbox.path } }
 end


### PR DESCRIPTION
This PR covers a few issues:
- Removes warning banner (fixes #4400)
- Uses bootstrap 4 with browse everything
- Remove css that takes over background causing modal not to look like a modal
- Adds missing config option for s3 browse-everything driver