### PR TITLE
CUD operations on supplemental files should check if can edit owning objects

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -145,6 +145,7 @@ class SupplementalFilesController < ApplicationController
     end
 
     def authorize_object
-      authorize! action_name.to_sym, @object, message: "You do not have sufficient privileges to #{action_name} this supplemental file"
+      action = action_name.to_sym == :show ? :show : :edit
+      authorize! action, @object, message: "You do not have sufficient privileges to #{action_name} this supplemental file"
     end
 end

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -61,7 +61,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
   let(:master_file) { FactoryBot.create(:master_file, media_object_id: media_object.id, supplemental_files: [supplemental_file]) }
   let(:supplemental_file) { FactoryBot.create(:supplemental_file, :with_attached_file, label: 'label') }
   let(:object) { object_class == MasterFile ? master_file : media_object }
-
+  let(:manager) { media_object.collection.managers.first }
 
   describe 'security' do
     context 'with unauthenticated user' do
@@ -103,7 +103,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
     let(:object) { object_class == MasterFile ? master_file : media_object }
 
     before do
-      login_as :administrator
+      login_user manager
     end
 
     context 'json request' do
@@ -203,7 +203,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
 
   describe "PUT #update" do
     before do
-      login_as :administrator
+      login_user manager
     end
 
     context 'json request' do
@@ -265,7 +265,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
 
   describe "DELETE #destroy" do
     before do
-      login_as :administrator
+      login_user manager
     end
 
     context 'json request' do


### PR DESCRIPTION
Currently the supplemental files controller is checking if the user can take the same action requested for the supplemental file on the owning object.  This works for administrators since they can take any action, but managers are blocked from creating supplemental files for master files because can :create, MasterFile isn't ever explicitly granted for any user.  This PR proposes only checking for edit privileges on the owning object since that better matches the actual change to the owning object: adding or removing a reference to a supplemental file.  This change would allow all users who have the ability to edit the MasterFile to manipulate supplement files.