### PR TITLE
Fix date sorting for paged_index datatables

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -63,7 +63,10 @@ class PlaylistsController < ApplicationController
     sort_column = params['order']['0']['column'].to_i rescue 0
     sort_direction = params['order']['0']['dir'] rescue 'asc'
     session[:playlist_sort] = [sort_column, sort_direction]
-    if columns[sort_column] != 'size'
+    if columns[sort_column] == 'created_at' || columns[sort_column] == 'updated_at'
+      @playlists = @playlists.order("#{columns[sort_column].downcase} #{sort_direction}")
+      @playlists = @playlists.offset(params['start']).limit(params['length'])
+    elsif columns[sort_column] != 'size'
       @playlists = @playlists.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
       @playlists = @playlists.offset(params['start']).limit(params['length'])
     else

--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -67,7 +67,10 @@ module Samvera
       sort_column = params['order']['0']['column'].to_i rescue 0
       sort_direction = params['order']['0']['dir'] == 'desc' ? 'desc' : 'asc' rescue 'asc'
       session[:presenter_sort] = [sort_column, sort_direction]
-      if columns[sort_column] != 'entry'
+      if columns[sort_column] == 'last_sign_in_at'
+        @presenter = @presenter.order("#{columns[sort_column].downcase} #{sort_direction}")
+        @presenter = @presenter.offset(params['start']).limit(params['length'])
+      elsif columns[sort_column] != 'entry'
         @presenter = @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
         @presenter = @presenter.offset(params['start']).limit(params['length'])
       end

--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -67,11 +67,11 @@ module Samvera
       sort_column = params['order']['0']['column'].to_i rescue 0
       sort_direction = params['order']['0']['dir'] == 'desc' ? 'desc' : 'asc' rescue 'asc'
       session[:presenter_sort] = [sort_column, sort_direction]
-      if columns[sort_column] == 'last_sign_in_at'
-        @presenter = @presenter.order("#{columns[sort_column].downcase} #{sort_direction}")
-      elsif columns[sort_column] != 'entry'
-        @presenter = @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
-      end
+      @presenter = if columns[sort_column] == 'last_sign_in_at'
+                     @presenter.order("#{columns[sort_column].downcase} #{sort_direction}")
+                   elsif columns[sort_column] != 'entry'
+                     @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
+                   end
       @presenter = @presenter.offset(params['start']).limit(params['length'])
 
       # Build json response

--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -69,11 +69,10 @@ module Samvera
       session[:presenter_sort] = [sort_column, sort_direction]
       if columns[sort_column] == 'last_sign_in_at'
         @presenter = @presenter.order("#{columns[sort_column].downcase} #{sort_direction}")
-        @presenter = @presenter.offset(params['start']).limit(params['length'])
       elsif columns[sort_column] != 'entry'
         @presenter = @presenter.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
-        @presenter = @presenter.offset(params['start']).limit(params['length'])
       end
