### PR TITLE
Fix flashing error message in player when scrubbing

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -1936,15 +1936,17 @@ Object.assign(_player2.default.prototype, {
 			}
 			if (t.forcedHandlePause) {
 				t.slider.focus();
-				let playPromise = t.play();
-				if(playPromise !== undefined) {
-					playPromise.then(_ => {
-						// Show play UI, and enable controls
-						t.play();
-						t.enableControls();
-					})
-					.catch(error => {	})
-				}
+				setTimeout(function () {
+					let playPromise = t.play();
+					if(playPromise !== undefined) {
+						playPromise.then(_ => {
+							// Show play UI, and enable controls
+							t.play();
+							t.enableControls();
+						})
+						.catch(error => {	})
+					}
+				}, 150)
 			}
 			t.forcedHandlePause = false;
 		};


### PR DESCRIPTION
Fixes #5119 

This should fix the last issue Charu reported with flashing error message when scrubbing during playback in video player.

Note: I adapted this from the jump forward and backward implementation in the ME.js code.