### PR TITLE
Enqueue media object indexing job when media object and children are reindexed

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -165,6 +165,7 @@ class MasterFile < ActiveFedora::Base
   before_destroy :stop_processing!
   before_destroy :update_parent!
   define_hooks :after_transcoding, :after_processing
+  after_update_index { |mf| mf.media_object&.enqueue_long_indexing }
 
   # Generate the waveform after proessing is complete but before master file management
   after_transcoding :generate_waveform

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -836,4 +836,19 @@ describe MasterFile do
       end
     end
   end
+
+  describe 'indexing' do
+    let(:master_file) { FactoryBot.build(:master_file, :with_media_object) }
+
+    before do
+      # Force creation of master_file and then clear queue of byproduct jobs
+      master_file
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    it 'enqueues indexing of parent media object' do
+      master_file.update_index
+      expect(MediaObjectIndexingJob).to have_been_enqueued.with(master_file.media_object.id)
+    end
+  end
 end


### PR DESCRIPTION
This should solve the case where a structure is updated or a section title is updated without saving the parent media object.  Also moving the enqueueing of the background job to the after_update_index callback for media objects (from `to_solr`) should ensure it isn't enqueued when the media object isn't actually getting reindexed.