### PR TITLE
Ensure MODS data is indexed when media object is indexed

### DIFF
--- a/app/helpers/upload_form_helper.rb
+++ b/app/helpers/upload_form_helper.rb
@@ -27,13 +27,14 @@ module UploadFormHelper
     if direct_upload?
       bucket = Aws::S3::Bucket.new(name: Settings.encoding.masterfile_bucket)
       direct_post = bucket.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: '201')
+      upload_form_url = direct_post.url
       if Settings.minio.present? && Settings.minio.public_host.present?
-        direct_post.url.sub!(Settings.minio.endpoint, Settings.minio.public_host)
+        upload_form_url = direct_post.url.sub(Settings.minio.endpoint, Settings.minio.public_host)
       end
       {
         'form-data' => (direct_post.fields),
-        'url' => direct_post.url,
-        'host' => Addressable::URI.parse(direct_post.url).host
+        'url' => upload_form_url,
+        'host' => Addressable::URI.parse(upload_form_url).host
       }
     else
       {}

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -240,7 +240,7 @@ class MediaObject < ActiveFedora::Base
   end
 
   def to_solr(include_child_fields: false)
-    super.tap do |solr_doc|
+    descMetadata.to_solr(super).tap do |solr_doc|
       solr_doc[ActiveFedora.index_field_mapper.solr_name("workflow_published", :facetable, type: :string)] = published? ? 'Published' : 'Unpublished'
       solr_doc[ActiveFedora.index_field_mapper.solr_name("collection", :symbol, type: :string)] = collection.name if collection.present?
       solr_doc[ActiveFedora.index_field_mapper.solr_name("unit", :symbol, type: :string)] = collection.unit if collection.present?


### PR DESCRIPTION
Fixes #5073

For some reason `descMetadata#to_solr` was only being called and included in the parent media object's solr document if it had already been loaded.  For example:
```
media_object = MediaObject.find(id)
media_object.to_solr["title_tesi"] # nil
#
media_object = MediaObject.find(id)
media_object.title # "Moomin"
media_object.to_solr["title_tesi"] # "Moomin"
```

Also included in this PR is a bugfix I found locally having to do with a modification of a frozen string.