### PR TITLE
Convert utc dates to local time zone on client-side using moment.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,6 +41,7 @@
 //= require cropperjs/dist/cropper.min
 //= require url-search-params-polyfill/index.js
 
+//= require moment/min/moment-with-locales.min.js
 //= require hls.js/dist/hls.min.js
 
 // include all of our vendored js

--- a/app/assets/javascripts/localize_times.js
+++ b/app/assets/javascripts/localize_times.js
@@ -1,0 +1,6 @@
+// Requires moment.js
+$(document).ready(function () {
+  $('*[data-utc-time]').each(function() {
+    $(this).text(moment($(this).data('utc-time')).format('LLL'))
+  });
+});

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -117,8 +117,8 @@ class CheckoutsController < ApplicationController
     def user_array(checkout)
       [
         view_context.link_to(checkout.media_object.title, main_app.media_object_url(checkout.media_object)),
-        checkout.checkout_time.to_s(:long_ordinal_12h),
-        checkout.return_time.to_s(:long_ordinal_12h),
+        checkout.checkout_time.iso8601,
+        checkout.return_time.iso8601,
         time_remaining(checkout),
         checkout_actions(checkout)
       ]

--- a/app/views/checkouts/index.html.erb
+++ b/app/views/checkouts/index.html.erb
@@ -30,8 +30,8 @@
             <td><%= checkout.user.user_key %></td>
           <% end %>
           <td><%= link_to checkout.media_object.title, main_app.media_object_url(checkout.media_object) %></td>
-          <td><%= checkout.checkout_time.to_s(:long_ordinal_12h) %></td>
-          <td><%= checkout.return_time.to_s(:long_ordinal_12h) %></td>
+          <td><span data-utc-time="<%= checkout.checkout_time.iso8601 %>" /></td>
+          <td><span data-utc-time="<%= checkout.return_time.iso8601 %>" /></td>
           <td><%= distance_of_time_in_words(checkout.return_time - DateTime.current) %></td>
           <td>
             <% if checkout.return_time > DateTime.current %>

--- a/app/views/media_objects/_embed_checkout.html.erb
+++ b/app/views/media_objects/_embed_checkout.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <%= t('media_object.cdl.checkout_message').html_safe %>
         <%= render "checkout" %>
       <% else %>
-        <%= t('media_object.cdl.not_available_message', :date => @media_object.return_time.strftime("%m/%d/%Y"), :time => @media_object.return_time.strftime("%I:%M%p")).html_safe %>
+        <%= t('media_object.cdl.not_available_message', :time => @media_object.return_time.iso8601).html_safe %>
       <% end %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
     empty_share_section_permalink_notice: "After processing has started the section link will be available."
     cdl:
       checkout_message: "<p>Borrow this item to access media resources.</p>"
-      not_available_message: "<p>This resource is currently checked out by another user. </br></br> This item is due to be returned on </br> %{date} at %{time}.</p>"
+      not_available_message: "<p>This resource is currently checked out by another user. </br></br> This item is due to be returned on </br><span data-utc-time='%{time}' />.</p>"
       time_remaining: "<p>Time <br />remaining: </p>"
       unauthenticated_message: "<p>You are not signed in. You may be able to borrow this item after signing in.</p>"
       expire:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "cropperjs": "^1.5.5",
     "hls.js": "https://github.com/avalonmediasystem/hls.js#stricter_ts_probing",
+    "moment": "^2.29.4",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-bootstrap": "^1.0.0",

--- a/spec/views/checkouts/index.html.erb_spec.rb
+++ b/spec/views/checkouts/index.html.erb_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe "checkouts/index", type: :view do
     end
   end
   describe 'checkout and return time' do
-    it 'renders a human readable string' do
+    it 'renders UTC time in a span for JS conversion to local time zone' do
       render
-      assert_select "tr>td", text: checkouts.first.checkout_time.to_s(:long_ordinal_12h)
-      expect(rendered).to include('January 13th, 2000 12:00 PM')
+      assert_select "tr>td>span[data-utc-time=?]", checkouts.first.checkout_time.iso8601
+      assert_select "tr>td>span[data-utc-time=?]", checkouts.first.return_time.iso8601
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,6 +5093,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
With users potentially all over the world it makes sense to store checkout and return times in UTC in the database.  This is currently happening, but users will expect to see times in their local time zones.  There is no easy way to know what time zone a request is coming from without having users set a default time zone.  However, in the front end the browser can tell us the device's timezone.  This PR suggests passing the UTC time to the front end and then have javascript convert it into a localized time on page load.

Fixes #4981 
