### PR TITLE
Allow file uris to include ? or # in filename

### DIFF
--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -74,7 +74,9 @@ class FileLocator
     when 's3'
       S3File.new(uri).object.presigned_url(:get)
     when 'file'
-      Addressable::URI.unencode(uri.path)
+      # In case file name includes ? or # use full uri omitting components before path
+      # instead of using only path which would miss query or fragment components
+      Addressable::URI.unencode(uri.omit(:scheme, :user, :password, :host, :port))
     else
       @uri.to_s
     end

--- a/spec/services/file_locator_spec.rb
+++ b/spec/services/file_locator_spec.rb
@@ -65,6 +65,14 @@ describe FileLocator, type: :service do
         expect(locator.attachment).to eq file
       end
     end
+
+    context "filename with reserved characters" do
+      let(:path) { "/path/to/file?#.mp4" }
+
+      it "should return the correct location" do
+        expect(locator.location).to eq path
+      end
+    end
   end
 
   describe "s3 file" do


### PR DESCRIPTION
In case file name includes ? or # use full uri omitting components before path instead of using only path which would miss query or fragment components

This was found in production where `Report from the Statehouse WTTV (#720-20-1977_5-1.mp4Edited).mp4` became truncated because of the portion to the right of the `#` being interpreted as the `fragment` of the uri and not part of the `path`.  So `uri.path` was `Report from the Statehouse WTTV (`.