### PR TITLE
Adjust collection card and metadata styling to properly align content on page

### DIFF
--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -50,16 +50,11 @@
 
 /* Collection cards */
 .collection-card {
-  height: 415px;
+  height: 95%;
   overflow: hidden;
 
-  // For medium screens
-  @media (min-width: 768px) and (max-width: 1199.98px) {
-    height: 420px;
-  }
-
-  // For smaller screens
-  @media screen and (max-width: 767px) {
+  // For smaller screens set height to auto
+  @media screen and (max-width: 575.98px) {
     height: auto;
   }
 
@@ -104,6 +99,15 @@
     padding-right: 8px;
     padding-left: 8px;
   }
+
+  // Limit metadata values to 2 lines in cards
+  dd {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .search-within-facets {
@@ -123,6 +127,23 @@
 .search-within-search-results {
   margin-top: 3rem;
   padding-left: 0;
+
+  // Using flexbox to adjust all card heights to match the tallest card height 
+  @media screen and (min-width: 575.98px) {
+    display: flex;
+    flex-direction: row;
+    padding: 10px;
+  
+    li {
+      padding-right: 10px;
+      flex-grow: 1;
+      width: 33%;
+  
+      &:last-child {
+        padding-right: 0;
+      }
+    }
+  }
 
   .document-thumbnail {
     position: relative;

--- a/app/javascript/components/collections/landing/SearchResultsCard.js
+++ b/app/javascript/components/collections/landing/SearchResultsCard.js
@@ -25,9 +25,6 @@ const CardMetaData = ({ doc, fieldLabel, fieldName }) => {
   let value = doc.attributes[fieldName]?.attributes?.value;
   if (Array.isArray(value) && value.length > 1) {
     metaData = value.join(', ');
-  } else if (typeof value == 'string') {
-    const summary = value.substring(0, 50);
-    metaData = value.length >= 50 ? `${summary}...` : value;
   } else {
     metaData = value;
   }


### PR DESCRIPTION
Fixes in this PR;
- The metadata  text is limited to 2 lines and then gets cut off via CSS. This removes the string truncation in the JS code.
- Height of all collection cards are set to the tallest card's height in medium and large screens using flexbox in CSS. Before, this was achieved by setting height to different values using media queries.

With these changes the collection card heights get auto adjusted based on the content length and prevents hiding the overflow.