### PR TITLE
Fix no-icon thumbnail height in browse

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -22,6 +22,10 @@
   max-width: 160px;
 }
 
+.no-icon img, img.no-icon {
+  max-height: 90px;
+}
+
 .btn-outline-primary {
   @extend .btn-sm;
   @extend .btn-outline;

--- a/app/views/catalog/_thumbnail_media_object.html.erb
+++ b/app/views/catalog/_thumbnail_media_object.html.erb
@@ -20,6 +20,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= image_tag( image_url ) %>
     <% end %>
   <% else %>
-    <%= image_tag 'no_icon.png', class: 'result-thumbnail' %>
+    <%= image_tag 'no_icon.png', class: 'result-thumbnail no-icon' %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes [AvalonIU/Avalon#126](https://github.iu.edu/AvalonIU/Avalon/issues/126)