### PR TITLE
Include metadata into IIIF manifest the same way as it is rendered on the item view page

### DIFF
--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -13,6 +13,11 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class IiifManifestPresenter
+  # Should <pre> tags be allowed?
+  # They aren't listed in the IIIF spec but we use them in our normal view page
+  IIIF_ALLOWED_TAGS = ['a', 'b', 'br', 'i', 'img', 'p', 'pre', 'small', 'span', 'sub', 'sup'].freeze
+  IIIF_ALLOWED_ATTRIBUTES = ['href', 'src', 'alt'].freeze
+
   attr_reader :media_object, :master_files
 
   def initialize(media_object:, master_files:)
@@ -42,11 +47,7 @@ class IiifManifestPresenter
   end
 
   def manifest_metadata
-    @manifest_metadata ||= iiif_metadata_fields.collect do |f|
-      value = media_object.send(f)
-      next if value.blank?
-      { 'label' => f.to_s.titleize, 'value' => Array(value) }
-    end.compact
+    @manifest_metadata ||= iiif_metadata_fields.compact
   end
 
   def thumbnail
@@ -75,36 +76,121 @@ class IiifManifestPresenter
 
   private
 
-    def iiif_metadata_fields
-      # TODO: refine and order this list of fields
-      [:title, :creator, :date_created, :date_issued, :note, :contributor,
-       :publisher, :subject, :genre, :geographic_subject, :temporal_subject, :topical_subject, :rights_statement]
+  def sanitize(value)
+    Rails::Html::Sanitizer.safe_list_sanitizer.new.sanitize(value, tags: IIIF_ALLOWED_TAGS, attributes: IIIF_ALLOWED_ATTRIBUTES)
+  end
+
+  # Following methods adapted from ApplicationHelper and MediaObjectHelper
+  def metadata_field(label, value, default = nil)
+    sanitized_values = Array(value).collect { |v| sanitize(v.to_s.strip) }.delete_if(&:empty?)
+    return nil if sanitized_values.empty? && default.nil?
+    sanitized_values = Array(default) if sanitized_values.empty?
+    label = label.pluralize(sanitized_values.size)
+    { 'label' => label, 'value' => sanitized_values.join('; ') }
+  end
+
+  def combined_display_date(media_object)
+    result = media_object.date_issued
+    result += " (Creation date: #{media_object.date_created})" if media_object.date_created.present?
+    result
+  end
+
+  def display_other_identifiers(media_object)
+    # bibliographic_id has form [:type,"value"], other_identifier has form [[:type,"value],[:type,"value"],...]
+    ids = media_object.bibliographic_id.present? ? [media_object.bibliographic_id] : []
+    ids += Array(media_object.other_identifier)
+    ids.uniq.collect { |i| "#{ModsDocument::IDENTIFIER_TYPES[i[:source]]}: #{i[:id]}" }
+  end
+
+  def note_fields(media_object)
+    fields = []
+    note_types = ModsDocument::NOTE_TYPES.clone
+    note_types['table of contents'] = 'Contents'
+    note_types['general'] = 'Notes'
+    sorted_note_types = note_types.keys.sort
+    sorted_note_types.prepend(sorted_note_types.delete('general'))
+    sorted_note_types.each do |note_type|
+      notes = note_type == 'table of contents' ? media_object.table_of_contents : gather_notes_of_type(media_object, note_type)
+      fields << metadata_field(note_types[note_type], notes.collect { |note| "<pre>#{note}</pre>" }.join)
     end
+    fields
+  end
 
-    def image_for(document)
-      master_file_id = document["section_id_ssim"].try :first
+  def gather_notes_of_type(media_object, type)
+    media_object.note.present? ? media_object.note.select { |n| n[:type] == type }.collect { |n| n[:note] } : []
+  end
 
-      video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image'.titleize) } rescue 0
-      audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording'.titleize) } rescue 0
+  def display_collection(media_object)
+    "<a href='#{Rails.application.routes.url_helpers.collection_url(media_object.collection.id)}'>#{media_object.collection.name}</a>"
+  end
 
