### PR TITLE
Change file_watcher implementation used in development to support M1 Macs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # Do NOT use an evented file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc because this feature depends on the listen gem.
+  # ActiveSupport::EventedFileUpdateChecker does not work with M1 Macs
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
Making this change allowed the avalon docker-compose to load successfully on an M1 Mac.