+      @presenter = @presenter.offset(params['start']).limit(params['length'])
 
       # Build json response
       response = {

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -60,11 +60,10 @@ class TimelinesController < ApplicationController
     session[:timeline_sort] = [sort_column, sort_direction]
     if columns[sort_column] == 'updated_at'
       @timelines = @timelines.order("#{columns[sort_column].downcase} #{sort_direction}")
-      @timelines = @timelines.offset(params['start']).limit(params['length'])
     else
       @timelines = @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
-      @timelines = @timelines.offset(params['start']).limit(params['length'])
     end
+    @timelines = @timelines.offset(params['start']).limit(params['length'])
     response = {
       "draw": params['draw'],
       "recordsTotal": records_total,

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -58,11 +58,11 @@ class TimelinesController < ApplicationController
     sort_direction = params['order']['0']['dir'] rescue 'asc'
 
     session[:timeline_sort] = [sort_column, sort_direction]
-    if columns[sort_column] == 'updated_at'
-      @timelines = @timelines.order("#{columns[sort_column].downcase} #{sort_direction}")
-    else
-      @timelines = @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
-    end
+    @timelines = if columns[sort_column] == 'updated_at'
+                   @timelines.order("#{columns[sort_column].downcase} #{sort_direction}")
+                 else
+                   @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
+                 end
     @timelines = @timelines.offset(params['start']).limit(params['length'])
     response = {
       "draw": params['draw'],

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -58,8 +58,13 @@ class TimelinesController < ApplicationController
     sort_direction = params['order']['0']['dir'] rescue 'asc'
 
     session[:timeline_sort] = [sort_column, sort_direction]
-    @timelines = @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
-    @timelines = @timelines.offset(params['start']).limit(params['length'])
+    if columns[sort_column] == 'updated_at'
+      @timelines = @timelines.order("#{columns[sort_column].downcase} #{sort_direction}")
+      @timelines = @timelines.offset(params['start']).limit(params['length'])
+    else
+      @timelines = @timelines.order("lower(#{columns[sort_column].downcase}) #{sort_direction}, #{columns[sort_column].downcase} #{sort_direction}")
+      @timelines = @timelines.offset(params['start']).limit(params['length'])
+    end
     response = {
       "draw": params['draw'],
       "recordsTotal": records_total,

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -455,6 +455,89 @@ RSpec.describe PlaylistsController, type: :controller do
           get :show, params: { id: playlist.id }
           expect(response).to render_template(:_share_resource)
           expect(response).to_not render_template(:_lti_url)
+        end
+      end
+    end
+
+    describe "POST #paged_index" do
+      before do
+        login_as :user
+      end
+      before :each do
+        FactoryBot.reload
+        FactoryBot.create(:playlist, title: "aardvark", user: user)
+        FactoryBot.create_list(:playlist, 9, user: user)
+        FactoryBot.create(:playlist, title: "zzzebra", user: user)
+      end
+
+      context 'paging' do
+        let(:common_params) { { order: { '0': { column: 0, dir: 'asc' } }, search: { value: '' }, columns: { '5': { search: { value: '' } } } } }
+        it 'returns all results' do
+          post :paged_index, format: 'json', params: common_params.merge(start: 0, length: 20), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['recordsTotal']).to eq(11)
+          expect(parsed_response['data'].count).to eq(11)
+        end
+        it 'returns first page' do
+          post :paged_index, format: 'json', params: common_params.merge(start: 0, length: 10), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'].count).to eq(10)
+        end
+        it 'returns second page' do
+          post :paged_index, format: 'json', params: common_params.merge(start: 10, length: 10), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'].count).to eq(1)
+        end
+      end
+
+      context 'searching' do
+        let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
+        it "returns results filtered by title" do
+          post :paged_index, format: 'json', params: common_params.merge(search: { value: "aardvark" }, columns: { '5': { search: { value: '' } } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['recordsFiltered']).to eq(1)
+          expect(parsed_response['data'].count).to eq(1)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+        end
+      end
+
+      context 'sorting' do
+        let(:common_params) { { start: 0, length: 20, search: { value: '' }, columns: { '5': { search: { value: '' } } } } }
+        it "returns results sorted by title ascending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 0, dir: 'asc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+        end
+        it "returns results sorted by title descending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 0, dir: 'desc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+        end
+        it "returns results sorted by Created ascending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'asc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+        end
+        it "returns results sorted by Created descending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'desc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+        end
+        it "returns results sorted by Updated ascending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 4, dir: 'asc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+        end
+        it "returns results sorted by Updated descending" do
+          post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 4, dir: 'desc' } }), session: valid_session
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Playlist.all[10].comment}\" href=\"/playlists/11\">zzzebra</a>")
+          expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Playlist.all[0].comment}\" href=\"/playlists/1\">aardvark</a>")
         end
       end
     end

--- a/spec/controllers/samvera/persona/user_controller_spec.rb
+++ b/spec/controllers/samvera/persona/user_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
     before do
       sign_in(user)
       FactoryBot.create(:user, username: 'zzzebra', email: 'zzzebra@example.edu', last_sign_in_at: Time.new(2022,05,26), invitation_token: 'invited')
-      FactoryBot.create_list(:user, 10, last_sign_in_at: Time.new(2022,06,01))
+      FactoryBot.create_list(:user, 10, last_sign_in_at: Time.new(2022,05,24))
     end
 
     context 'paging' do
@@ -58,25 +58,25 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
 
     context 'filtering' do
       context 'username' do
-	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
-	it "returns results filtered by username" do
-	  post :paged_index, format: 'json', params: common_params.merge(search: { value: user.username })
-	  parsed_response = JSON.parse(response.body)
-	  expect(parsed_response['recordsFiltered']).to eq(1)
-	  expect(parsed_response['data'].count).to eq(1)
-	  expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">#{user.username}</a>")
-	end
+      	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 0, dir: 'asc' } } } }
+      	it "returns results filtered by username" do
+      	  post :paged_index, format: 'json', params: common_params.merge(search: { value: user.username })
+      	  parsed_response = JSON.parse(response.body)
+      	  expect(parsed_response['recordsFiltered']).to eq(1)
+      	  expect(parsed_response['data'].count).to eq(1)
+      	  expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">#{user.username}</a>")
+      	end
       end
 
       context 'email' do
