### PR TITLE
Remove checkout buttons for historical checkouts

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -133,9 +133,8 @@ class CheckoutsController < ApplicationController
     end
 
     def checkout_actions(checkout)
-      if checkout.return_time > DateTime.current
-        view_context.link_to('Return', return_checkout_url(checkout), class: 'btn btn-outline btn-xs', method: :patch)
-      end
+      return unless checkout.return_time > DateTime.current
+      view_context.link_to('Return', return_checkout_url(checkout), class: 'btn btn-outline btn-xs', method: :patch)
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -133,7 +133,7 @@ class CheckoutsController < ApplicationController
     end
 
     def checkout_actions(checkout)
-      return unless checkout.return_time > DateTime.current
+      return '' unless checkout.return_time > DateTime.current
       view_context.link_to('Return', return_checkout_url(checkout), class: 'btn btn-outline btn-xs', method: :patch)
     end
 

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -135,10 +135,6 @@ class CheckoutsController < ApplicationController
     def checkout_actions(checkout)
       if checkout.return_time > DateTime.current
         view_context.link_to('Return', return_checkout_url(checkout), class: 'btn btn-outline btn-xs', method: :patch)
-      elsif checkout.return_time < DateTime.current && checkout.media_object.lending_status == 'available'
-        view_context.link_to('Checkout', checkouts_url(params: { checkout: { media_object_id: checkout.media_object_id } }), class: 'btn btn-primary btn-xs', method: :post)
-      else
-        ''
       end
     end
 


### PR DESCRIPTION
As discussed [here](https://github.com/avalonmediasystem/avalon/pull/4989#discussion_r1038426498), it was decided that the only buttons in the checkouts table should be the `Return` button for currently active checkouts. All historical checkouts should have the final column be blank.