### PR TITLE
Strip out all unquoted colons

### DIFF
--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe SearchBuilder do
       expect(subject.only_published_items({})).to eq "test:clause OR workflow_published_sim:\"Published\""
     end
   end
+
+  describe "#strip_extra_colons" do
+    it "should remove all unquoted colons" do
+      expect(subject.strip_extra_colons({q: "a : b : c : d"})).to eq "a  b  c  d"
+      expect(subject.strip_extra_colons({q: "\"a : b\" : c : d"})).to eq "\"a : b\"  c  d"
+    end
+  end
 end


### PR DESCRIPTION
This fixes a problem we saw in production where searching for `"[Clio : 1983 Clio international preliminaries : Craft : Classic : Misc]"` works but `[Clio : 1983 Clio international preliminaries : Craft : Classic : Misc]` does not return any results.  Interestingly this does not seem to be a problem with Solr 8 (we're currently running solr 6).  This PR works around the problem by removing all colons from the search query that aren't inside of a quoted phrase.