### PR TITLE
Speed up media objects show page for many sectioned items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', '~> 0.3'
-gem 'speedy-af', '~> 0.2'
+gem 'speedy-af', '~> 0.3'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active-fedora (13.2.7)
+    active-fedora (13.3.0)
       active-triples (>= 0.11.0, < 2.0.0)
       activemodel (>= 5.1)
       activesupport (>= 5.1)
@@ -851,7 +851,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    slop (4.9.1)
+    slop (4.9.3)
     solr_wrapper (3.1.2)
       http
       retriable
@@ -863,9 +863,9 @@ GEM
       nokogiri
       stomp
       xml-simple
-    speedy-af (0.2.0)
+    speedy-af (0.3.0)
       active-fedora (>= 11.0.0)
-      activesupport (> 5.2, < 6.1)
+      activesupport (> 5.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -908,7 +908,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
-    unicode-types (1.7.0)
+    unicode-types (1.8.0)
     user_agent_parser (2.9.0)
     view_component (2.58.0)
       activesupport (>= 5.0.0, < 8.0)
@@ -945,7 +945,7 @@ GEM
       nokogiri (~> 1.8)
     xray-rails (0.3.2)
       rails (>= 3.1.0)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
     zk (1.10.0)
       zookeeper (~> 1.5.0)
     zookeeper (1.5.1)
@@ -1066,7 +1066,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.2)!
   simplecov
   solr_wrapper (>= 0.16)
-  speedy-af (~> 0.2)
+  speedy-af (~> 0.3)
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -538,7 +538,8 @@ class MediaObjectsController < ApplicationController
                                         workflow_id: nil,
                                         comment: [],
                                         supplemental_files_json: nil
-                                      })
+                                      },
+                                      load_reflections: true)
   end
 
   def load_master_files(mode = :rw)

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -54,7 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     </div>
 
     <% if can_stream && @currentStream %>
-      <% supplemental_files = @media_object.ordered_master_files.to_a.map { |mf| {"id" => mf.id, "transcripts" => mf.supplemental_files.select { |sf| sf.tags.include?('transcript')} } }.flatten(1) %>
+      <% supplemental_files = @masterFiles.map { |mf| {"id" => mf.id, "transcripts" => mf.supplemental_files.select { |sf| sf.tags.include?('transcript')} } }.flatten(1) %>
       <%= react_component("ReactIIIFTranscript", {base_url: request.protocol+request.host_with_port, transcripts: supplemental_files }) %>
     <% end %>
   </div>


### PR DESCRIPTION
Pull in newer version of `speedy_af` which has an option to bundle the solr requests into a single large request and enable this feature in MediaObjectsController.  Also fix a case where fedora requests were happening instead of using the speedy_af proxies.