-      if master_file_id
-        if video_count > 0
-         Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
-        elsif audio_count > 0
-          ActionController::Base.helpers.asset_url('audio_icon.png')
-        else
-          nil
-        end
-      else
-        if video_count > 0 && audio_count > 0
-          ActionController::Base.helpers.asset_url('hybrid_icon.png')
-        elsif video_count > audio_count
-          ActionController::Base.helpers.asset_url('video_icon.png')
-        elsif audio_count > video_count
-          ActionController::Base.helpers.asset_url('audio_icon.png')
-        else
-          nil
-        end
+  def display_unit(media_object)
+    "<a href='#{Rails.application.routes.url_helpers.collections_url(filter: media_object.collection.unit)}'>#{media_object.collection.unit}</a>"
+  end
+
+  def display_language(media_object)
+    media_object.language.collect { |l| l[:text] }.uniq
+  end
+
+  def display_related_item(media_object)
+    media_object.related_item_url.collect { |r| "<a href='#{r[:url]}'>#{r[:label]}</a>" }
+  end
+
+  def display_rights_statement(media_object)
+    return nil unless media_object.rights_statement.present?
+    label = ModsDocument::RIGHTS_STATEMENTS[media_object.rights_statement]
+    return nil unless label.present?
+    "<a href='#{media_object.rights_statement}'>#{label}</a>"
+  end
+
+  def display_summary(media_object)
+    return nil unless media_object.abstract.present?
+    "<pre>#{media_object.abstract}</pre>"
+  end
+
+  def iiif_metadata_fields
+    fields = [
+      metadata_field('Title', media_object.title),
+      metadata_field('Date', combined_display_date(media_object), 'Not provided'),
+      metadata_field('Main contributor', media_object.creator),
+      metadata_field('Summary', display_summary(media_object)),
+      metadata_field('Contributor', media_object.contributor),
+      metadata_field('Publisher', media_object.publisher),
+      metadata_field('Genre', media_object.genre),
+      metadata_field('Subject', media_object.subject),
+      metadata_field('Time period', media_object.temporal_subject),
+      metadata_field('Location', media_object.geographic_subject),
+      metadata_field('Collection', display_collection(media_object)),
+      metadata_field('Unit', display_unit(media_object)),
+      metadata_field('Language', display_language(media_object)),
+      metadata_field('Rights Statement', display_rights_statement(media_object)),
+      metadata_field('Terms of Use', media_object.terms_of_use),
+      metadata_field('Physical Description', media_object.physical_description),
+      metadata_field('Related Item', display_related_item(media_object))
+    ]
+    fields += note_fields(media_object)
+    fields += [metadata_field('Other Identifier', display_other_identifiers(media_object))]
+    fields
+  end
+
+  def image_for(document)
+    master_file_id = document["section_id_ssim"].try :first
+
+    video_count = document["avalon_resource_type_ssim"]&.count { |m| m.start_with?('moving image'.titleize) } || 0
+    audio_count = document["avalon_resource_type_ssim"]&.count { |m| m.start_with?('sound recording'.titleize) } || 0
+
+    if master_file_id
+      if video_count > 0
+        Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
+      elsif audio_count > 0
+        ActionController::Base.helpers.asset_url('audio_icon.png')
       end
+    elsif video_count > 0 && audio_count > 0
+      ActionController::Base.helpers.asset_url('hybrid_icon.png')
+    elsif video_count > audio_count
+      ActionController::Base.helpers.asset_url('video_icon.png')
+    elsif audio_count > video_count
+      ActionController::Base.helpers.asset_url('audio_icon.png')
     end
+  end
 end

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -40,13 +40,14 @@ FactoryBot.define do
         geographic_subject { [Faker::Address.country] }
         physical_description { [Faker::Lorem.word] }
         table_of_contents { [Faker::Lorem.paragraph] }
-        note { [{ note: Faker::Lorem.paragraph, type: 'general' }] }
+        note { [{ note: Faker::Lorem.paragraph, type: 'general' }, { note: Faker::Lorem.paragraph, type: 'local' }] }
         other_identifier { [{ id: Faker::Lorem.word, source: 'local' }] }
         language { ['eng'] }
         related_item_url { [{ url: Faker::Internet.url, label: Faker::Lorem.sentence }]}
         bibliographic_id { { id: Faker::Lorem.word, source: 'local' } }
         comment { ['MO comment'] }
         rights_statement { ['http://rightsstatements.org/vocab/InC-EDU/1.0/'] }
+        terms_of_use { [ 'Terms of Use: Be kind. Rewind.' ] }
         # after(:create) do |mo|
         #   mo.update_datastream(:descMetadata, {
         #     note: {note[Faker::Lorem.paragraph],

--- a/spec/models/iiif_manifest_presenter_spec.rb
+++ b/spec/models/iiif_manifest_presenter_spec.rb
@@ -29,4 +29,21 @@ describe IiifManifestPresenter do
       expect(subject[:label]).to include("none" => ["View in Repository"])
     end
   end
+
+  context 'metadata' do
+    let(:media_object) { FactoryBot.build(:fully_searchable_media_object) }
+    subject do
+      metadata_hash = {}
+      presenter.manifest_metadata.map { |e| metadata_hash[e['label']] = e['value'] }
+      metadata_hash
+    end
+
+    it 'provides metadata' do
+      ['Title', 'Date', 'Main contributor', 'Summary', 'Contributor', 'Publisher', 'Genre', 'Subject', 'Time period',
+       'Location', 'Collection', 'Unit', 'Language', 'Rights Statement', 'Terms of Use', 'Physical Description',
+       'Related Item', 'Notes', 'Contents', 'Local Note', 'Other Identifiers'].each do |field|
+        expect(subject).to include(field)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #5170 

I did not add permalink.  A link to the item view page is included in `homepage` but it isn't a permalink yet.  Maybe this should be a different ticket to make `homepage` a permalink?