### PR TITLE
Prevent reification when requesting manifest

### DIFF
--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -87,9 +87,6 @@ class Derivative < ActiveFedora::Base
 
   def to_solr
     super.tap do |solr_doc|
-      solr_doc['format_ss'] = self.format
-      solr_doc['mime_type_ss'] = self.mime_type.nil? ? "Nil" : self.mime_type
-      solr_doc['bitrate_is'] = self.bitrate
       solr_doc['stream_path_ssi'] = if location_url&.start_with?("rtmp")
                                       location_url.split(/:/).last
                                     else

--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -87,6 +87,9 @@ class Derivative < ActiveFedora::Base
 
   def to_solr
     super.tap do |solr_doc|
+      solr_doc['format_ss'] = self.format
+      solr_doc['mime_type_ss'] = self.mime_type.nil? ? "Nil" : self.mime_type
+      solr_doc['bitrate_is'] = self.bitrate
       solr_doc['stream_path_ssi'] = if location_url&.start_with?("rtmp")
                                       location_url.split(/:/).last
                                     else

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -38,9 +38,9 @@ class IiifCanvasPresenter
   end
 
   def sequence_rendering
-    [{ 
-      "@id" => "#{@master_file.waveform_master_file_url(@master_file.id)}.json", 
-      "type" => "Dataset", 
+    [{
+      "@id" => "#{@master_file.waveform_master_file_url(@master_file.id)}.json",
+      "type" => "Dataset",
       "label" => { "en" => ["waveform.json"] },
       "format" => "application/json"
     }]
@@ -144,7 +144,11 @@ class IiifCanvasPresenter
       # in which case SyntaxError shall be prompted to the user during file upload.
       # This can be done by defining some XML schema to require that at least one Div/Span child node exists
       # under root or each Div node, otherwise Nokogiri::XML parser will report error, and raise exception here.
-      @structure_ng_xml ||= (s = master_file.structuralMetadata.content).nil? ? Nokogiri::XML(nil) : Nokogiri::XML(s)
+      @structure_ng_xml ||= if master_file.has_structuralMetadata?
+                              Nokogiri::XML(master_file.structuralMetadata.content)
+                            else
+                              Nokogiri::XML(nil)
+                            end
     end
 
     def auth_service(quality)

--- a/app/presenters/speedy_af/proxy/derivative.rb
+++ b/app/presenters/speedy_af/proxy/derivative.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2022, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class SpeedyAF::Proxy::Derivative < SpeedyAF::Base
-  self.defaults = { video_bitrate: 0, video_codec: nil, mime_type: nil }
+  self.defaults = { video_bitrate: nil, video_codec: nil, mime_type: nil }
 
   def bitrate
     audio_bitrate.to_i + video_bitrate.to_i

--- a/app/presenters/speedy_af/proxy/derivative.rb
+++ b/app/presenters/speedy_af/proxy/derivative.rb
@@ -1,0 +1,21 @@
+# Copyright 2011-2022, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class SpeedyAF::Proxy::Derivative < SpeedyAF::Base
+  self.defaults = { video_bitrate: 0, video_codec: nil, mime_type: nil }
+
+  def bitrate
+    audio_bitrate.to_i + video_bitrate.to_i
+  end
+end

--- a/spec/presenters/speedy_af/proxy/derivative_spec.rb
+++ b/spec/presenters/speedy_af/proxy/derivative_spec.rb
@@ -1,0 +1,43 @@
+# Copyright 2011-2022, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe SpeedyAF::Proxy::Derivative do
+  let(:derivative) { FactoryBot.create(:derivative) }
+  before(:each) do
+    derivative.video_codec = nil
+    derivative.video_bitrate = nil
+    derivative.mime_type = nil
+    derivative.save
+  end
+  subject(:presenter) { described_class.find(derivative.id) }
+
+  describe "#defaults" do
+    it "sets video_bitrate to nil" do
+      expect(subject.inspect).to include("video_bitrate")
+      expect(subject.video_bitrate).to be_nil
+    end
+
+    it "sets video_codec to nil" do
+      expect(subject.inspect).to include("video_codec")
+      expect(subject.video_codec).to be_nil
+    end
+
+    it "sets mime_type to nil" do
+      expect(subject.inspect).to include("mime_type")
+      expect(subject.mime_type).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This PR attempts to keep IIIF manifest generation from reifying any files.

The two areas causing reification are: 

- Requesting the structural metadata. The structural metadata is contained in an XML file as a subresource of the master file and I don't think it is possible to prevent the reification here. However, what I found is that reification was happening even for master files that do not have structural metadata. This PR adds a check of `has_structuralMetadata?` (which is in the SpeedyAF proxy) so that reification only occurs when a master file actually has structural metadata.
- Retrieving information from the Derivative. When the IIIF manifest is generated it pulls the `derivative.bitrate`, `derivative.mime_type`, and `derivative.format`. None of these fields were available from the SpeedyAF proxy so it would trigger reification. This PR adds all three fields to the Derivative `to_solr` function so that they are available from the proxy. This is problematic for the `mime_type` though as assigning it seems to be commented out, as can be seen [here](https://github.com/avalonmediasystem/avalon/blob/941b660b2da9d9c7f1c4fbc98fd8fdc9e5fbd213/app/models/master_file.rb#L299) and [here](https://github.com/avalonmediasystem/avalon/blob/941b660b2da9d9c7f1c4fbc98fd8fdc9e5fbd213/app/models/derivative.rb#L105). I do not know if that work has been done but for the items I tested with the `mime_type` was `nil`. When a solr field is `nil` SpeedyAF skips that field, so I check if `derivative.mime_type = nil` and insert the string "nil". This is sloppy and I am not sure of the full implications of handling it this way. Do we need to include `mime_type` at all if assigning it to the Derivative is commented out? Should it be getting assigned elsewhere?