### PR TITLE
Strip out childless paths from structural metadata to ensure valid manifest

### DIFF
--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -56,4 +56,62 @@ describe IiifCanvasPresenter do
       end
     end
   end
+
+  describe '#range' do
+    let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Div 1"><Span label="Span 1" begin="00:00:00.000" end="00:00:01.235"/></Div></Item>' }
+
+    subject { presenter.range }
+
+    before do
+      master_file.structuralMetadata.content = structure_xml
+    end
+
+    it 'converts stored xml into IIIF ranges' do
+      expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+      expect(subject.items.size).to eq 1
+      expect(subject.items.first.label.to_s).to eq '{"none"=>["Div 1"]}'
+      expect(subject.items.first.items.size).to eq 1
+      expect(subject.items.first.items.first.label.to_s).to eq '{"none"=>["Span 1"]}'
+      expect(subject.items.first.items.first.items.size).to eq 1
+      expect(subject.items.first.items.first.items.first).to be_a IiifCanvasPresenter
+      expect(subject.items.first.items.first.items.first.media_fragment).to eq 't=0.0,1.235'
+    end
+
+    context 'with no structural metadata' do
+      let(:structure_xml) { "" }
+
+      it 'autogenerates a basic range' do
+	expect(subject.label.to_s).to eq "{\"none\"=>[\"#{master_file.embed_title}\"]}"
+	expect(subject.items.size).to eq 1
+	expect(subject.items.first).to be_a IiifCanvasPresenter
+        expect(subject.items.first.media_fragment).to eq 't=0,'
+      end
+    end
+
+    context 'with invalid structural metadata' do
+      let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Bad"/><Div label="Div 1"><Div label="Also bad"/><Span label="Span 1" begin="00:00:00.000" end="00:00:01.235"/></Div></Item>' }
+
+      it 'removes ranges without descendant canvases' do
+	expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+	expect(subject.items.size).to eq 1
+	expect(subject.items.first.label.to_s).to eq '{"none"=>["Div 1"]}'
+	expect(subject.items.first.items.size).to eq 1
+	expect(subject.items.first.items.first.label.to_s).to eq '{"none"=>["Span 1"]}'
+	expect(subject.items.first.items.first.items.size).to eq 1
+	expect(subject.items.first.items.first.items.first).to be_a IiifCanvasPresenter
+	expect(subject.items.first.items.first.items.first.media_fragment).to eq 't=0.0,1.235'
+      end
+
+      context 'when there are no valid ranges' do
+        let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Div 1"/></Item>' }
+
+        it 'autogenerates a basic range but preserves the root level label' do
+	  expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+	  expect(subject.items.size).to eq 1
+	  expect(subject.items.first).to be_a IiifCanvasPresenter
+	  expect(subject.items.first.media_fragment).to eq 't=0,'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
These changes ensure a valid IIIF manifest is returned when the stored XML structural metadata contains blank divs.  This allows the SME to load instead of erroring.

This PR leaves the Error in place but it really shouldn't be raised.  Do you think it should be removed?

Related to https://github.com/avalonmediasystem/react-structural-metadata-editor/issues/176