### PR TITLE
Manually save translated output urls

### DIFF
--- a/app/models/watched_encode.rb
+++ b/app/models/watched_encode.rb
@@ -26,6 +26,8 @@ class WatchedEncode < ActiveEncode::Base
   end
 
   after_completed do |encode|
+    record = ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s)
+
     # Upload to S3 if using ffmpeg or passthrough adapter
     if Settings.encoding.derivative_bucket &&
        (Settings.encoding.engine_adapter.to_sym == :ffmpeg || is_a?(PassThroughEncode))
@@ -41,9 +43,11 @@ class WatchedEncode < ActiveEncode::Base
         output.url = "s3://#{obj.bucket.name}/#{obj.key}"
         output
       end
+
+      # Save translated output urls
+      record.update(raw_object: encode.to_json)
     end
 
-    record = ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s)
     master_file = MasterFile.find(record.master_file_id)
     master_file.update_progress_on_success!(encode)
   end


### PR DESCRIPTION
Do this because the normal callback persisting the encode record happens before this callback.
Fixes #4070