### PR TITLE
Fix overflow of encode records table

### DIFF
--- a/app/views/encode_records/index.html.erb
+++ b/app/views/encode_records/index.html.erb
@@ -85,6 +85,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         stateSave: true,
         processing: true,
         serverSide: true,
+        scrollX: true,
         dom:'<"dataTableToolsTop"Blf><"dataTableBody"t><"dataTableToolsBottom"ipr>',
         autoWidth:true,
         order: [[ 6, 'desc' ]],


### PR DESCRIPTION
Handle encoding dashboard datatable overflow properly using datatable option `scrollX: true`, so that horizontal overflow of the table is scroll-able as below;
![Screenshot from 2022-09-13 09-09-04](https://user-images.githubusercontent.com/1331659/189909511-dc3bf964-d11e-4f2e-8ce7-6863abe2f13e.png)
