### PR TITLE
Use class instead of id since the id wasn't unique

### DIFF
--- a/app/assets/javascripts/move_section.js
+++ b/app/assets/javascripts/move_section.js
@@ -14,7 +14,7 @@
  * ---  END LICENSE_HEADER BLOCK  ---
 */
 
-$('#show_move_modal').on('click', function(){
+$('.show_move_modal').on('click', function(){
   $('#move_modal').show();
   var id = $(this).data('id');
   // Set the URL for form POST action

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -73,7 +73,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                           method: :delete %>
                     </span>
                     <span>
-                      <button id="show_move_modal" class="btn btn-sm btn-outline" data-id="<%= section.id %>"
+                      <button class="btn btn-sm btn-outline show_move_modal" data-id="<%= section.id %>"
                         data-toggle="modal" data-target="#move_modal">
                         Move
                       </button>


### PR DESCRIPTION
With multiple files associated with a media object attempting to move any files after the first would cause the form target url be for the media object instead of the file leading to a 500 ("ActiveFedora::ModelMismatch (Expected MasterFile. Got: MediaObject)")