### PR TITLE
Make Timeliner iiif manifest homepage an array

### DIFF
--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -60,7 +60,7 @@ class Timeline < ActiveRecord::Base
 
     manifest_json = JSON.parse(manifest)
     manifest_json["homepage"] ||= {}
-    manifest_json["homepage"]["id"] = "#{base_url}?t=#{media_fragment}"
+    manifest_json["homepage"][0]["id"] = "#{base_url}?t=#{media_fragment}"
     self.manifest = manifest_json.to_json
   end
 
@@ -160,7 +160,8 @@ class Timeline < ActiveRecord::Base
             description
           ]
         },
-        "homepage": {
+        "homepage":[
+          {
           "id": source,
           "type": "Text",
           "label": {
@@ -169,7 +170,8 @@ class Timeline < ActiveRecord::Base
             ]
           },
           "format": "text/html"
-        },
+          }
+        ],
         "items": [
           {
             "id": "#{manifest_url}/canvas",

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -161,17 +161,17 @@ class Timeline < ActiveRecord::Base
           ]
         },
         "homepage": [
-        {
-          "id": source,
-          "type": "Text",
-          "label": {
-            "en": [
-                    "View Source Item"
-            ]
-          },
-          "format": "text/html"
-        }
-      ],
+          {
+            "id": source,
+            "type": "Text",
+            "label": {
+              "en": [
+                "View Source Item"
+              ]
+            },
+            "format": "text/html"
+          }
+        ],
         "items": [
           {
             "id": "#{manifest_url}/canvas",

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -160,8 +160,8 @@ class Timeline < ActiveRecord::Base
             description
           ]
         },
-        "homepage":[
-          {
+        "homepage": [
+        {
           "id": source,
           "type": "Text",
           "label": {
@@ -170,7 +170,7 @@ class Timeline < ActiveRecord::Base
             ]
           },
           "format": "text/html"
-          }
+        }
         ],
         "items": [
           {

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -171,7 +171,7 @@ class Timeline < ActiveRecord::Base
           },
           "format": "text/html"
         }
-        ],
+      ],
         "items": [
           {
             "id": "#{manifest_url}/canvas",

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -60,6 +60,7 @@ class Timeline < ActiveRecord::Base
 
     manifest_json = JSON.parse(manifest)
     manifest_json["homepage"] ||= []
+    manifest_json["homepage"][0] ||= {}
     manifest_json["homepage"][0]["id"] = "#{base_url}?t=#{media_fragment}"
     self.manifest = manifest_json.to_json
   end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -59,7 +59,7 @@ class Timeline < ActiveRecord::Base
     base_url ||= Rails.application.routes.url_helpers.master_file_url(master_file)
 
     manifest_json = JSON.parse(manifest)
-    manifest_json["homepage"] ||= {}
+    manifest_json["homepage"] ||= []
     manifest_json["homepage"][0]["id"] = "#{base_url}?t=#{media_fragment}"
     self.manifest = manifest_json.to_json
   end
@@ -166,7 +166,7 @@ class Timeline < ActiveRecord::Base
           "type": "Text",
           "label": {
             "en": [
-              "View Source Item"
+                    "View Source Item"
             ]
           },
           "format": "text/html"

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -351,14 +351,16 @@ RSpec.describe TimelinesController, type: :controller do
             "summary": {
               "en": [description]
             },
-            "homepage": {
-              "id": source,
-              "type": "Text",
-              "label": {
-                "en": ["View Source Item"]
-              },
-              "format": "text/html"
-            },
+            "homepage": [
+              {
+                "id": source,
+                "type": "Text",
+                "label": {
+                  "en": ["View Source Item"]
+                },
+                "format": "text/html"
+              }
+            ],
             "items": [
               {
                 "id": "http://test.host/timelines/1/manifest/canvas",

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Timeline, type: :model do
         expect(timeline.source_changed?).to eq true
         timeline.save
         manifest_json = JSON.parse(timeline.manifest)
-        expect(manifest_json["homepage"]["id"]).to eq new_homepage
+        expect(manifest_json["homepage"][0]["id"]).to eq new_homepage
       end
     end
 
@@ -310,7 +310,7 @@ RSpec.describe Timeline, type: :model do
         expect(timeline.source_changed?).to eq true
         timeline.standardize_homepage
         manifest_json = JSON.parse(timeline.manifest)
-        expect(manifest_json["homepage"]["id"]).to eq new_homepage
+        expect(manifest_json["homepage"][0]["id"]).to eq new_homepage
       end
     end
   end


### PR DESCRIPTION
IIIF presentation V3 requires that 'homepage' be an array. This PR adds the array structure to manifests generated by Timeliner and updates the tests to work with the new structure.