### PR TITLE
Use real releases instead of github branches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'webpacker'
 
 # Core Samvera
 gem 'active-fedora', '~> 13.2', '>= 13.2.5'
-gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams', branch: 'rails6'
+gem 'active_fedora-datastreams', '~> 0.4'
 gem 'hydra-head', '~> 12.0'
 gem 'ldp', '~> 1.0.3'
 gem 'noid-rails', '~> 3.0.1'
@@ -41,7 +41,7 @@ gem 'rsolr', '~> 1.0'
 
 # Rails & Samvera Plugins
 gem 'about_page', git: 'https://github.com/avalonmediasystem/about_page.git', tag: 'avalon-r6.5'
-gem 'active_annotations', git: 'https://github.com/avalonmediasystem/active_annotations.git', branch: 'the_future'
+gem 'active_annotations', '~> 0.4'
 gem 'activerecord-session_store', '>= 2.0.0'
 gem 'acts_as_list'
 gem 'api-pagination'
@@ -54,7 +54,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', '~> 0.3'
-gem 'speedy-af', git: 'https://github.com/samvera-labs/speedy_af.git', branch: 'rails6'
+gem 'speedy-af', '~> 0.2'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,6 @@ GIT
       rails (>= 3.2)
 
 GIT
-  remote: https://github.com/avalonmediasystem/active_annotations.git
-  revision: 0b8f5a8b4c319e6bc2c4764d9d0a3a7f351f1501
-  branch: the_future
-  specs:
-    active_annotations (0.3.0)
-      json-ld
-      rails (>= 5.2, < 7.1)
-      rdf-vocab (>= 2.1.0)
-
-GIT
   remote: https://github.com/avalonmediasystem/avalon-about.git
   revision: 8ae33197219cb6cb8b6fee1f616950c29f2b94ce
   tag: avalon-r6.4
@@ -64,28 +54,6 @@ GIT
     sidekiq-cron (1.2.1)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
-
-GIT
-  remote: https://github.com/samvera-labs/active_fedora-datastreams
-  revision: 13eefc7bdc879fd6c3ad607a1ecc087898777d3d
-  branch: rails6
-  specs:
-    active_fedora-datastreams (0.3.0)
-      active-fedora (>= 11.0.0.pre, < 14)
-      activemodel (< 6.1)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf (< 3.2)
-      rdf-rdfxml (~> 2.0)
-
-GIT
-  remote: https://github.com/samvera-labs/speedy_af.git
-  revision: acffb24d405316fb2da5b67f16d3c8dae71fb57e
-  branch: rails6
-  specs:
-    speedy-af (0.2.0)
-      active-fedora (>= 11.0.0)
-      activesupport (> 5.2, < 6.1)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -149,9 +117,20 @@ GEM
       activesupport (>= 3.0.0)
       rdf (>= 2.0.2, < 4.0)
       rdf-vocab (>= 2.0, < 4.0)
+    active_annotations (0.4.0)
+      json-ld
+      rails (>= 5.2, < 7.1)
+      rdf-vocab (>= 2.1.0)
     active_encode (0.8.2)
       rails
       sprockets (< 4)
+    active_fedora-datastreams (0.4.0)
+      active-fedora (>= 11.0.0.pre, < 14)
+      activemodel (< 6.1)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (< 3.2)
+      rdf-rdfxml (~> 2.0)
     activejob (6.0.5)
       activesupport (= 6.0.5)
       globalid (>= 0.3.6)
@@ -901,6 +880,9 @@ GEM
       nokogiri
       stomp
       xml-simple
+    speedy-af (0.2.0)
+      active-fedora (>= 11.0.0)
+      activesupport (> 5.2, < 6.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -992,10 +974,10 @@ PLATFORMS
 DEPENDENCIES
   about_page!
   active-fedora (~> 13.2, >= 13.2.5)
-  active_annotations!
+  active_annotations (~> 0.4)
   active_elastic_job!
   active_encode (~> 0.8.2)
-  active_fedora-datastreams!
+  active_fedora-datastreams (~> 0.4)
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)
@@ -1101,7 +1083,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.2)!
   simplecov
   solr_wrapper (>= 0.16)
-  speedy-af!
+  speedy-af (~> 0.2)
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3


### PR DESCRIPTION
Use releases of active_annotations, active_fedora-datastreams, and speedy-af.