### PR TITLE
Cdl embeds

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -38,7 +38,7 @@ class MediaObjectsController < ApplicationController
     ctx.user_session.present? && ctx.user_session[:lti_group].present?
   end
   def self.is_cdl_enabled ctx
-    ctx.instance_variable_get('@media_object').cdl_enabled
+    ctx.instance_variable_get('@media_object').cdl_enabled?
   end
 
   is_editor_or_not_lti = proc { |ctx| self.is_editor(ctx) || !self.is_lti_session(ctx) }

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -37,12 +37,16 @@ class MediaObjectsController < ApplicationController
   def self.is_lti_session ctx
     ctx.user_session.present? && ctx.user_session[:lti_group].present?
   end
+  def self.is_cdl_enabled ctx
+    ctx.instance_variable_get('@media_object').cdl_enabled
+  end
 
   is_editor_or_not_lti = proc { |ctx| self.is_editor(ctx) || !self.is_lti_session(ctx) }
   is_editor_or_lti = proc { |ctx| (Avalon::Authentication::Providers.any? {|p| p[:provider] == :lti } && self.is_editor(ctx)) || self.is_lti_session(ctx) }
+  is_editor_or_not_lti_and_cdl_disabled = proc { |ctx| !self.is_cdl_enabled(ctx) && (self.is_editor(ctx) || !self.is_lti_session(ctx)) }
 
   add_conditional_partial :share, :share, partial: 'share_resource', if: is_editor_or_not_lti
-  add_conditional_partial :share, :embed, partial: 'embed_resource', if: is_editor_or_not_lti
+  add_conditional_partial :share, :embed, partial: 'embed_resource', if: is_editor_or_not_lti_and_cdl_disabled
   add_conditional_partial :share, :lti_url, partial: 'lti_url',  if: is_editor_or_lti
 
   def can_embed?

--- a/app/views/master_files/_cdl_embed.html.erb
+++ b/app/views/master_files/_cdl_embed.html.erb
@@ -13,10 +13,31 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% if lending_enabled?(@master_file.media_object) %>
-  <%= render 'cdl_embed' %>
-<% elsif cannot? :read, @master_file %>
-  <%= render 'authorize' %>
-<% else %>
-  <%= render 'player' %>
-<% end %>
+  <style>
+    body {
+      background: rgba(10,10,10,0.95);
+      font-family: Arial,Helvetica,sans-serif;
+      font-size: 14px;
+      text-align: center;
+      color: white
+    }
+    .centered {
+      margin: auto;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 33px;
+      width: 50%
+    }
+    .centered.video {
+      height: 110px
+    }
+  </style>
+
+  <div>
+    <div class="centered">
+      <p>This item cannot be embedded.</p>
+    </div>
+  </div>

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -245,6 +245,22 @@ describe MasterFilesController do
       expect(get(:embed, params: { id: master_file.id })).to render_template('modules/_google_analytics')
     end
 
+    context 'with cdl enabled' do
+      before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(true) }
+      before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(true) }
+      it "renders the cdl_embed partial" do
+        expect(get(:embed, params: { id: master_file.id })).to render_template('master_files/_cdl_embed')
+      end
+    end
+
+    context 'with cdl disabled' do
+      before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(true) }
+      before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(false) }
+      it "renders the authorize partial" do
+        expect(get(:embed, params: { id: master_file.id })).to render_template('master_files/_player')
+      end
+    end
+
     context 'with fedora 3 pid' do
       let!(:master_file) { FactoryBot.create(:master_file, identifier: [fedora3_pid]) }
       let(:fedora3_pid) { 'avalon:1234' }

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -812,7 +812,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
             it "managers: should include lti, embed, and share" do
@@ -820,7 +820,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
             it "editors: should include lti, embed, and share" do
@@ -828,7 +828,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
             it "others: should include embed and share and NOT lti" do
@@ -836,7 +836,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to_not render_template(:_lti_url)
             end
           end
@@ -848,7 +848,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
             it "others: should include only lti" do
@@ -888,7 +888,7 @@ describe MediaObjectsController, type: :controller do
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
               expect(response).to render_template(:_share_resource)
