### PR TITLE
Allow configuration of recaptcha v3 or v2_checkbox

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,7 +29,7 @@ class CommentsController < ApplicationController
     @comment.subject = params[:comment][:subject]
     @comment.comment = params[:comment][:comment]
 
-    if @comment.valid? && (Settings.recaptcha.blank? || verify_recaptcha(model: @comment))
+    if @comment.valid? && recaptcha_valid?
       begin
         CommentsMailer.contact_email(@comment.to_h).deliver_later
       rescue Errno::ECONNRESET => e
@@ -46,5 +46,16 @@ class CommentsController < ApplicationController
   protected
   def set_subjects
     @subjects = Comment::SUBJECTS
+  end
+
+  def recaptcha_valid?
+    return true unless Settings.recaptcha.site_key.present?
+    options = case Settings.recaptcha.type
+              when "v2_checkbox"
+                { model: @comment }
+              when "v3"
+                { action: Settings.recaptcha.v3.action, minimum_score: Settings.recaptcha.v3.minimum_score }
+              end
+    verify_recaptcha(options)
   end
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -29,10 +29,16 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= comment.email_field :email_confirmation, label: 'Confirm email address' %>
       <%= comment.select :subject, options_for_select(@subjects), { :prompt => 'Select one' }, { :control_class => 'form-control' } %>
       <%= comment.text_area :comment, rows: 10 %>
-      <% if Settings.recaptcha.present?%>
-        <div class="form-group">
-          <%= recaptcha_tags %>
-        </div>
+      <% if Settings.recaptcha.site_key.present?%>
+        <% if Settings.recaptcha.type == "v2_checkbox" %>
+	  <div class="form-group">
+	    <%= recaptcha_tags %>
+	  </div>
+        <% elsif Settings.recaptcha.type == "v3" %>
+	  <div class="form-group">
+	    <%= recaptcha_v3(action: Settings.recaptcha.v3.action) %>
+	  </div>
+        <% end %>
       <% end %>
       <%= comment.primary "Submit comments" %>
     </fieldset>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,3 +104,10 @@ caption_default:
   # Language should be 2 or 3 letter ISO 639 codes
   language: 'en'
   name: 'English'
+recaptcha:
+  site_key: # Setting a site_key will enable recaptcha on the comments form
+  secret_key: # Required along with site_key
+  type: "v2_checkbox" # or "v3"
+  v3:
+    action: "comment"
+    minimum_score: 0.5

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,75 @@
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe CommentsController do
+  render_views
+
+  let(:comment) { FactoryBot.build(:comment) }
+  let(:comment_parameters) { comment.to_h.merge({ email_confirmation: comment.email }) } 
+
+  describe '#create' do
+    it 'sends a comment email' do
+      post :create, params: { comment: comment_parameters }
+      expect(response.status).to be 200
+    end
+
+    context 'missing parameters' do
+      it 'shows error message' do
+        post :create, params: { comment: { name: "Test" } }
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'recaptcha enabled' do
+      before do
+        allow(Settings.recaptcha).to receive(:site_key).and_return("site_key")
+        allow(Settings.recaptcha).to receive(:secret_key).and_return("secret_key")
+        allow(Settings.recaptcha).to receive(:type).and_return(recaptcha_type)
+        allow(Recaptcha.configuration).to receive(:site_key!).and_return("site_key")
+        allow(Recaptcha.configuration).to receive(:secret_key!).and_return("secret_key")
+      end
+
+      context 'recaptcha v2' do
+        let(:recaptcha_type) { "v2_checkbox" }
+
+	it 'sends a comment email' do
+          allow(controller).to receive(:verify_recaptcha)
+	  post :create, params: { comment: comment_parameters }
+	  expect(response.status).to be 200
+          expect(controller).to have_received(:verify_recaptcha).with({ model: assigns(:comment) })
+	end
+      end
+
+      context 'recaptcha v3' do
+        let(:recaptcha_type) { "v3" }
+        let(:action) { "comment" }
+        let(:minimum_score) { 0.7 }
+
+        before do
+          allow(Settings.recaptcha.v3).to receive(:action).and_return(action)
+          allow(Settings.recaptcha.v3).to receive(:minimum_score).and_return(minimum_score)
+        end
+
+	it 'sends a comment email' do
+          allow(controller).to receive(:verify_recaptcha)
+	  post :create, params: { comment: comment_parameters }
+	  expect(response.status).to be 200
+          expect(controller).to have_received(:verify_recaptcha).with({ action: action, minimum_score: minimum_score })
+	end
+      end
+    end
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,22 @@
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+FactoryBot.define do
+  factory :comment do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    subject { "General feedback" }
+    comment { Faker::Lorem.sentence }
+  end
+end


### PR DESCRIPTION
Closes #5126 

Recaptcha is disabled by default in tests so I didn't add any tests.  Do you think I should add any for `#recaptcha_valid?`?