### PR TITLE
Fix development mode for rails 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for building gems
-FROM        ruby:3.1-bullseye as bundle
+FROM        ruby:3.2-bullseye as bundle
 LABEL       stage=build
 LABEL       project=avalon
 RUN        apt-get update && apt-get upgrade -y build-essential && apt-get autoremove \
@@ -30,7 +30,7 @@ RUN         bundle config set --local without 'production' \
 
 
 # Download binaries in parallel
-FROM        ruby:3.1-bullseye as download
+FROM        ruby:3.2-bullseye as download
 LABEL       stage=build
 LABEL       project=avalon
 RUN         curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz | tar xvz -C /usr/bin/
@@ -43,7 +43,7 @@ RUN      apt-get -y update && apt-get install -y ffmpeg
 
 
 # Base stage for building final images
-FROM        ruby:3.1-slim-bullseye as base
+FROM        ruby:3.2-slim-bullseye as base
 LABEL       stage=build
 LABEL       project=avalon
 RUN         echo "deb     http://ftp.us.debian.org/debian/    bullseye main contrib non-free"  >  /etc/apt/sources.list.d/bullseye.list \

--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,6 @@ group :development do
   # Use Bixby instead of rubocop directly
   gem 'bixby', require: false
   gem 'web-console'
-  gem 'xray-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1012,8 +1012,6 @@ GEM
       rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    xray-rails (0.3.2)
-      rails (>= 3.1.0)
     zeitwerk (2.6.7)
     zk (1.10.0)
       zookeeper (~> 1.5.0)
@@ -1150,7 +1148,6 @@ DEPENDENCIES
   webmock (~> 3.5)
   webpacker
   with_locking
-  xray-rails
   zk
   zoom
 


### PR DESCRIPTION
`xray-rails` hasn't been updated to work with rails 7 and breaks rendering.
Also update the `Dockerfile` to use ruby 3.2 base images.