### PR TITLE
Handle invalid URI errors

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -13,6 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class Admin::CollectionsController < ApplicationController
+  include NoidValidator
   include Rails::Pagination
 
   before_action :authenticate_user!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,6 @@ class ApplicationController < ActionController::Base
   include Hydra::Controller::ControllerBehavior
   # To deal with a load order issue breaking persona impersonate
   include Samvera::Persona::BecomesBehavior
-  include Identifier
   layout 'avalon'
 
   # Prevent CSRF attacks by raising an exception.
@@ -184,22 +183,6 @@ class ApplicationController < ActionController::Base
     else
       # m3u8 request
       head 410
-    end
-  end
-
-  rescue_from URI::InvalidURIError do |exception|
-    # Strip all non-alphanumeric characters from passed in NOID
-    noid_id = params[:id]&.gsub(/[^A-Za-z0-9]/, '')
-
-    # If cleaned NOID is valid, redo the request. Otherwise generate an error page.
-    if noid_service.valid?(noid_id)
-      redirect_to(request.parameters.merge(id: noid_id))
-    else
-      if request.format == :json
-        render json: {errors: ["#{params[:id]} not found"]}, status: 404
-      else
-        render '/errors/unknown_pid', status: 404
-      end
     end
   end
 

--- a/app/controllers/concerns/noid_validator.rb
+++ b/app/controllers/concerns/noid_validator.rb
@@ -1,0 +1,39 @@
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module NoidValidator
+  extend ActiveSupport::Concern
+
+  include Identifier
+
+  included do
+    before_action :validate_noid, only: [:show]
+  end
+
+  private
+
+  def validate_noid
+    return if noid_service.valid?(params[:id])
+
+    # Strip all non-alphanumeric characters from passed in NOID
+    noid_id = params[:id]&.gsub(/[^A-Za-z0-9]/, '')
+
+    # If cleaned NOID is valid, redo the request. Otherwise raise error.
+    if noid_service.valid?(noid_id)
+      redirect_to(request.parameters.merge(id: noid_id))
+    else
+      raise ActiveFedora::ObjectNotFoundError
+    end
+  end
+end

--- a/app/controllers/concerns/noid_validator.rb
+++ b/app/controllers/concerns/noid_validator.rb
@@ -23,17 +23,14 @@ module NoidValidator
 
   private
 
-  def validate_noid
-    return if noid_service.valid?(params[:id])
+    def validate_noid
+      return if noid_service.valid?(params[:id])
 
-    # Strip all non-alphanumeric characters from passed in NOID
-    noid_id = params[:id]&.gsub(/[^A-Za-z0-9]/, '')
+      # Strip all non-alphanumeric characters from passed in NOID
+      noid_id = params[:id]&.gsub(/[^A-Za-z0-9]/, '')
 
-    # If cleaned NOID is valid, redo the request. Otherwise raise error.
-    if noid_service.valid?(noid_id)
-      redirect_to(request.parameters.merge(id: noid_id))
-    else
-      raise ActiveFedora::ObjectNotFoundError
+      # If cleaned NOID is valid, redo the request. Otherwise raise error.
+      raise ActiveFedora::ObjectNotFoundError if !noid_service.valid?(noid_id)
+      redirect_to(request.parameters.merge(:only_path => true, id: noid_id))
     end
-  end
 end

--- a/app/controllers/concerns/noid_validator.rb
+++ b/app/controllers/concerns/noid_validator.rb
@@ -29,8 +29,8 @@ module NoidValidator
       # Strip all non-alphanumeric characters from passed in NOID
       noid_id = params[:id]&.gsub(/[^A-Za-z0-9]/, '')
 
-      # If cleaned NOID is valid, redo the request. Otherwise raise error.
-      raise ActiveFedora::ObjectNotFoundError if !noid_service.valid?(noid_id)
-      redirect_to(request.parameters.merge(:only_path => true, id: noid_id))
+      # If cleaned NOID is not valid raise error, otherwise redirect request.
+      raise ActiveFedora::ObjectNotFoundError unless noid_service.valid?(noid_id)
+      redirect_to(request.parameters.merge(id: noid_id))
     end
 end

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -18,6 +18,7 @@ include SecurityHelper
 
 class MasterFilesController < ApplicationController
   # include Avalon::Controller::ControllerBehavior
+  include NoidValidator
 
   before_action :authenticate_user!, :only => [:create]
   before_action :set_masterfile, except: [:create, :oembed]

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -20,6 +20,7 @@ class MediaObjectsController < ApplicationController
   include Avalon::Workflow::WorkflowControllerBehavior
   include Avalon::Controller::ControllerBehavior
   include ConditionalPartials
+  include NoidValidator
   include SecurityHelper
 
   before_action :authenticate_user!, except: [:show, :set_session_quality, :show_stream_details, :manifest]
@@ -180,7 +181,7 @@ class MediaObjectsController < ApplicationController
         render json: { errors: ["Collection not found for #{api_params[:collection_id]}"] }, status: 422
         return
       end
