### PR TITLE
Fix html encoded titles in collection cards

### DIFF
--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -83,6 +83,17 @@
   .italic {
     font-style: italic;
   }
+
+  // When `line-clamp` is used with `display: -webkit-box`
+  // contains text to a given amount of lines (e.g.: 2)
+  // Reference: https://mgearon.com/css/line-clamp-css-guide/
+  h4 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .card-text {

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -74,10 +74,7 @@ const thumbnailSrc = (doc, props) => {
 };
 
 const titleHTML = (doc) => {
-  var title = doc.attributes['title_tesi'] && doc.attributes['title_tesi'].attributes.value.substring(0, 50) || doc['id'];
-  if (doc.attributes['title_tesi'] && doc.attributes['title_tesi'].attributes.value.length >= 50) {
-    title += "<span>...</span>";
-  }
+  var title = doc.attributes['title_tesi'] && doc.attributes['title_tesi'].attributes.value || doc['id'];
   return { __html: title };
 };
 


### PR DESCRIPTION
Before:
![Screenshot from 2022-08-29 12-58-52](https://user-images.githubusercontent.com/1331659/187287496-d6c0b357-ef11-4eb3-ad4c-6a444f92899b.png)
After:
![Screenshot from 2022-08-29 12-59-10](https://user-images.githubusercontent.com/1331659/187287498-09b0c569-a063-4941-a34e-6551fe0f12f7.png)

The fix in this PR, removes string truncation from the JS code, and uses CSS's `line-clamp` property to limit the title to 2 lines along with other CSS properties truncates the overflowing text.