### PR TITLE
Make deleted content error message clearer

### DIFF
--- a/app/views/errors/deleted_pid.html.erb
+++ b/app/views/errors/deleted_pid.html.erb
@@ -15,7 +15,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <div id="main_content_container" class="container-fluid">
   <div class="content" class="col-md-8">
-    <h2>Item(s) being deleted</h2>
-    <p>The item(s) you requested are being deleted from the system. If this is not expected, contact your support staff.</p>
+    <% item = request.original_url.include?("admin/collections") ? "collection" : "item" %>
+    <h2><%= "#{item.titleize} Deleted" %> </h2>
+    <p><%= "The #{item} you requested has been deleted from the system. If this is not expected, contact your support staff." %></p>
   </div>
 </div>

--- a/app/views/errors/deleted_pid.html.erb
+++ b/app/views/errors/deleted_pid.html.erb
@@ -15,8 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <div id="main_content_container" class="container-fluid">
   <div class="content" class="col-md-8">
-    <% item = request.original_url.include?("admin/collections") ? "collection" : "item" %>
-    <h2><%= "#{item.titleize} Deleted" %> </h2>
-    <p><%= "The #{item} you requested has been deleted from the system. If this is not expected, contact your support staff." %></p>
+    <h2><%= "Item Deleted" %> </h2>
+    <p><%= "The item you requested has been deleted from the system. If this is not expected, contact your support staff." %></p>
   </div>
 </div>

--- a/app/views/errors/deleted_pid.html.erb
+++ b/app/views/errors/deleted_pid.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <div id="main_content_container" class="container-fluid">
   <div class="content" class="col-md-8">
-    <h2><%= "Item Deleted" %> </h2>
-    <p><%= "The item you requested has been deleted from the system. If this is not expected, contact your support staff." %></p>
+    <h2>Item Deleted</h2>
+    <p>The item you requested has been deleted from the system. If this is not expected, contact your support staff.</p>
   </div>
 </div>


### PR DESCRIPTION
This message appears when a user manually navigates to a Media Object or Collection page after the item/collection has been deleted. Is this new message clear/good enough?