-      
+
       @media_object.collection = collection
     end
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -258,6 +258,18 @@ describe Admin::CollectionsController, type: :controller do
         expect(JSON.parse(response.body)["errors"].first.class).to eq String
       end
     end
+
+    context 'misformed NOID' do
+      it 'should redirect to the requested collection' do
+        get 'show', params: { id: "#{collection.id}] " }
+        expect(response).to redirect_to(admin_collection_path(id: collection.id))
+      end
+      it 'should redirect to unknown_pid page if invalid' do
+        get 'show', params: { id: "nonvalid noid]" }
+        expect(response).to render_template("errors/unknown_pid")
+        expect(response.response_code).to eq(404)
+      end
+    end
   end
 
   describe "#items" do
@@ -277,7 +289,7 @@ describe Admin::CollectionsController, type: :controller do
     context "with structure" do
       let!(:mf_1) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[0]) }
       let!(:mf_2) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[1]) }
-      
+
       it "should not return structure by default" do
         get 'items', params: { id: collection.id, format: 'json' }
         expect(JSON.parse(response.body)[collection.media_objects[0].id]["files"][0]["structure"]).to be_blank

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -240,14 +240,14 @@ describe MasterFilesController do
     end
 
     context 'misformed NOID' do
-      # URI::InvalidURIError handling in ApplicationController
       it 'should redirect to the requested master file' do
         get 'show', params: { id: "#{master_file.id}] " }
         expect(response).to redirect_to(master_file_path(id: master_file.id))
       end
-      it 'should redirect to homepage if invalid' do
+      it 'should redirect to unknown_pid page if invalid' do
         get 'show', params: { id: "nonvalid noid]" }
         expect(response).to render_template("errors/unknown_pid")
+        expect(response.response_code).to eq(404)
       end
     end
   end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -236,6 +236,18 @@ describe MasterFilesController do
 
       it "redirects" do
         expect(get(:show, params: { id: fedora3_pid })).to redirect_to(master_file_url(master_file.id))
+      end
+    end
+
+    context 'misformed NOID' do
+      # URI::InvalidURIError handling in ApplicationController
+      it 'should redirect to the requested master file' do
+        get 'show', params: { id: "#{master_file.id}] " }
+        expect(response).to redirect_to(master_file_path(id: master_file.id))
+      end
+      it 'should redirect to homepage if invalid' do
+        get 'show', params: { id: "nonvalid noid]" }
+        expect(response).to render_template("errors/unknown_pid")
       end
     end
   end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -1237,6 +1237,18 @@ describe MediaObjectsController, type: :controller do
           get 'show', params: { id: media_object.id, format:'json', include_structure: false }
           expect(json['files'].first['structure']).not_to eq master_file.structuralMetadata.content
         end
+      end
+    end
+
+    context 'misformed NOID' do
+      # URI::InvalidURIError handling in ApplicationController
+      it 'should redirect to the requested media object if valid' do
+        get 'show', params: { id: "#{media_object.id}] !-()" }
+        expect(response).to redirect_to(media_object_path(id: media_object.id))
+      end
+      it 'should redirect to homepage if invalid' do
+        get 'show', params: { id: "nonvalid noid]" }
+        expect(response).to render_template("errors/unknown_pid")
       end
     end
   end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -784,8 +784,8 @@ describe MediaObjectsController, type: :controller do
       end
 
       it "should return an error if the PID does not exist" do
-        expect(MediaObject).to receive(:find).with('no-such-object') { raise ActiveFedora::ObjectNotFoundError }
         get :show, params: { id: 'no-such-object' }
+        expect(response).to render_template("errors/unknown_pid")
         expect(response.response_code).to eq(404)
       end
 
@@ -1241,14 +1241,14 @@ describe MediaObjectsController, type: :controller do
     end
 
     context 'misformed NOID' do
-      # URI::InvalidURIError handling in ApplicationController
       it 'should redirect to the requested media object if valid' do
         get 'show', params: { id: "#{media_object.id}] !-()" }
         expect(response).to redirect_to(media_object_path(id: media_object.id))
       end
-      it 'should redirect to homepage if invalid' do
+      it 'should redirect to unknown_pid page if invalid' do
         get 'show', params: { id: "nonvalid noid]" }
         expect(response).to render_template("errors/unknown_pid")
+        expect(response.response_code).to eq(404)
       end
     end
   end


### PR DESCRIPTION
Wait to merge until after 7.6

This PR adds handling for Invalid URI errors to the application controller. Malformed NOIDs seem to be the only (or at least main) trigger that we have seen in our honeybadger reports. The NOID is expected to be alphanumeric so if an invalid URI error is detected, this strips any special characters from the ID param and, if the NOID is now valid, resubmits the request with the edited ID. Otherwise, an error page is rendered.

In manual testing I have done, this seems to be robust enough but it is possible this is too general an approach and there might be edge cases that are not handled properly. Possibly inserting the sanitizing logic where the NOID gets converted to the fedora id would work and be less generalized? I'm not sure where in the code that is though.