### PR TITLE
Override bootstrap invalid-feedback class for from validation

### DIFF
--- a/app/assets/stylesheets/avalon/_form.scss
+++ b/app/assets/stylesheets/avalon/_form.scss
@@ -15,7 +15,7 @@
 */
 
 // Copied in from bootstrap-sass
-$border-radius-base:        4px !default;
+$border-radius-base: 4px !default;
 
 // Form-group input fields
 .form-group .input-group {
@@ -42,6 +42,11 @@ $border-radius-base:        4px !default;
   }
 }
 
+.form-group.invalid-feedback {
+  display: block;
+  font-size: 100%;
+}
+
 .form-text .close {
   cursor: pointer;
 }
@@ -61,10 +66,11 @@ $border-radius-base:        4px !default;
 
   }
 
-  .input-group-prepend:last-of-type,.input-group-append:last-of-type {
+  .input-group-prepend:last-of-type,
+  .input-group-append:last-of-type {
     button {
       border-bottom-right-radius: 0;
-    }  
+    }
   }
 }
 
@@ -94,14 +100,14 @@ label {
 }
 
 .fileinput-submit {
-  background-color: $blue !important;
-  border-color: $blue !important;
+  background-color: $blue  !important;
+  border-color: $blue  !important;
 
   &:hover {
     background-color: darken($blue, 15%) !important;
   }
 
-  color: $white !important;
+  color: $white  !important;
 }
 
 .upload-file-wrapper {


### PR DESCRIPTION
With the class override, invalid form submission looks as follows;

![description-error](https://user-images.githubusercontent.com/1331659/177365403-b5d29f4b-da43-48a9-ace3-1c95c6920f75.png)
