### PR TITLE
Styling changes for collection search cards

### DIFF
--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -72,6 +72,8 @@
   .card-body {
     padding-top: 5px;
     padding-bottom: 0px;
+    padding-right: 1rem;
+    padding-left: 1rem;
   }
 }
 
@@ -80,6 +82,16 @@
 
   .italic {
     font-style: italic;
+  }
+}
+
+.card-text {
+  font-size: 14px;
+
+  dt, dd {
+    width: 100%;
+    padding-right: 8px;
+    padding-left: 8px;
   }
 }
 

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -35,8 +35,8 @@ const CardMetaData = ({ doc, fieldLabel, fieldName }) => {
   if (doc.attributes[fieldName]) {
     return (
       <React.Fragment>
-        <dt className='col-sm-5'>{fieldLabel}</dt>
-        <dd className='col-sm-7' dangerouslySetInnerHTML={{ __html: metaData }}></dd>
+        <dt>{fieldLabel}</dt>
+        <dd dangerouslySetInnerHTML={{ __html: metaData }}></dd>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1053603/185215607-ebba3f97-ed93-47da-a437-4a96adbfbea6.png)

After:
![image](https://user-images.githubusercontent.com/1053603/185215402-39e69dab-9913-4311-9ae7-99fc8d7c55fa.png)

Changes proposed:
- Reducing right and left padding to 1rem
- Switch to 1 column for metadata display