### PR TITLE
Change check out button text on item page

### DIFF
--- a/app/assets/stylesheets/avalon/_buttons.scss
+++ b/app/assets/stylesheets/avalon/_buttons.scss
@@ -38,9 +38,3 @@ button.close {
     text-decoration: none;
   }
 }
-
-.check-out-btn:hover {
-  transform:scale(1.1);
-  -webkit-transform:scale(1.1);
-  -moz-transform:scale(1.1);
-}

--- a/app/views/media_objects/_checkout.html.erb
+++ b/app/views/media_objects/_checkout.html.erb
@@ -14,22 +14,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% media_object_id=@media_object.id %>
+<% lending_period=ActiveSupport::Duration.build(@media_object.lending_period).to_day_hour_s%>
 <%= form_for(Checkout.new) do |f| %>
   <%= hidden_field_tag "authenticity_token", form_authenticity_token %>
   <%= hidden_field_tag "checkout[media_object_id]", media_object_id %>
-  <%= f.submit "Check Out", class: "btn btn-info check-out-btn", 
-    data: { lending_period: ActiveSupport::Duration.build(@media_object.lending_period).to_day_hour_s } %>
-<% end %>
-
-<% content_for :page_scripts do %>
-  <script>
-    $(".check-out-btn").hover(
-      function() {
-        var lending_period = $(this).data().lendingPeriod;
-        $(this).val(`Borrow for ${lending_period}`);
-      }, function() {
-        $(this).val('Check Out');
-      }
-    );
-  </script>
+  <%= f.submit "Borrow for #{lending_period}", class: "btn btn-info" %>
 <% end %>

--- a/spec/features/media_object_spec.rb
+++ b/spec/features/media_object_spec.rb
@@ -93,7 +93,7 @@ describe 'MediaObject' do
     context 'displays embedded player' do
       it 'with proper text when available' do
         visit media_object_path(available_media_object)
-        expect(page.has_content?('Borrow this item to access media resources.')).to be_truthy
+        expect(page).to have_content('Borrow this item to access media resources.')
         expect(page).to have_selector(:link_or_button, 'Borrow for 14 days')
       end
       it 'with proper text when not available' do

--- a/spec/features/media_object_spec.rb
+++ b/spec/features/media_object_spec.rb
@@ -85,4 +85,31 @@ describe 'MediaObject' do
       end
     end
   end
+  describe 'displays cdl controls' do
+    before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(true) }
+    let(:available_media_object) { FactoryBot.build(:media_object) }
+    let!(:mf) { FactoryBot.create(:master_file, media_object: available_media_object) }
+
+    context 'displays embedded player' do
+      it 'with proper text when available' do
+        visit media_object_path(available_media_object)
+        expect(page.has_content?('Borrow this item to access media resources.')).to be_truthy
+        expect(page).to have_selector(:link_or_button, 'Borrow for 14 days')
+      end
+      it 'with proper text when not available' do
+        # Checkout the available media object with a different user
+        normal_user = FactoryBot.create(:user)
+        FactoryBot.create(:checkout, media_object_id: available_media_object.id, user_id: normal_user.id).save
+
+        visit media_object_path(available_media_object)
+        expect(page.has_content?('This resource is not available to be checked out at the moment. Please check again later.')).to be_truthy
+      end
+    end
+
+    it 'displays countdown timer when checked out' do
+      visit media_object_path(media_object)
+      expect(page.has_content?('Time remaining:')).to be_truthy
+      expect(page).to have_selector(:link_or_button, 'Return now')
+    end
+  end
 end


### PR DESCRIPTION
Change check out button text to `Borrow for #{lending_period}`;
![Screenshot from 2022-08-31 14-46-39](https://user-images.githubusercontent.com/1331659/187757837-200a2221-2c09-4388-a4ab-d39f432adc30.png)
