### PR TITLE
Add description search to timeline index

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -46,9 +46,9 @@ class TimelinesController < ApplicationController
     records_total = @timelines.count
     columns = ['title', 'description', 'visibility', 'updated_at', 'tags', 'actions']
 
-    # Filter title
-    title_filter = params['search']['value']
-    @timelines = @timelines.title_like(title_filter) if title_filter.present?
+    # Filter title and description
+    filter = params['search']['value']
+    @timelines = @timelines.title_like(filter).or(@timelines.desc_like(filter)) if filter.present?
 
     # Apply tag filter if requested
     tag_filter = params['columns']['4']['search']['value']

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -16,6 +16,7 @@ class Timeline < ActiveRecord::Base
   belongs_to :user
   scope :by_user, ->(user) { where(user_id: user.id) }
   scope :title_like, ->(title_filter) { where("title LIKE ?", "%#{title_filter}%") }
+  scope :desc_like, ->(desc_filter) { where("description LIKE ?", "%#{desc_filter}%") }
   scope :with_tag, ->(tag_filter) { where("tags LIKE ?", "%\n- #{tag_filter}\n%") }
 
   validates :user, presence: true

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe Timeline, type: :model do
         expect(Timeline.title_like(title_filter)).not_to include(timeline3)
       end
     end
+    describe 'desc_like' do
+      let(:timeline1) { FactoryBot.create(:timeline, description: 'Moose tunes') }
+      let(:timeline2) { FactoryBot.create(:timeline, description: 'My favorite by smoose') }
+      let(:timeline3) { FactoryBot.create(:timeline, description: 'Favorites') }
+      let(:desc_filter) { 'moose' }
+      it 'returns timelines with matching descriptions' do
+        # Commented out since case insensitivity is default for mysql but not postgres
+        # expect(Timeline.desc_like(desc_filter)).to include(timeline1)
+        expect(Timeline.desc_like(desc_filter)).to include(timeline2)
+      end
+      it 'does not return timelines without matching descriptions' do
+        expect(Timeline.desc_like(desc_filter)).not_to include(timeline3)
+      end
+    end
     describe 'with_tag' do
       let(:timeline1) { FactoryBot.create(:timeline, tags: ['Moose']) }
       let(:timeline2) { FactoryBot.create(:timeline, tags: ['Goose', 'moose']) }


### PR DESCRIPTION
This PR adds tests for the timeline paged_index endpoint and changes the indexing so that text matches in timeline descriptions are included in search results.