### PR TITLE
LDAP search will return nil sometimes instead of []

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,7 +147,7 @@ class User < ActiveRecord::Base
 
   def self.ldap_member_of(cn)
     return [] unless defined? Avalon::GROUP_LDAP
-    entry = Avalon::GROUP_LDAP.search(:base => Avalon::GROUP_LDAP_TREE, :filter => Net::LDAP::Filter.eq("cn", cn), :attributes => ["memberof"]).first
+    entry = Avalon::GROUP_LDAP.search(:base => Avalon::GROUP_LDAP_TREE, :filter => Net::LDAP::Filter.eq("cn", cn), :attributes => ["memberof"])&.first
     entry.nil? ? [] : entry["memberof"].collect {|mo| mo.split(',').first.split('=').second}
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,6 +121,10 @@ describe User do
       allow_any_instance_of(Net::LDAP).to receive(:search).and_return([entry])
       expect(user.send(:ldap_groups)).to eq(['Group1','Group2'])
     end
+    it "should return [] when ldap search returns nil" do
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return(nil)
+      expect(user.send(:ldap_groups)).to eq([])
+    end
   end
 
   describe "#autocomplete" do


### PR DESCRIPTION
Based upon honeybadger errors from production.