### PR TITLE
Fix for ios fullscreen captions not displaying

### DIFF
--- a/app/views/modules/player/_video_element.html.erb
+++ b/app/views/modules/player/_video_element.html.erb
@@ -22,7 +22,9 @@ Unless required by applicable law or agreed to in writing, software distributed
                 height="<%= @player_height || 270 %>"
                 data-canvasindex=0
                 poster="<%= section_info[:poster_image] if f_start == 0 %>"
-                preload="auto">
+                preload="auto"
+                playsinline="true"
+                webkit-playsinline="true">
           <% section_info[:stream_hls].each do |hls| %>
             <source src="<%= hls[:url] %>" type="application/x-mpegURL" data-quality="<%= hls[:quality] %>"/>
           <% end %>

--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1300,7 +1300,7 @@ Object.assign(_player.config, {
 
 	fullscreenText: null,
 
-	useFakeFullscreen: false
+	useFakeFullscreen: true
 });
 
 Object.assign(_player2.default.prototype, {
@@ -1461,6 +1461,10 @@ Object.assign(_player2.default.prototype, {
 			t.getElement(t.container).style.height = '100%';
 			t.setControlsSize();
 		}, 500);
+
+		if(_constants.IS_ANDROID || _constants.IS_IOS) {
+			t.getElement(t.container).querySelector('.' + t.options.classPrefix + 'overlay-button').style.display = 'none';
+		}
 
 		if (isNative) {
 			t.node.style.width = '100%';


### PR DESCRIPTION
This fix overrides the native iOS player in fullscreen mode and display a similar interface of the avalon's media player. This way the captions are accessible in a similar way to the regular player.
![ios fakefullscreen](https://user-images.githubusercontent.com/1331659/201216632-cf6b6819-3bea-4a5c-92dc-2dc90c35b30d.png)

This could be a temporary fix from a UI perspective. Related ticket: #4951 