### PR TITLE
Add ability to display full filenames on the media object edit page

### DIFF
--- a/app/assets/javascripts/expand_filename.js
+++ b/app/assets/javascripts/expand_filename.js
@@ -1,0 +1,15 @@
+function expandFilename(id) {
+  var trunc = document.getElementById("truncated_" + id);
+  var full = document.getElementById("full_" + id);
+  var expand = document.getElementById("expand_" + id);
+
+  if (full.style.display === "none") {
+    full.style.display = "";
+    trunc.style.display = "none";
+    expand.innerHTML = "(Show less)";
+  } else {
+    full.style.display = "none";
+    trunc.style.display = "";
+    expand.innerHTML = "(Expand)"
+  }
+}

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -842,6 +842,14 @@ h5.card-title {
       float: right;
       width: auto;
     }
+
+    /*
+    Override default d-flex behavior to display
+    media object edit page buttons properly
+    */
+    .d-flex {
+      gap: 5px;
+    }
   }
 
   .file-upload {
@@ -1276,11 +1284,3 @@ td {
   position: relative;
 }
 /* End of CDL controls on view page styles */
-
-/*
-Override default d-flex behavior to display
-media object edit page buttons properly
-*/
-.d-flex {
-  gap: 5px;
-}

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -409,7 +409,7 @@ a[data-trigger='submit'] {
     margin-top: 10px;
     margin-bottom: 10px;
   }
-  
+
   @include media-breakpoint-down(sm) {
     margin-top: 1rem;
     padding: 0;
@@ -1276,3 +1276,11 @@ td {
   position: relative;
 }
 /* End of CDL controls on view page styles */
+
+/*
+Override default d-flex behavior to display
+media object edit page buttons properly
+*/
+.d-flex {
+  gap: 5px;
+}

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -48,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
             <div class="associated-files-block">
               <div class="associated-files-top-row row">
                 <!-- Icon -->
-                <div class="col-xs-8">
+                <div class="col-md-9 col-xs-8">
                   <span>
                     <% case section.file_format
                     when 'Sound' %>
@@ -75,7 +75,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                     </span>
                   <% end %>
                 </div>
-                <div class="col-xs-4 float-right">
+                <div class="col-md-3 col-xs-4 d-flex justify-content-end">
                   <% if can? :edit, @media_object %>
                     <span>
                       <%= link_to 'Delete'.html_safe,

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -59,8 +59,21 @@ Unless required by applicable law or agreed to in writing, software distributed
                     <i class="fa fa-question-sign"></i>
                     <% end %>
                   </span>
-                  <span class="mediaobject-filename"><%= section.title || truncate_center(File.basename(section.file_location.to_s), 30, 10) %></span>
+                  <% filename = section.title || File.basename(section.file_location.to_s) %>
+                  <span class="mediaobject-filename" id= <%= "truncated_#{section.id}" %> title=<%= filename %>>
+                    <%= section.title || truncate_center(File.basename(section.file_location.to_s), 30, 10) %>
+                  </span>
+                  <span class="mediaobject-filename" id= <%= "full_#{section.id}" %> style="display: none;" title=<%= filename %>>
+                    <%= filename %>
+                  </span>
                   <span><%= number_to_human_size(section.file_size) %></span>
+                  <% if filename.length > 30 %>
+                    <span>
+                      <button class="btn btn-sm" id=<%= "expand_#{section.id}" %> onclick=<%="expandFilename('#{section.id}')"%>>
+                        (Expand)
+                      </button>
+                    </span>
+                  <% end %>
                 </div>
                 <div class="col-xs-4 float-right">
                   <% if can? :edit, @media_object %>
@@ -79,7 +92,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                       </button>
                     </span>
                     <span>
-                      <button id="<%="edit_section_#{section.id}"%>" class="btn btn-sm btn-primary" onclick="return false;" data-toggle="collapse" 
+                      <button id="<%="edit_section_#{section.id}"%>" class="btn btn-sm btn-primary" onclick="return false;" data-toggle="collapse"
                               data-target="<%="#collapseExample#{section.id}"%>" data-section-id="<%= section.id %>" aria-expanded="false" aria-controls="collapseExample">
                         Edit
                       </button>
@@ -311,7 +324,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-     $('.filedata').change(function (e) {
+    $('.filedata').change(function (e) {
       e.preventDefault();
       $(this).closest('form').submit();
     });


### PR DESCRIPTION
Resolves #5025 

This PR adds hover text and an expand/show less option to filenames on the Media Object edit page.

The expand/show less option only renders on filenames that get truncated.
![Screenshot_20230203_121734](https://user-images.githubusercontent.com/68433277/216666781-c824669c-dde2-4c41-a929-1984b875c00b.png)

![Screenshot_20230203_121750](https://user-images.githubusercontent.com/68433277/216666790-89bcd0bf-fb16-4b3e-8632-7a3e025bc7e8.png)
