### PR TITLE
Override ActiveFedora and HydraAccessControls to ensure AccessControl…

### DIFF
--- a/spec/jobs/bulk_action_job_spec.rb
+++ b/spec/jobs/bulk_action_job_spec.rb
@@ -122,6 +122,9 @@ describe BulkActionJobs::ApplyCollectionAccessControl do
         mo.reload
         expect(mo.read_users).to contain_exactly("co_user")
         expect(mo.read_groups).to contain_exactly("co_group", "public")
+        solr_doc = ActiveFedora::SolrService.query("id:#{mo.id}").first
+        expect(solr_doc["read_access_person_ssim"]).to contain_exactly("co_user")
+        expect(solr_doc["read_access_group_ssim"]).to contain_exactly("co_group", "public")
       end
     end
 
@@ -131,6 +134,9 @@ describe BulkActionJobs::ApplyCollectionAccessControl do
         mo.reload
         expect(mo.read_users).to contain_exactly("mo_user", "co_user")
         expect(mo.read_groups).to contain_exactly("mo_group", "co_group", "public")
+        solr_doc = ActiveFedora::SolrService.query("id:#{mo.id}").first
+        expect(solr_doc["read_access_person_ssim"]).to contain_exactly("mo_user", "co_user")
+        expect(solr_doc["read_access_group_ssim"]).to contain_exactly("mo_group", "co_group", "public")
       end
     end
   end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1062,4 +1062,34 @@ describe MediaObject do
       end
     end
   end
+
+  describe 'read_groups=' do
+    let(:solr_doc) { ActiveFedora::SolrService.query("id:#{media_object.id}").first }
+
+    context 'when creating a MediaObject' do
+      let(:media_object) { FactoryBot.build(:media_object) }
+
+      it 'saves and indexes' do
+        expect(media_object.read_groups).to be_empty
+        media_object.read_groups = ["ExternalGroup"]
+        expect(media_object.access_control).to be_changed
+        media_object.save
+        expect(media_object.reload.read_groups).to eq ["ExternalGroup"]
+        expect(solr_doc["read_access_group_ssim"]).to eq ["ExternalGroup"]
+      end
+    end
+
+    context 'when updating a MediaObject' do
+      let(:media_object) { FactoryBot.create(:media_object) }
+
+      it 'saves and indexes' do
+        expect(media_object.read_groups).to be_empty
+        media_object.read_groups = ["ExternalGroup"]
+        expect(media_object.access_control).to be_changed
+        media_object.save
+        expect(media_object.reload.read_groups).to eq ["ExternalGroup"]
+        expect(solr_doc["read_access_group_ssim"]).to eq ["ExternalGroup"]
+      end
+    end
+  end
 end


### PR DESCRIPTION
… objects are marked dirty and autosave so they get indexed properly

I added some tests but was not able to get any of them to fail prior to the changes in this PR.  It is possible that the issue is only present in a production environment.