### PR TITLE
Perform pass through encode job later to ensure it runs on same server as subsequent polling jobs

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -270,7 +270,7 @@ class MasterFile < ActiveFedora::Base
       options[:outputs] = [{ label: 'high', url: input }]
     end
 
-    ActiveEncodeJobs::CreateEncodeJob.perform_now(input, id, options)
+    ActiveEncodeJobs::CreateEncodeJob.perform_later(input, id, options)
   end
 
   def input_path


### PR DESCRIPTION
The pass through encoding adapter creates directories and files on local disk that need to be read later when the encode is looked up in the polling job.  In the docker-compose environment with avalon and the background worker in separate containers the encode create and polling jobs need to be run on the same container so the files will be present.  Alternatively the work directory could be externalized and mounted into each container.  But it makes the most sense to run the create job as a background job because it is expensive and running it later on the background worker makes it align with non skip-transcoding encodes.

Fixes #4968 