### PR TITLE
Use old namespace for bibframe property to align with pre-existing data

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -34,7 +34,7 @@ class Admin::Collection < ActiveFedora::Base
   property :name, predicate: ::RDF::Vocab::DC.title, multiple: false do |index|
     index.as :stored_sortable
   end
-  property :unit, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false do |index|
+  property :unit, predicate: Avalon::RDFVocab::Bibframe.heldBy, multiple: false do |index|
     index.as :stored_sortable
   end
   property :description, predicate: ::RDF::Vocab::DC.description, multiple: false do |index|

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -72,5 +72,9 @@ module Avalon
       property :identifier, "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
       property :locator,    "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
     end
+
+    class Bibframe < RDF::StrictVocabulary("http://bibframe.org/vocab/")
+      property :heldBy,   "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
+    end
   end
 end


### PR DESCRIPTION
Resolves #5074 

It looks like `rdf-vocab` updated the Bibframe vocabulary including changing the URI namespace for properties.  This PR allows us to use the old namespace.

Existing data: <http://bibframe.org/vocab/heldBy>
Newer `rdf-vocab`: <http://id.loc.gov/ontologies/bibframe/heldBy>