### PR TITLE
Fix video player aspect ratio and size for mobile devices

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -48,6 +48,10 @@ body {
 */
 html {
   font-size: 14px;
+
+  @include media-breakpoint-down(md) {
+    font-size: 12px;
+  }
 }
 
 .alert {
@@ -138,6 +142,12 @@ div.alert-danger {
 .page-title-wrapper {
   h3 {
     margin-top: 0;
+  }
+
+  @include media-breakpoint-down(md) {
+    h1 {
+      font-size: 2rem;
+    }
   }
 }
 
@@ -399,6 +409,12 @@ a[data-trigger='submit'] {
     margin-top: 10px;
     margin-bottom: 10px;
   }
+  
+  @include media-breakpoint-down(sm) {
+    margin-top: 1rem;
+    padding: 0;
+  }
+
 }
 
 .index_title {

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -65,4 +65,22 @@ Unless required by applicable law or agreed to in writing, software distributed
   <% if @currentStream.present? and @currentStream.derivatives.present? %>
     <%= render partial: "mejs4_player_js", locals: {section: @currentStream, section_info: @currentStreamInfo} %>
   <% end %>
+
+  <script>
+    // When viewing video on smaller devices scroll to page content to fully
+    // display the video player
+    $(document).ready(function () {
+      const isVideo = "<%= @currentStreamInfo[:is_video] %>";
+      if(isVideo) {
+        const screenHeight = screen.height;
+        const playerHeight = document.getElementsByTagName('video')[0].style.height.replace(/[^-\d\.]/g, '');
+        if(screenHeight - playerHeight < 200) {
+          $('html, body').animate({
+              scrollTop: $('#user-util-collapse').offset().top
+          }, 1000);
+        }
+      }
+    });
+  </script>
+
 <% end %>

--- a/app/views/modules/player/_video_element.html.erb
+++ b/app/views/modules/player/_video_element.html.erb
@@ -18,8 +18,8 @@ Unless required by applicable law or agreed to in writing, software distributed
                 class="mejs-avalon <%= is_mejs_2? ? '' : 'invisible' %>"
                 controls
                 style="width: 100%; height: 100%"
-                width="<%= @player_width || 450 %>"
-                height="<%= @player_height || 309 %>"
+                width="<%= @player_width || 480 %>"
+                height="<%= @player_height || 270 %>"
                 data-canvasindex=0
                 poster="<%= section_info[:poster_image] if f_start == 0 %>"
                 preload="auto">


### PR DESCRIPTION
This PR has the following changes:
1. Scroll to main content in smaller mobile devices when video player is not displayed entirely
2. Reduce the overall font-size for mobile devices so that content fits into mobile device screen sizes
3. Change default video player height and width to adhere 16:9 aspect ratio