### PR TITLE
Use bugfixed browse-everything

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "omniauth-saml", "~> 2.0"
 # Media Access & Transcoding
 gem 'active_encode', '~> 1.0', '>= 1.1.2'
 gem 'audio_waveform-ruby', '~> 1.0.7', require: 'audio_waveform'
-gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", tag: 'v1.2.0-avalon'
+gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'v1.2-avalon'
 gem 'fastimage'
 gem 'media_element_add_to_playlist', git: 'https://github.com/avalonmediasystem/media-element-add-to-playlist.git', tag: 'avalon-r6.5'
 gem 'mediainfo', git: "https://github.com/avalonmediasystem/mediainfo.git", tag: 'v0.7.1-avalon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/browse-everything.git
-  revision: 38610d19d36105ca9c311e0a641fdb43697fabea
-  tag: v1.2.0-avalon
+  revision: fb3060bf2a4e556b6cbf84d7ac9a363f8ac20583
+  branch: v1.2-avalon
   specs:
     browse-everything (1.2.0)
       addressable (~> 2.5)
@@ -199,13 +199,13 @@ GEM
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.709.0)
+    aws-partitions (1.735.0)
     aws-record (2.10.1)
       aws-sdk-dynamodb (~> 1.18)
     aws-sdk-cloudfront (1.75.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.170.0)
+    aws-sdk-core (3.171.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -216,7 +216,7 @@ GEM
     aws-sdk-elastictranscoder (1.40.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.62.0)
+    aws-sdk-kms (1.63.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-rails (3.7.0)
@@ -227,7 +227,7 @@ GEM
       aws-sessionstore-dynamodb (~> 2)
       concurrent-ruby (~> 1)
       railties (>= 5.2.0)
-    aws-sdk-s3 (1.119.0)
+    aws-sdk-s3 (1.119.2)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -459,7 +459,7 @@ GEM
       webrick
     google-apis-drive_v3 (0.37.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    googleauth (1.3.0)
+    googleauth (1.5.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -661,14 +661,14 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.6.3)
+    rack (2.2.6.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-protection (3.0.5)
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.2)
       actioncable (= 7.0.4.2)


### PR DESCRIPTION
The fix in our customizations of browse-everything is to force a hash into a splat to act as kwargs.  I had to make similar changes when upgrading other core components to ruby 3.2 so I think this is related to that and not a change in the google sdk.

Once this is merged and tested on `avalon-dev` then I'll tag `browse-everything` and create a follow up PR to use that tag instead of the branch.