### PR TITLE
Prefix timeline title to avoid test failures

### DIFF
--- a/app/controllers/encode_records_controller.rb
+++ b/app/controllers/encode_records_controller.rb
@@ -59,7 +59,7 @@ class EncodeRecordsController < ApplicationController
     # Sort
     sort_column = columns[params['order']['0']['column'].to_i]
     sort_direction = params['order']['0']['dir'] == 'desc' ? 'desc' : 'asc'
-    @encode_records = @encode_records.order(sort_column + ' ' + sort_direction)
+    @encode_records = @encode_records.order("lower(CAST(#{sort_column} as char)) #{sort_direction}, #{sort_column} #{sort_direction}")
 
     # Paginate
     page_num = (params['start'].to_i / params['length'].to_i).floor + 1

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -64,7 +64,7 @@ class PlaylistsController < ApplicationController
     sort_direction = params['order']['0']['dir'] rescue 'asc'
     session[:playlist_sort] = [sort_column, sort_direction]
     if columns[sort_column] != 'size'
-      @playlists = @playlists.order({ columns[sort_column].downcase => sort_direction })
+      @playlists = @playlists.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
       @playlists = @playlists.offset(params['start']).limit(params['length'])
     else
       # sort by size (item count): decorate list with playlistitem count then sort and undecorate
@@ -275,7 +275,7 @@ class PlaylistsController < ApplicationController
   end
 
   def get_all_other_playlists
-    @playlists = Playlist.by_user(current_user).where.not( id: @playlist ).order(:title)
+    @playlists = Playlist.by_user(current_user).where.not( id: @playlist ).order("lower(title), title")
   end
 
   def load_playlist_token

--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -75,7 +75,7 @@ module Samvera
       sort_direction = params['order']['0']['dir'] == 'desc' ? 'desc' : 'asc' rescue 'asc'
       session[:presenter_sort] = [sort_column, sort_direction]
       if columns[sort_column] != 'entry'
-        @presenter = @presenter.order(columns[sort_column].downcase => sort_direction)
+        @presenter = @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
         @presenter = @presenter.offset(params['start']).limit(params['length'])
       else
         user_roles = @presenter.collect { |p| [ p.groups, p ] }
@@ -196,7 +196,10 @@ module Samvera
     end
 
     def last_sign_in(user)
-      user.last_sign_in_at? ? user.last_sign_in_at : user.invitation_sent_at
+      result = user.last_sign_in_at if user.last_sign_in_at?
+      result ||= user.invitation_sent_at
+      result ||= user.created_at
+      result
     end
 
     def format_roles(roles)

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -54,11 +54,11 @@ class TimelinesController < ApplicationController
     tag_filter = params['columns']['4']['search']['value']
     @timelines = @timelines.with_tag(tag_filter) if tag_filter.present?
     timelines_filtered_total = @timelines.count
-
     sort_column = params['order']['0']['column'].to_i rescue 0
     sort_direction = params['order']['0']['dir'] rescue 'asc'
+
     session[:timeline_sort] = [sort_column, sort_direction]
-    @timelines = @timelines.order(columns[sort_column].downcase => sort_direction)
+    @timelines = @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
     @timelines = @timelines.offset(params['start']).limit(params['length'])
     response = {
       "draw": params['draw'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       - minio
     environment:
       - APP_NAME=avalon
-      - SETTINGS__DOMAIN=http://localhost:3000
       - BUNDLE_FLAGS=--with development postgres --without production test
       - ENCODE_WORK_DIR=/tmp
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       - ENCODE_WORK_DIR=/tmp
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=postgres://postgres:password@db/avalon
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
       - RAILS_ENV=development

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -105,7 +105,6 @@ services:
       - minio
     environment:
       - APP_NAME=avalon
-      - SETTINGS__DOMAIN=http://localhost:3000
       - BUNDLE_FLAGS=--with development postgres --without production test
       - ENCODE_WORK_DIR=/tmp
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -110,6 +110,7 @@ services:
       - ENCODE_WORK_DIR=/tmp
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=postgres://postgres:password@db/avalon
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
       - RAILS_ENV=development

--- a/spec/factories/timeline.rb
+++ b/spec/factories/timeline.rb
@@ -15,7 +15,7 @@
 FactoryBot.define do
   factory :timeline do
     user { FactoryBot.create(:user) }
-    title { Faker::Lorem.word }
+    title { "Timeline: #{Faker::Lorem.word}" }
     description { Faker::Lorem.sentence }
     visibility { Playlist::PRIVATE }
     manifest { }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ end
 
 # Stub out all AWS clients
 require 'aws-sdk-core'
+require 'aws-sdk-s3'
 Aws.config[:stub_responses] = true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,9 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
+# Force test rails environment
+ENV['RAILS_ENV'] = 'test'
+
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'
   require 'codeclimate-test-reporter'
@@ -27,7 +30,6 @@ require 'aws-sdk-core'
 Aws.config[:stub_responses] = true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?


### PR DESCRIPTION
The datatables json response tests for sorting were failing when faker returned `a` as the word to be used as the title of the timeline.