### PR TITLE
Add metadata check before publishing/unpublishing

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -209,9 +209,7 @@ class Admin::CollectionsController < ApplicationController
         target_path = admin_collection_path(@target_collection)
         @source_collection.reload
       else
-        mos = @source_collection.media_objects.to_a
-        invalid_mos = mos.collect { |mo| "<li>#{mo.id}</li>" unless mo.valid? }.compact
-        flash[:error] = "Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{@source_collection.name}.<ul>#{invalid_mos.join('')}</ul>".html_safe
+        flash[:error] = "Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{@source_collection.name}."
         redirect_to admin_collection_path(@source_collection) and return
       end
     end

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -209,7 +209,9 @@ class Admin::CollectionsController < ApplicationController
         target_path = admin_collection_path(@target_collection)
         @source_collection.reload
       else
-        flash[:error] = "Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{@source_collection.name}."
+        mos = @source_collection.media_objects.to_a
+        invalid_mos = mos.collect { |mo| "<li>#{mo.id}</li>" unless mo.valid? }.compact
+        flash[:error] = "Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{@source_collection.name}.<ul>#{invalid_mos.join('')}</ul>".html_safe
         redirect_to admin_collection_path(@source_collection) and return
       end
     end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -419,14 +419,14 @@ class MediaObjectsController < ApplicationController
       if cannot? :update, media_object
         errors += ["#{media_object&.title} (#{id}) (permission denied)."]
       else
-        unless media_object.title.present? && media_object.date_issued.present?
-          errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
-          next
-        end
         begin
           case status
           when 'publish'
-            media_object.publish!(user_key)
+            unless media_object.title.present? && media_object.date_issued.present?
+              errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
+              next
+            end
+            media_object.publish!(user_key, validate: true)
             # additional save to set permalink
             media_object.save( validate: false )
             success_count += 1

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -419,7 +419,7 @@ class MediaObjectsController < ApplicationController
       if cannot? :update, media_object
         errors += ["#{media_object&.title} (#{id}) (permission denied)."]
       else
-        unless (media_object.title.present? && media_object.date_issued.present?)
+        unless media_object.title.present? && media_object.date_issued.present?
           errors += ["Validation failed: Title field is required., Date issued field is required."]
           break
         end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -420,8 +420,8 @@ class MediaObjectsController < ApplicationController
         errors += ["#{media_object&.title} (#{id}) (permission denied)."]
       else
         unless media_object.title.present? && media_object.date_issued.present?
-          errors += ["Validation failed: Title field is required., Date issued field is required."]
-          break
+          errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
+          next
         end
         begin
           case status

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -426,13 +426,13 @@ class MediaObjectsController < ApplicationController
               errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
               next
             end
-            media_object.publish!(user_key, validate: true)
+            media_object.publish!(user_key)
             # additional save to set permalink
             media_object.save( validate: false )
             success_count += 1
           when 'unpublish'
             if can? :unpublish, media_object
-              media_object.publish!(nil)
+              media_object.publish!(nil, validate: false)
               success_count += 1
             else
               errors += ["#{media_object&.title} (#{id}) (permission denied)."]

--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -109,7 +109,7 @@ module BulkActionJobs
         media_object = MediaObject.find(id)
         case status
         when 'publish'
-          media_object.publish!(user_key, validate: true)
+          media_object.publish!(user_key)
           # additional save to set permalink
           if media_object.save
             successes += [media_object]
@@ -117,7 +117,7 @@ module BulkActionJobs
             errors += [media_object]
           end
         when 'unpublish'
-          if media_object.publish!(nil)
+          if media_object.publish!(nil, validate: false)
             successes += [media_object]
           else
             errors += [media_object]

--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -109,7 +109,7 @@ module BulkActionJobs
         media_object = MediaObject.find(id)
         case status
         when 'publish'
-          media_object.publish!(user_key)
+          media_object.publish!(user_key, validate: true)
           # additional save to set permalink
           if media_object.save
             successes += [media_object]

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -159,9 +159,9 @@ class MediaObject < ActiveFedora::Base
   def publish!(user_key, validate: false)
     self.avalon_publisher = user_key.blank? ? nil : user_key
     if validate
-      save(validate: false) || raise "Save failed"
-    else
       save!
+    else
+      raise "Save failed" unless save(validate: false)
     end
   end
 

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -156,7 +156,7 @@ class MediaObject < ActiveFedora::Base
   # Sets the publication status. To unpublish an object set it to nil or
   # omit the status which will default to unpublished. This makes the act
   # of publishing _explicit_ instead of an accidental side effect.
