### PR TITLE
Remove special handling of childless divs

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -94,14 +94,6 @@ class IiifCanvasPresenter
     end
 
     def structure_to_iiif_range
-      # Remove all "Div" nodes which do not have a "Span" descendant to ensure a valid manifest.
-      # According the to IIIF presentation 3 spec each Range needs to have a descendant that is a Canvas.
-      # See https://iiif.io/api/presentation/3.0/#34-structural-properties
-      structure_ng_xml.root.xpath("//*[local-name() = 'Div' and not(descendant::*[local-name() = 'Span'])]").map(&:remove)
-
-      # Return default range if nothing valid is left
-      return simple_iiif_range(structure_ng_xml.root.attr('label')) if structure_ng_xml.root.children.all?(&:blank?)
-
       div_to_iiif_range(structure_ng_xml.root)
     end
 
@@ -113,10 +105,6 @@ class IiifCanvasPresenter
           span_to_iiif_range(node)
         end
       end
-
-      # if a non-leaf node has no valid "Div" or "Span" children, then it would become empty range node containing no canvas
-      # raise an exception here as this error shall have been caught and handled by the parser and shall never happen here
-      raise Nokogiri::XML::SyntaxError, "Empty root or Div node: #{div_node[:label]}" if items.empty?
 
       IiifManifestRange.new(
         label: { "none" => [div_node[:label]] },

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -87,31 +87,5 @@ describe IiifCanvasPresenter do
         expect(subject.items.first.media_fragment).to eq 't=0,'
       end
     end
-
-    context 'with invalid structural metadata' do
-      let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Bad"/><Div label="Div 1"><Div label="Also bad"/><Span label="Span 1" begin="00:00:00.000" end="00:00:01.235"/></Div></Item>' }
-
-      it 'removes ranges without descendant canvases' do
-	expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
-	expect(subject.items.size).to eq 1
-	expect(subject.items.first.label.to_s).to eq '{"none"=>["Div 1"]}'
-	expect(subject.items.first.items.size).to eq 1
-	expect(subject.items.first.items.first.label.to_s).to eq '{"none"=>["Span 1"]}'
-	expect(subject.items.first.items.first.items.size).to eq 1
-	expect(subject.items.first.items.first.items.first).to be_a IiifCanvasPresenter
-	expect(subject.items.first.items.first.items.first.media_fragment).to eq 't=0.0,1.235'
-      end
-
-      context 'when there are no valid ranges' do
-        let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Div 1"/></Item>' }
-
-        it 'autogenerates a basic range but preserves the root level label' do
-	  expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
-	  expect(subject.items.size).to eq 1
-	  expect(subject.items.first).to be_a IiifCanvasPresenter
-	  expect(subject.items.first.media_fragment).to eq 't=0,'
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Partially reverts changes in #5113 and prior work to remove childless divs.
Resolves #5141 