### PR TITLE
Add structural metadata param to additional endpoints

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -82,7 +82,7 @@ class Admin::CollectionsController < ApplicationController
   # GET /collections/1/items
   def items
     mos = paginate @collection.media_objects
-    render json: mos.to_a.collect{|mo| [mo.id, mo.as_json(include_structure: params[:include_structure] == "true")] }.to_h
+    render json: mos.to_a.collect { |mo| [mo.id, mo.as_json(include_structure: params[:include_structure] == "true")] }.to_h
   end
 
   # POST /collections

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -82,7 +82,7 @@ class Admin::CollectionsController < ApplicationController
   # GET /collections/1/items
   def items
     mos = paginate @collection.media_objects
-    render json: mos.to_a.collect{|mo| [mo.id, mo.as_json] }.to_h
+    render json: mos.to_a.collect{|mo| [mo.id, mo.as_json(include_structure: params[:include_structure] == "true")] }.to_h
   end
 
   # POST /collections

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -321,7 +321,7 @@ class MediaObjectsController < ApplicationController
     mos = MediaObject.accessible_by(current_ability, :index)
     respond_to do |format|
       format.json {
-        paginate json: mos.to_a.collect{|mo| mo.as_json(include_structure: params[:include_structure] == "true") }
+        paginate json: mos.to_a.collect { |mo| mo.as_json(include_structure: params[:include_structure] == "true") }
       }
     end
   end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -318,9 +318,10 @@ class MediaObjectsController < ApplicationController
   end
 
   def index
+    mos = MediaObject.accessible_by(current_ability, :index)
     respond_to do |format|
       format.json {
-        paginate json: MediaObject.accessible_by(current_ability, :index)
+        paginate json: mos.to_a.collect{|mo| mo.as_json(include_structure: params[:include_structure] == "true") }
       }
     end
   end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -318,12 +318,8 @@ class MediaObjectsController < ApplicationController
   end
 
   def index
-    mos = MediaObject.accessible_by(current_ability, :index)
-    respond_to do |format|
-      format.json {
-        paginate json: mos.to_a.collect { |mo| mo.as_json(include_structure: params[:include_structure] == "true") }
-      }
-    end
+    mos = paginate MediaObject.accessible_by(current_ability, :index)
+    render json: mos.to_a.collect { |mo| mo.as_json(include_structure: params[:include_structure] == "true") }
   end
 
   def show

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -274,6 +274,27 @@ describe Admin::CollectionsController, type: :controller do
       #TODO add check that mediaobject is serialized to json properly
     end
 
+    context "with structure" do
+      let!(:mf_1) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[0]) }
+      let!(:mf_2) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[1]) }
+      
+      it "should not return structure by default" do
+        get 'items', params: { id: collection.id, format: 'json' }
+        expect(JSON.parse(response.body)[collection.media_objects[0].id]["files"][0]["structure"]).to be_blank
+        expect(JSON.parse(response.body)[collection.media_objects[1].id]["files"][0]["structure"]).to be_blank
+      end
+      it "should return structure if requested" do
+        get 'items', params: { id: collection.id, format: 'json', include_structure: true }
+        expect(JSON.parse(response.body)[collection.media_objects[0].id]["files"][0]["structure"]).to eq mf_1.structuralMetadata.content
+        expect(JSON.parse(response.body)[collection.media_objects[1].id]["files"][0]["structure"]).to eq mf_2.structuralMetadata.content
+      end
+      it "should not return structure if requested" do
+        get 'items', params: { id: collection.id, format: 'json', include_structure: false}
+        expect(JSON.parse(response.body)[collection.media_objects[0].id]["files"][0]["structure"]).not_to eq mf_1.structuralMetadata.content
+        expect(JSON.parse(response.body)[collection.media_objects[1].id]["files"][0]["structure"]).not_to eq mf_2.structuralMetadata.content
+      end
+    end
+
     context 'user is a collection manager' do
       let(:manager) { FactoryBot.create(:manager) }
       before(:each) do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -665,6 +665,22 @@ describe MediaObjectsController, type: :controller do
         expect(json.second['published']).to eq(private_media_object.published?)
         expect(json.second['summary']).to eq(private_media_object.abstract)
       end
+
+      context "with structure" do
+        let!(:master_file) { FactoryBot.create(:master_file, :with_structure, media_object: media_object) }
+        it "should not return structure by default" do
+          get 'index', params: {  format: 'json' }
+          expect(json.first["files"][0]["structure"]).to be_blank
+        end
+        it "should return structure if requested" do
+          get 'index', params: { format: 'json', include_structure: true }
+          expect(json.first["files"][0]["structure"]).to eq master_file.structuralMetadata.content
+        end
+        it "should not return structure if requested" do
+          get 'index', params: { format: 'json', include_structure: false}
+          expect(json.first["files"][0]["structure"]).not_to eq master_file.structuralMetadata.content
+        end
+      end
     end
 
     context 'user is not an administrator' do


### PR DESCRIPTION
Fixes #4928

This PR adds the `include_structure` parameter to the `/admin/collections/:id/items.json` and `/media_objects.json` end points. Avalon should now return structural metadata, when requested, for all API endpoints that return media objects.