### PR TITLE
Add missing queues to ensure activestorage background jobs run

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,8 @@
 ---
 :queues:
   - default
+  - active_storage_analysis
+  - active_storage_purge
   - batch_ingest
   - bulk_access_control
   - create_encode


### PR DESCRIPTION
I noticed there are jobs sitting waiting to be run on avalon-dev which aren't because sidekiq wasn't configured to watch these queues.