### PR TITLE
Fix overlapping captions in player in iPhone

### DIFF
--- a/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
+++ b/vendor/assets/javascripts/mediaelement/mediaelement-and-player.js
@@ -2777,7 +2777,7 @@ Object.assign(_player2.default.prototype, {
 		}
 	},
 	displayCaptions: function displayCaptions() {
-		if (this.tracks === undefined) {
+		if (this.tracks === undefined || _mejs2.default.Features.isiPhone) {
 			return;
 		}
 


### PR DESCRIPTION
This fix is only applied for iPhones not iPads. 

The overlapping captions are still visible in iPads, if the user enables captions in the native player in fullscreen and then exit full-screen. We could maybe look at this after #5108 has been resolved.