-              expect(response).to render_template(:_embed_resource)
+              expect(response).not_to render_template(:_embed_resource)
               expect(response).to_not render_template(:_lti_url)
             end
           end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -807,7 +807,7 @@ describe MediaObjectsController, type: :controller do
         before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(true) }
         context "With check out" do
           context "Normal login" do
-            it "administrators: should include lti, embed, and share" do
+            it "administrators: should include lti and share, NOT embed" do
               login_as(:administrator)
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
@@ -815,7 +815,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
-            it "managers: should include lti, embed, and share" do
+            it "managers: should include lti and share, NOT embed" do
               login_user media_object.collection.managers.first
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
@@ -823,7 +823,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
-            it "editors: should include lti, embed, and share" do
+            it "editors: should include lti and share, NOT embed" do
               login_user media_object.collection.editors.first
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
@@ -831,7 +831,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).not_to render_template(:_embed_resource)
               expect(response).to render_template(:_lti_url)
             end
-            it "others: should include embed and share and NOT lti" do
+            it "others: should include share and NOT embed or lti" do
               login_as(:user)
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
@@ -841,7 +841,7 @@ describe MediaObjectsController, type: :controller do
             end
           end
           context "LTI login" do
-            it "administrators/managers/editors: should include lti, embed, and share" do
+            it "administrators/managers/editors: should include lti and share, NOT embed" do
               login_lti 'administrator'
               lti_group = @controller.user_session[:virtual_groups].first
               FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
@@ -883,7 +883,7 @@ describe MediaObjectsController, type: :controller do
               example.run
               Avalon::Authentication::Providers = providers
             end
-            it "should not include lti" do
+            it "should not include lti or embed" do
               login_as(:administrator)
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
               get :show, params: { id: media_object.id }
@@ -895,25 +895,25 @@ describe MediaObjectsController, type: :controller do
         end
         context "Without check out" do
           context "Normal login" do
-            it "administrators: should include lti, embed, and share" do
+            it "administrators: should render checkout button in player, NOT share" do
               login_as(:administrator)
               get :show, params: { id: media_object.id }
               expect(response).not_to render_template(:_share_resource)
               expect(response).to render_template(:_embed_checkout)
             end
-            it "managers: should include lti, embed, and share" do
+            it "managers: should render checkout button in player, NOT share" do
               login_user media_object.collection.managers.first
               get :show, params: { id: media_object.id }
               expect(response).not_to render_template(:_share_resource)
               expect(response).to render_template(:_embed_checkout)
             end
-            it "editors: should include lti, embed, and share" do
+            it "editors: should render checkout button in player, NOT share" do
               login_user media_object.collection.editors.first
               get :show, params: { id: media_object.id }
               expect(response).not_to render_template(:_share_resource)
               expect(response).to render_template(:_embed_checkout)
             end
-            it "others: should include embed and share and NOT lti" do
+            it "others: should render checkout button in player, NOT share" do
               login_as(:user)
               get :show, params: { id: media_object.id }
               expect(response).not_to render_template(:_share_resource)
@@ -921,7 +921,7 @@ describe MediaObjectsController, type: :controller do
             end
           end
           context "LTI login" do
-            it "administrators/managers/editors: should include lti, embed, and share" do
+            it "administrators/managers/editors: should render checkout button in player, NOT share" do
               login_lti 'administrator'
               lti_group = @controller.user_session[:virtual_groups].first
               FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
@@ -929,7 +929,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).not_to render_template(:_share_resource)
               expect(response).to render_template(:_embed_checkout)
             end
-            it "others: should include only lti" do
+            it "others: should render checkout button in player, NOT share" do
               login_lti 'student'
               lti_group = @controller.user_session[:virtual_groups].first
               FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
@@ -959,7 +959,7 @@ describe MediaObjectsController, type: :controller do
               example.run
               Avalon::Authentication::Providers = providers
             end
-            it "should not include lti" do
+            it "should render checkout button in player, NOT share" do
               login_as(:administrator)
               get :show, params: { id: media_object.id }
               expect(response).not_to render_template(:_share_resource)


### PR DESCRIPTION
Hide embed menu when cdl is enabled and render "This item is unable to be embedded" for existing embeds now protected by cdl.