### PR TITLE
Revert "Fix for ios fullscreen captions not displaying"

### DIFF
--- a/app/views/modules/player/_video_element.html.erb
+++ b/app/views/modules/player/_video_element.html.erb
@@ -22,9 +22,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 height="<%= @player_height || 270 %>"
                 data-canvasindex=0
                 poster="<%= section_info[:poster_image] if f_start == 0 %>"
-                preload="auto"
-                playsinline="true"
-                webkit-playsinline="true">
+                preload="auto">
           <% section_info[:stream_hls].each do |hls| %>
             <source src="<%= hls[:url] %>" type="application/x-mpegURL" data-quality="<%= hls[:quality] %>"/>
           <% end %>

--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1300,7 +1300,7 @@ Object.assign(_player.config, {
 
 	fullscreenText: null,
 
-	useFakeFullscreen: true
+	useFakeFullscreen: false
 });
 
 Object.assign(_player2.default.prototype, {
@@ -1461,10 +1461,6 @@ Object.assign(_player2.default.prototype, {
 			t.getElement(t.container).style.height = '100%';
 			t.setControlsSize();
 		}, 500);
-
-		if(_constants.IS_ANDROID || _constants.IS_IOS) {
-			t.getElement(t.container).querySelector('.' + t.options.classPrefix + 'overlay-button').style.display = 'none';
-		}
 
 		if (isNative) {
 			t.node.style.width = '100%';


### PR DESCRIPTION
Reverts avalonmediasystem/avalon#4953

Document this as a known issue with the workaround.