### PR TITLE
Configure sorting by solr timestamp for atom feed

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -189,6 +189,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'date_ssi desc, title_ssort asc', label: 'Date'
     config.add_sort_field 'creator_ssort asc, title_ssort asc', label: 'Main contributor'
     config.add_sort_field 'title_ssort asc, date_ssi desc', label: 'Title'
+    config.add_sort_field 'timestamp desc', label: 'Recently Updated', if: false
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
This fixes a regression for a feature we use at IU.  Sorting the atom feed so most recently updated records appear first was working before the Blacklight upgrade.  Blacklight 7 only includes configured sort orders in requests to solr.  Registering this sort in CatalogController would have the side effect of displaying it in the search UI but setting `if: false` hides it.