### PR TITLE
Render mediaobject without masterfile properly when CDL is enabled

### DIFF
--- a/app/views/media_objects/_embed_checkout.html.erb
+++ b/app/views/media_objects/_embed_checkout.html.erb
@@ -13,7 +13,8 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-  <% master_file=@media_object.master_files.first if @media_object.master_files.size > 0%>
+<% if !@masterFiles.blank? %>
+  <% master_file=@media_object.master_files.first %>
   <div class="checkout <%= master_file.is_video? ? 'video' : 'audio' %>" style="height: <%= master_file.is_video? ? 400 : 100 %>px">
     <% if  @media_object.lending_status == "available" %>
       <%= t('media_object.cdl.checkout_message').html_safe %>
@@ -22,3 +23,8 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= t('media_object.cdl.not_available_message').html_safe %>
     <% end %>
   </div>
+<% else %>
+  <div class="alert">
+    <p>No media is associated with this item</p>
+  </div>
+<% end %>


### PR DESCRIPTION
With the fix in this PR, items without masterfiles when CDL is enabled looks as follows;

![Screenshot from 2022-07-29 14-42-10](https://user-images.githubusercontent.com/1331659/181824271-2895cc4f-64cd-4bf3-8af5-9eb2b1dc90c6.png)
