### PR TITLE
Mount volume where solr 8's docker container stores data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     image: solr:8-slim
     volumes:
       - ./solr/conf:/opt/solr/avalon_conf
-      - solr:/opt/solr/server/solr/mycores
+      - solr:/var/solr
     command:
       - solr-precreate
       - avalon


### PR DESCRIPTION
This is only for the development environment and should allow the solr data to be persistent instead of disappearing after every restart.