-  def publish!(user_key, validate: false)
+  def publish!(user_key, validate: true)
     self.avalon_publisher = user_key.blank? ? nil : user_key
     if validate
       save!

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -156,9 +156,13 @@ class MediaObject < ActiveFedora::Base
   # Sets the publication status. To unpublish an object set it to nil or
   # omit the status which will default to unpublished. This makes the act
   # of publishing _explicit_ instead of an accidental side effect.
-  def publish!(user_key)
+  def publish!(user_key, validate: false)
     self.avalon_publisher = user_key.blank? ? nil : user_key
-    save!
+    if validate
+      save(validate: false) || raise "Save failed"
+    else
+      save!
+    end
   end
 
   def finished_processing?

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -277,7 +277,7 @@ describe Admin::CollectionsController, type: :controller do
     context "with structure" do
       let!(:mf_1) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[0]) }
       let!(:mf_2) { FactoryBot.create(:master_file, :with_structure, media_object: collection.media_objects[1]) }
-      
+
       it "should not return structure by default" do
         get 'items', params: { id: collection.id, format: 'json' }
         expect(JSON.parse(response.body)[collection.media_objects[0].id]["files"][0]["structure"]).to be_blank
@@ -578,6 +578,39 @@ describe Admin::CollectionsController, type: :controller do
       login_user collection.managers.first
       expect(controller.current_ability.can? :destroy, collection).to be_truthy
       expect(get :remove, params: { id: collection.id }).to render_template(:remove)
+    end
+  end
+
+  describe "#destroy" do
+    let!(:collection) { FactoryBot.create(:collection, items: 1) }
+    let!(:target) { FactoryBot.create(:collection) }
+    before do
+      login_user collection.managers.first
+    end
+
+    it "moves media objects to target collection" do
+      media_object = collection.media_objects[0]
+      expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.to change { target.media_objects.count }.by(1)
+      expect(target.media_objects).to include(media_object)
+    end
+
+    it "deletes the collection" do
+      expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.to change { Admin::Collection.count }.by(-1)
+      expect(Admin::Collection.all).not_to include(collection)
+    end
+
+    it "redirects to target collection" do
+      delete :destroy, params: { id: collection.id, target_collection_id: target.id }
+      expect(response).to redirect_to(admin_collection_path(target))
+    end
+
+    context "collection with invalid media object" do
+      it "does not delete collection" do
+        allow_any_instance_of(MediaObject).to receive(:valid?).and_return(false)
+        expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.not_to change { Admin::Collection.count }
+        expect(response).to redirect_to(admin_collection_path(collection))
+        expect(flash[:error]).to eq("Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{collection.name}.<ul><li>#{collection.media_objects[0].id}</li></ul>")
+      end
     end
   end
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -581,39 +581,6 @@ describe Admin::CollectionsController, type: :controller do
     end
   end
 
-  describe "#destroy" do
-    let!(:collection) { FactoryBot.create(:collection, items: 1) }
-    let!(:target) { FactoryBot.create(:collection) }
-    before do
-      login_user collection.managers.first
-    end
-
-    it "moves media objects to target collection" do
-      media_object = collection.media_objects[0]
-      expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.to change { target.media_objects.count }.by(1)
-      expect(target.media_objects).to include(media_object)
-    end
-
-    it "deletes the collection" do
-      expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.to change { Admin::Collection.count }.by(-1)
-      expect(Admin::Collection.all).not_to include(collection)
-    end
-
-    it "redirects to target collection" do
-      delete :destroy, params: { id: collection.id, target_collection_id: target.id }
-      expect(response).to redirect_to(admin_collection_path(target))
-    end
-
-    context "collection with invalid media object" do
-      it "does not delete collection" do
-        allow_any_instance_of(MediaObject).to receive(:valid?).and_return(false)
-        expect { delete :destroy, params: { id: collection.id, target_collection_id: target.id } }.not_to change { Admin::Collection.count }
-        expect(response).to redirect_to(admin_collection_path(collection))
-        expect(flash[:error]).to eq("Collection contains invalid media objects that cannot be moved. Please address these issues before attempting to delete #{collection.name}.<ul><li>#{collection.media_objects[0].id}</li></ul>")
-      end
-    end
-  end
-
   describe '#attach_poster' do
     let(:collection) { FactoryBot.create(:collection) }
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1367,7 +1367,7 @@ describe MediaObjectsController, type: :controller do
           media_object.workflow.last_completed_step = 'file-upload'
           media_object.save!(validate: false)
           get 'update_status', params: { id: media_object.id, status: 'publish' }
