### PR TITLE
Redirect unauthenticated users from checkouts page 

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -95,7 +95,7 @@ class CheckoutsController < ApplicationController
         @checkouts = if current_ability.is_administrator?
                        set_active_checkouts.or(Checkout.all.where("return_time <= now()"))
                      else
-                       set_active_checkouts.or(Checkout.returned_for_user(current_user.id))
+                       set_active_checkouts.or(Checkout.returned_for_user(current_user&.id))
                      end
       else
         @checkouts = set_active_checkouts

--- a/spec/requests/checkouts_spec.rb
+++ b/spec/requests/checkouts_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "/checkouts", type: :request do
       it "renders the restricted content page" do
         get checkouts_url
         expect(response).to render_template(:restricted_pid)
+        get checkouts_url, params: { display_returned: true }
+        expect(response).to render_template(:restricted_pid)
       end
     end
 


### PR DESCRIPTION
Fixes #4987 

This adds a safe navigation operator to the methods that assemble the current user's list of checkouts. Doing this prevents a nil class error for unauthenticated users and allows the `errors/restricted_pid` partial to render, directing the user to login to access the content.