### PR TITLE
Filter only on username and email; disable sorting on roles

### DIFF
--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -52,17 +52,10 @@ module Samvera
       # Filtering
       search_value = params['search']['value']
       @presenter = if search_value.present?
-                     search_role = @presenter.select { |p| p.groups.any? { |g| g.include? search_value } }
-                     search_date = @presenter.select { |p| last_sign_in(p).to_formatted_s(:long_ordinal).include? search_value }
-                     search_status = @presenter.select { |p| user_status(p).downcase.include? search_value.downcase }
                      @presenter.where(%(
                                 username LIKE :search_value OR
-                                email LIKE :search_value OR
-                                provider LIKE :search_value
+                                email LIKE :search_value
                               ), search_value: "%#{search_value}%")
-                               .or(User.where(id: search_role.map(&:id)))
-                               .or(User.where(id: search_date.map(&:id)))
-                               .or(User.where(id: search_status.map(&:id)))
                    else
                      @presenter
                    end
@@ -77,12 +70,6 @@ module Samvera
       if columns[sort_column] != 'entry'
         @presenter = @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
         @presenter = @presenter.offset(params['start']).limit(params['length'])
-      else
-        user_roles = @presenter.collect { |p| [ p.groups, p ] }
-        user_roles.sort_by! { |r| [-r[0].length, r] }
-        @presenter = user_roles.collect { |p| p[1] }
-        @presenter.reverse! if sort_direction == 'desc'
-        @presenter = @presenter.slice(params['start'].to_i, params['length'].to_i)
       end
 
       # Build json response

--- a/app/views/samvera/persona/users/index.html.erb
+++ b/app/views/samvera/persona/users/index.html.erb
@@ -45,7 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <tr>
         <th><%= t('.id_label') %></th>
         <th><%= t('.email_label') %></th>
-        <th><%= t('.role_label') %></th>
+        <th data-orderable="false"><%= t('.role_label') %></th>
         <th><%= t('.access_label') %></th>
         <th><%= t('.status_label') %></th>
         <% if User.column_names.include? 'provider' %>

--- a/spec/controllers/samvera/persona/user_controller_spec.rb
+++ b/spec/controllers/samvera/persona/user_controller_spec.rb
@@ -57,49 +57,26 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
     end
 
     context 'filtering' do
-      let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
-      it "returns results filtered by username" do
-        post :paged_index, format: 'json', params: common_params.merge(search: { value: user.username })
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['recordsFiltered']).to eq(1)
-        expect(parsed_response['data'].count).to eq(1)
-        expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">#{user.username}</a>")
+      context 'username' do
+	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
+	it "returns results filtered by username" do
+	  post :paged_index, format: 'json', params: common_params.merge(search: { value: user.username })
+	  parsed_response = JSON.parse(response.body)
+	  expect(parsed_response['recordsFiltered']).to eq(1)
+	  expect(parsed_response['data'].count).to eq(1)
+	  expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">#{user.username}</a>")
+	end
       end
 
-      let(:common_params) { { start: 0, length: 20, order: { '0': { column: 'entry', dir: 'asc' } } } }
-      it "returns results filtered by email" do
-        post :paged_index, format: 'json', params: common_params.merge(search: { value: 'zzzebra@example.edu' })
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['recordsFiltered']).to eq(1)
-        expect(parsed_response['data'].count).to eq(1)
-        expect(parsed_response['data'][0][1]).to eq("<a href=\"/persona/users/2/edit\">zzzebra@example.edu</a>")
-      end
-
-      let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
-      it "returns results filtered by role" do
-        post :paged_index, format: 'json', params: common_params.merge( { search: { value: 'administrator' } } )
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['recordsFiltered']).to eq(1)
-        expect(parsed_response['data'].count).to eq(1)
-        expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">aardvark</a>")
-      end
-
-      let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
-      it "returns results filtered by date" do
-        post :paged_index, format: 'json', params: common_params.merge( { search: { value: 'May' } } )
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['recordsFiltered']).to eq(2)
-        expect(parsed_response['data'].count).to eq(2)
-        expect(parsed_response['data'][0][3]).to eq("<relative-time datetime=\"2022-05-15T00:00:00Z\" title=\"2022-05-15 00:00:00 UTC\">May 15th, 2022 00:00</relative-time>")
-      end
-
-      let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
-      it "returns results filtered by status" do
-        post :paged_index, format: 'json', params: common_params.merge( { search: { value: 'Pending' } } )
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['recordsFiltered']).to eq(1)
-        expect(parsed_response['data'].count).to eq(1)
-        expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/2/edit\">zzzebra</a>")
+      context 'email' do
+	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 'entry', dir: 'asc' } } } }
+	it "returns results filtered by email" do
+	  post :paged_index, format: 'json', params: common_params.merge(search: { value: 'zzzebra@example.edu' })
+	  parsed_response = JSON.parse(response.body)
+	  expect(parsed_response['recordsFiltered']).to eq(1)
+	  expect(parsed_response['data'].count).to eq(1)
+	  expect(parsed_response['data'][0][1]).to eq("<a href=\"/persona/users/2/edit\">zzzebra@example.edu</a>")
+	end
       end
     end
 
@@ -117,20 +94,6 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/2/edit\">zzzebra</a>")
         expect(parsed_response['data'][11][0]).to eq("<a href=\"/persona/users/1/edit\">aardvark</a>")
-      end
-
-      it "returns results sorted by role ascending" do
-        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 2, dir: 'asc' } })
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['data'][0][2]).to eq("<ul><li>administrator</li></ul>")
-        expect(parsed_response['data'][11][2]).to eq("<ul></ul>")
-      end
-
-      it "returns results sorted by role descending" do
-        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 2, dir: 'desc' } })
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['data'][0][2]).to eq("<ul></ul>")
-        expect(parsed_response['data'][11][2]).to eq("<ul><li>administrator</li></ul>")
       end
     end
   end


### PR DESCRIPTION
This PR is in response to slow response times on filtering and sorting of roles when run in production with ~30K users.  Avoiding non-DB query filtering and sorting speeds up response times considerably.  This PR proposes filtering on only username and email and disabling sorting on roles.