### PR TITLE
Change CDL message for existing embeds & re-add embed share tab

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -37,16 +37,12 @@ class MediaObjectsController < ApplicationController
   def self.is_lti_session ctx
     ctx.user_session.present? && ctx.user_session[:lti_group].present?
   end
-  def self.is_cdl_enabled ctx
-    ctx.instance_variable_get('@media_object').cdl_enabled?
-  end
 
   is_editor_or_not_lti = proc { |ctx| self.is_editor(ctx) || !self.is_lti_session(ctx) }
   is_editor_or_lti = proc { |ctx| (Avalon::Authentication::Providers.any? {|p| p[:provider] == :lti } && self.is_editor(ctx)) || self.is_lti_session(ctx) }
-  is_editor_or_not_lti_and_cdl_disabled = proc { |ctx| !self.is_cdl_enabled(ctx) && (self.is_editor(ctx) || !self.is_lti_session(ctx)) }
 
   add_conditional_partial :share, :share, partial: 'share_resource', if: is_editor_or_not_lti
-  add_conditional_partial :share, :embed, partial: 'embed_resource', if: is_editor_or_not_lti_and_cdl_disabled
+  add_conditional_partial :share, :embed, partial: 'embed_resource', if: is_editor_or_not_lti
   add_conditional_partial :share, :lti_url, partial: 'lti_url',  if: is_editor_or_lti
 
   def can_embed?

--- a/app/views/master_files/_cdl_embed.html.erb
+++ b/app/views/master_files/_cdl_embed.html.erb
@@ -28,8 +28,8 @@ Unless required by applicable law or agreed to in writing, software distributed
       left: 0;
       right: 0;
       bottom: 0;
-      height: 33px;
-      width: 50%
+      height: 45px;
+      width: 80%
     }
     .centered.video {
       height: 110px
@@ -38,6 +38,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <div>
     <div class="centered">
-      <p>This item cannot be embedded.</p>
+      <p>This item is no longer able to be embedded.<br/>
+         You may be able to view this item on
+         <%= link_to Settings.name, media_object_path(@master_file.media_object_id), target: :_blank %></p>
     </div>
   </div>

--- a/app/views/media_objects/_embed_resource.html.erb
+++ b/app/views/media_objects/_embed_resource.html.erb
@@ -16,7 +16,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% if section=='tab-content' %>
 
     <div class="tab-pane" id="embed-tab">
-      <% if @currentStream.present? %>
+      <% if @media_object.cdl_enabled?%>
+      <p>This item cannot be embedded.</p>
+      <% elsif @currentStream.present? %>
       <p class="muted">Copy the text below to embed this resource</p>
       <textarea class="col-md-12" rows="3" id="embed-part" onClick="this.select();" readonly="readonly"><%= @currentStream.embed_code(MasterFile::EMBED_SIZE[:medium], { urlappend: '/embed' }) %></textarea>
       <% else %>

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -269,7 +269,7 @@ describe MasterFilesController do
     context 'with cdl disabled' do
       before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(true) }
       before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(false) }
-      it "renders the authorize partial" do
+      it "renders the player" do
         expect(get(:embed, params: { id: master_file.id })).to render_template('master_files/_player')
       end
     end


### PR DESCRIPTION
This PR adds the `Embed` tab back to the `Share` menu for items with CDL enabled, replacing the iframe with the message "This item cannot be embedded". 

It also changes the message displayed in existing embeds after CDL is enabled to "This item is no longer able to be embedded. You may be able to view this item on * _Name of Service_ *", which links to the item's page in Avalon.