### PR TITLE
Fix two bugs in JSON update API

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -173,14 +173,17 @@ class MediaObjectsController < ApplicationController
   end
 
   def update_media_object
-    begin
-      collection = Admin::Collection.find(api_params[:collection_id])
-    rescue ActiveFedora::ObjectNotFoundError
-      render json: { errors: ["Collection not found for #{api_params[:collection_id]}"] }, status: 422
-      return
+    if (api_params[:collection_id].present?)
+      begin
+        collection = Admin::Collection.find(api_params[:collection_id])
+      rescue ActiveFedora::ObjectNotFoundError
+        render json: { errors: ["Collection not found for #{api_params[:collection_id]}"] }, status: 422
+        return
+      end
+      
+      @media_object.collection = collection
     end
 
-    @media_object.collection = collection
     @media_object.avalon_uploader = 'REST API'
 
     populate_from_catalog = (!!api_params[:import_bib_record] && media_object_parameters[:bibliographic_id].present?)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -165,6 +165,11 @@ class Ability
         # anyone who can edit a media_object can also push it
         can? :edit, media_object
       end
+
+      can :json_update, MediaObject do |media_object|
+        # anyone who can edit a media_object can also update it via the API
+        is_api_request? && can?(:edit, media_object)
+      end
     end
   end
 


### PR DESCRIPTION
- Make `collection_id` optional in updates
- Allow `:json_update, media_object` for all users who can `:edit, media_object`

I couldn't figure out how to create test cases for these because I've been away from Rails/Rspec for so long and there don't seem to be any existing test cases for JSON updates via the API to base them off of.