### PR TITLE
Update CORS to echo request origin

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module Avalon
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins '*'
+        origins { |source| true }
         resource '/media_objects/*/manifest*', headers: :any, methods: [:get]
         resource '/master_files/*/thumbnail', headers: :any, methods: [:get]
         resource '/master_files/*/transcript/*/*', headers: :any, methods: [:get]

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -18,7 +18,6 @@ describe 'CORS', type: :request do
   let(:media_object) { FactoryBot.create(:published_media_object) }
   let(:headers) { ['localhost', 'http://example.com', 'https://example.edu'] }
 
-
   it 'echoes the request origin in the CORS headers' do
     headers.each do |header|
       get "/media_objects/#{media_object.id}/manifest", headers: { 'HTTP_ORIGIN': header }

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -1,0 +1,28 @@
+# Copyright 2011-2022, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper.rb'
+
+describe 'CORS', type: :request do
+  let(:media_object) { FactoryBot.create(:published_media_object) }
+  let(:headers) { ['localhost', 'http://example.com', 'https://example.edu'] }
+
+
+  it 'echoes the request origin in the CORS headers' do
+    headers.each do |header|
+      get "/media_objects/#{media_object.id}/manifest", headers: { 'HTTP_ORIGIN': header }
+      expect(response.headers['Access-Control-Allow-Origin']).to eq(header)
+    end
+  end
+end


### PR DESCRIPTION
Rack-CORS allows for dynamically setting allowed origins in a block in the config. Manually testing with cURL, a simple block looking at the request source is sufficient to have the origin header echoed.

I think this change should retain the functionality of using a wildcard, while echoing the request origin into the `Access-Control-Allow-Origin` header.