### PR TITLE
Fix for video player aspect ratio change when switching between sections

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_helper_utility.es6
@@ -30,8 +30,8 @@ class MEJSUtility {
       node = document.createElement('video');
       node.setAttribute('id', 'mejs-avalon-player');
       node.setAttribute('controls', '');
-      node.setAttribute('width', '450');
-      node.setAttribute('height', '309');
+      node.setAttribute('width', '480');
+      node.setAttribute('height', '270');
       node.setAttribute('style', 'width: 100%; height: 100%');
       if (currentStreamInfo.poster_image) {
         node.setAttribute('poster', currentStreamInfo.poster_image);


### PR DESCRIPTION
I came across this issue while working on #5118 where the video player's aspect ratio change when switching between sections or playlist items by clicking on the structure timespan links or playlist item links respectively;

![aspect-ratio-changes](https://user-images.githubusercontent.com/1331659/228353235-4fe53659-0a39-43cd-82bb-56d751baebb1.gif)

I think this bug was introduced from the work done in https://github.com/avalonmediasystem/avalon/pull/4881
