### PR TITLE
Update browse-everything to handle more exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/browse-everything.git
-  revision: fb8a059d369000c9ce01b0e6053c1795309fcb36
+  revision: 38610d19d36105ca9c311e0a641fdb43697fabea
   branch: v1.2-avalon
   specs:
     browse-everything (1.2.0)


### PR DESCRIPTION
This PR bumps the revision of browse-everything which now includes handling for errors raised during the rendering of the modal.  This covers the case when tokens have expired (Google OAuth tokens default to 1 hour lifetime).  Previously this was being handled for the show action but not the index action.

To test this out, you can manually expire the oauth token you granted by:
1. Log into google
2. Go to Account -> Security -> Manage third-party access
3. Click on Avalon Media System
4. Click Remove Access