### PR TITLE
Bump miminist to v1.2.6 to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "serialize-javascript": "^3.1.0",
     "set-value": "^4.0.1",
     "tar": "^4.4.19",
-    "minimist": "^1.2.3",
     "acorn": "^6.4.1",
     "kind-of": "^6.0.3",
     "dot-prop": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,9 +5018,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This upgrade was not possible via upgrading the parent dependencies (similar to #4733) since there are multiple libraries referring to `minimist` library.

So it was upgraded by removing the relevant section in the yarn.lock file manually and then running `yarn` in the console.