### PR TITLE
Add authentication prompt for cdl items

### DIFF
--- a/app/views/media_objects/_checkout_authenticate.html.erb
+++ b/app/views/media_objects/_checkout_authenticate.html.erb
@@ -1,0 +1,64 @@
+<%#
+Copyright 2011-2022, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<div class="log-in-out text-muted header-user">
+  <center>
+    <%= link_to t('auth.sign_in'), new_user_session_path(:login_popup=>"1"), :onclick=>"openPopup(this);return false;", :class=> "btn btn-info" %>
+  </center>
+</div>
+
+<% content_for :page_scripts do %>
+  <script>
+
+    window.onload = function(){
+      window["authterval"] = window.setInterval(function(){
+        if (getCookie("signed_in") != null) {
+          window.clearInterval(authterval);
+          location.reload();
+        }
+      }, 1000)
+    }
+
+    function getCookie(name) {
+      var dc = document.cookie;
+      var prefix = name + "=";
+      var begin = dc.indexOf("; " + prefix);
+      if (begin == -1) {
+        begin = dc.indexOf(prefix);
+        if (begin != 0) return null;
+      } else {
+        begin += 2;
+        var end = document.cookie.indexOf(";", begin);
+        if (end == -1) {
+          end = dc.length;
+        }
+      }
+      return unescape(dc.substring(begin + prefix.length, end));
+    }
+
+    function openPopup(link) {
+      window.clearInterval(authterval);
+      var popup_window = window.open(link.href,'Avalon Login', 'height=600, width=600');
+      var interval = window.setInterval((function() {
+        if (popup_window.closed) {
+          window.clearInterval(interval);
+          location.reload();
+        }
+      }), 1000);
+    }
+
+  </script>
+<% end %>

--- a/app/views/media_objects/_checkout_authenticate.html.erb
+++ b/app/views/media_objects/_checkout_authenticate.html.erb
@@ -16,49 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <div class="log-in-out text-muted header-user">
   <center>
-    <%= link_to t('auth.sign_in'), new_user_session_path(:login_popup=>"1"), :onclick=>"openPopup(this);return false;", :class=> "btn btn-info" %>
+    <% session[:previous_url] = request.fullpath unless request.xhr? %>
+    <%= link_to 'Sign in', main_app.new_user_session_path, :class=> "btn btn-info" %>
   </center>
 </div>
-
-<% content_for :page_scripts do %>
-  <script>
-
-    window.onload = function(){
-      window["authterval"] = window.setInterval(function(){
-        if (getCookie("signed_in") != null) {
-          window.clearInterval(authterval);
-          location.reload();
-        }
-      }, 1000)
-    }
-
-    function getCookie(name) {
-      var dc = document.cookie;
-      var prefix = name + "=";
-      var begin = dc.indexOf("; " + prefix);
-      if (begin == -1) {
-        begin = dc.indexOf(prefix);
-        if (begin != 0) return null;
-      } else {
-        begin += 2;
-        var end = document.cookie.indexOf(";", begin);
-        if (end == -1) {
-          end = dc.length;
-        }
-      }
-      return unescape(dc.substring(begin + prefix.length, end));
-    }
-
-    function openPopup(link) {
-      window.clearInterval(authterval);
-      var popup_window = window.open(link.href,'Avalon Login', 'height=600, width=600');
-      var interval = window.setInterval((function() {
-        if (popup_window.closed) {
-          window.clearInterval(interval);
-          location.reload();
-        }
-      }), 1000);
-    }
-
-  </script>
-<% end %>

--- a/app/views/media_objects/_embed_checkout.html.erb
+++ b/app/views/media_objects/_embed_checkout.html.erb
@@ -15,9 +15,13 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <% if !@masterFiles.blank? %>
   <% master_file=@media_object.master_files.first %>
-  <div class="checkout <%= master_file.is_video? ? 'video' : 'audio' %> mb-3" style="height: <%= master_file.is_video? ? 400 : 100 %>px">
+  <% h = current_user ? 100 : 120 %>
+  <div class="checkout <%= master_file.is_video? ? 'video' : 'audio' %> mb-3" style="height: <%= master_file.is_video? ? 400 : h %>px">
     <div class="centered <%= 'video' if master_file.is_video? %>">
-      <% if  @media_object.lending_status == "available" %>
+      <% if !current_user %>
+        <%= t('media_object.cdl.unauthenticated_message').html_safe %>
+        <%= render "checkout_authenticate" %>
+      <% elsif @media_object.lending_status == "available" %>
         <%= t('media_object.cdl.checkout_message').html_safe %>
         <%= render "checkout" %>
       <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
       checkout_message: "<p>Borrow this item to access media resources.</p>"
       not_available_message: "<p>This resource is not available to be checked out at the moment. Please check again later.</p>"
       time_remaining: "<p>Time <br />remaining: </p>"
+      unauthenticated_message: "<p>You are not signed in. You may be able to borrow this item after signing in.</p>"
       expire:
         heading: "Check Out Expired!"
         message: "Your lending period has been expired. Please return the item, and check for availability later."


### PR DESCRIPTION
This seems to work. I used the implementation from the masterfile `_authenticate` partial for doing a login popup. Though, since we are already in avalon, rather than an external site, would it be better to send the user to the regular login page and return them to the item instead of using a popup?

I also needed to tweak some of the styling for the player area so that the sign in button would render entirely within the player. It looks balanced to me, but may need additional tweaking.