-          expect(flash[:notice]).to eq("Unable to publish item: Validation failed: Title field is required., Date issued field is required.")
+          expect(flash[:notice]).to eq("Unable to publish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
           media_object.reload
           expect(media_object).not_to be_published
         end
@@ -1379,7 +1379,7 @@ describe MediaObjectsController, type: :controller do
           media_object.workflow.last_completed_step = ''
           media_object.save!(validate: false)
           get 'update_status', params: { id: media_object.id, status: 'publish' }
-          expect(flash[:notice]).to eq("Unable to publish item: Validation failed: Title field is required., Date issued field is required.")
+          expect(flash[:notice]).to eq("Unable to publish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
           media_object.reload
           expect(media_object).not_to be_published
         end
@@ -1407,7 +1407,7 @@ describe MediaObjectsController, type: :controller do
           media_object.workflow.last_completed_step = 'file-upload'
           media_object.save!(validate: false)
           get 'update_status', params: { id: media_object.id, status: 'unpublish' }
-          expect(flash[:notice]).to eq("Unable to unpublish item: Validation failed: Title field is required., Date issued field is required.")
+          expect(flash[:notice]).to eq("Unable to unpublish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
           media_object.reload
           expect(media_object).to be_published
         end
@@ -1419,7 +1419,7 @@ describe MediaObjectsController, type: :controller do
           media_object.workflow.last_completed_step = ''
           media_object.save!(validate: false)
           get 'update_status', params: { id: media_object.id, status: 'unpublish' }
-          expect(flash[:notice]).to eq("Unable to unpublish item: Validation failed: Title field is required., Date issued field is required.")
+          expect(flash[:notice]).to eq("Unable to unpublish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
           media_object.reload
           expect(media_object).to be_published
         end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1394,34 +1394,31 @@ describe MediaObjectsController, type: :controller do
         expect(media_object).not_to be_published
       end
 
+      it 'unpublishes invalid items' do
+        media_object = FactoryBot.create(:published_media_object, collection: collection)
+        media_object.title = nil
+        media_object.date_issued = nil
+        media_object.save!(validate: false)
+        get 'update_status', params: { id: media_object.id, status: 'unpublish' }
+        media_object.reload
+        expect(media_object).not_to be_published
+      end
+
+      it 'unpublishes invalid items and no last completed step' do
+        media_object = FactoryBot.create(:published_media_object, collection: collection)
+        media_object.title = nil
+        media_object.date_issued = nil
+        media_object.workflow.last_completed_step = ''
+        media_object.save!(validate: false)
+        get 'update_status', params: { id: media_object.id, status: 'unpublish' }
+        media_object.reload
+        expect(media_object).not_to be_published
+      end
+
       context "should fail when" do
         it "id doesn't exist" do
           get 'update_status', params: { id: 'this-id-is-fake', status: 'unpublish' }
           expect(response.code).to eq '404'
-        end
-
-        it "item is invalid" do
-          media_object = FactoryBot.create(:published_media_object, collection: collection)
-          media_object.title = nil
-          media_object.date_issued = nil
-          media_object.workflow.last_completed_step = 'file-upload'
-          media_object.save!(validate: false)
-          get 'update_status', params: { id: media_object.id, status: 'unpublish' }
-          expect(flash[:notice]).to eq("Unable to unpublish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
-          media_object.reload
-          expect(media_object).to be_published
-        end
-
-        it "item is invalid and no last_completed_step" do
-          media_object = FactoryBot.create(:published_media_object, collection: collection)
-          media_object.title = nil
-          media_object.date_issued = nil
-          media_object.workflow.last_completed_step = ''
-          media_object.save!(validate: false)
-          get 'update_status', params: { id: media_object.id, status: 'unpublish' }
-          expect(flash[:notice]).to eq("Unable to unpublish item: #{media_object&.title} (#{media_object.id}) (missing required fields)")
-          media_object.reload
-          expect(media_object).to be_published
         end
       end
 

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -556,6 +556,20 @@ describe MediaObject do
       it 'unpublishes' do
         media_object.publish!(nil)
         expect(media_object.to_solr["workflow_published_sim"]).to eq('Unpublished')
+      end
+      context 'validate: false' do
+        it 'publishes' do
+          media_object.publish!('adam@adam.com', validate: false)
+          expect(media_object.to_solr["workflow_published_sim"]).to eq('Published')
+        end
+        it 'unpublishes' do
+          media_object.publish!(nil, validate: false)
+          expect(media_object.to_solr["workflow_published_sim"]).to eq('Unpublished')
+        end
+        it 'raises runtime error if save fails' do
+          allow_any_instance_of(MediaObject).to receive(:save).and_return(false)
+          expect { media_object.publish!(nil, validate: false) }.to raise_error(RuntimeError)
+        end
       end
     end
   end


### PR DESCRIPTION
Also updates publish/unpublish error message to reflect whether user was attempting to publish or unpublish the media object and updates the error message generated when deleting a collection with invalid media objects to provide the IDs of the culprit media objects.