-	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 'entry', dir: 'asc' } } } }
-	it "returns results filtered by email" do
-	  post :paged_index, format: 'json', params: common_params.merge(search: { value: 'zzzebra@example.edu' })
-	  parsed_response = JSON.parse(response.body)
-	  expect(parsed_response['recordsFiltered']).to eq(1)
-	  expect(parsed_response['data'].count).to eq(1)
-	  expect(parsed_response['data'][0][1]).to eq("<a href=\"/persona/users/2/edit\">zzzebra@example.edu</a>")
-	end
+      	let(:common_params) { { start: 0, length: 20, order: { '0': { column: 'entry', dir: 'asc' } } } }
+      	it "returns results filtered by email" do
+      	  post :paged_index, format: 'json', params: common_params.merge(search: { value: 'zzzebra@example.edu' })
+      	  parsed_response = JSON.parse(response.body)
+      	  expect(parsed_response['recordsFiltered']).to eq(1)
+      	  expect(parsed_response['data'].count).to eq(1)
+      	  expect(parsed_response['data'][0][1]).to eq("<a href=\"/persona/users/2/edit\">zzzebra@example.edu</a>")
+      	end
       end
     end
 
@@ -91,6 +91,19 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
 
       it "returns results sorted by username descending" do
         post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 0, dir: 'desc' } })
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/2/edit\">zzzebra</a>")
+        expect(parsed_response['data'][11][0]).to eq("<a href=\"/persona/users/1/edit\">aardvark</a>")
+      end
+
+      it "returns results sorted by last sign in ascending" do
+        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'asc' } })
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/1/edit\">aardvark</a>")
+        expect(parsed_response['data'][11][0]).to eq("<a href=\"/persona/users/2/edit\">zzzebra</a>")
+      end
+      it "returns results sorted by last sign in descending" do
+        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'desc' } })
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['data'][0][0]).to eq("<a href=\"/persona/users/2/edit\">zzzebra</a>")
         expect(parsed_response['data'][11][0]).to eq("<a href=\"/persona/users/1/edit\">aardvark</a>")

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -150,8 +150,8 @@ RSpec.describe TimelinesController, type: :controller do
     before :each do
       FactoryBot.reload
       FactoryBot.create(:timeline, title: 'aardvark', description: 'Aardvark lorem ipsum.', user: user)
-      FactoryBot.create(:timeline, title: 'zzzebra', description: 'Zzzebra lorem ipsum.', user: user)
       FactoryBot.create_list(:timeline, 9, user: user)
+      FactoryBot.create(:timeline, title: 'zzzebra', description: 'Zzzebra lorem ipsum.', user: user)
     end
 
     context 'paging' do
@@ -198,12 +198,24 @@ RSpec.describe TimelinesController, type: :controller do
         post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 0, dir: 'asc' } }), session: valid_session
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Timeline.all[0].description}\" href=\"/timelines/1\">aardvark</a>")
-        expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Timeline.all[1].description}\" href=\"/timelines/2\">zzzebra</a>")
+        expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Timeline.all[10].description}\" href=\"/timelines/11\">zzzebra</a>")
       end
       it "returns results sorted by title descending" do
         post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 0, dir: 'desc' } }), session: valid_session
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Timeline.all[1].description}\" href=\"/timelines/2\">zzzebra</a>")
+        expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Timeline.all[10].description}\" href=\"/timelines/11\">zzzebra</a>")
+        expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Timeline.all[0].description}\" href=\"/timelines/1\">aardvark</a>")
+      end
+      it "returns results sorted by Updated ascending" do
+        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'asc' } }), session: valid_session
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Timeline.all[0].description}\" href=\"/timelines/1\">aardvark</a>")
+        expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Timeline.all[10].description}\" href=\"/timelines/11\">zzzebra</a>")
+      end
+      it "returns results sorted by Updated descending" do
+        post :paged_index, format: 'json', params: common_params.merge(order: { '0': { column: 3, dir: 'desc' } }), session: valid_session
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['data'][0][0]).to eq("<a title=\"#{Timeline.all[10].description}\" href=\"/timelines/11\">zzzebra</a>")
         expect(parsed_response['data'][10][0]).to eq("<a title=\"#{Timeline.all[0].description}\" href=\"/timelines/1\">aardvark</a>")
       end
     end


### PR DESCRIPTION
Fixes #4963 

This PR fixes a bug where datatables would generate an error when attempting to sort by date columns (updated_at, created_at, etc.)  The error was first noticed on the playlists page, but I checked the implementation and it was present on the timelines and persona users pages as well. The root cause was it attempting to convert date/time formatted data to lowercase and that caused an internal server error. By setting up a case specifically for the date columns to not convert to lowercase, this issue should be resolved.