### PR TITLE
Update rubocop/codeclimate to run with target ruby 3.2 and rails 7.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,11 +1,11 @@
 ---
 prepare:
-  fetch: # Pinned to bixby 2.0.0
-  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/394ba20eac3f3c8146a679b1dc45c3513074848c/bixby_default.yml"
+  fetch:
+  - url: "https://raw.githubusercontent.com/samvera/bixby/v5.0.2/bixby_default.yml"
     path: "bixby_default.yml"
-  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/394ba20eac3f3c8146a679b1dc45c3513074848c/bixby_rails_enabled.yml"
+  - url: "https://raw.githubusercontent.com/samvera/bixby/v5.0.2/bixby_rails_enabled.yml"
     path: "bixby_rails_enabled.yml"
-  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/394ba20eac3f3c8146a679b1dc45c3513074848c/bixby_rspec_enabled.yml"
+  - url: "https://raw.githubusercontent.com/samvera/bixby/v5.0.2/bixby_rspec_enabled.yml"
     path: "bixby_rspec_enabled.yml"
 engines:
   brakeman:
@@ -22,7 +22,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
-    channel: rubocop-0-50
+    channel: rubocop-1-48-1
     config:
       file: .rubocop.cc.yml
     checks:

--- a/.rubocop.cc.yml
+++ b/.rubocop.cc.yml
@@ -5,8 +5,8 @@ inherit_from:
   - bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
-  TargetRailsVersion: 5.1
+  TargetRubyVersion: 3.2
+  TargetRailsVersion: 7.0
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,8 @@ inherit_gem:
   bixby: bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
-  TargetRailsVersion: 5.1
+  TargetRubyVersion: 3.2
+  TargetRailsVersion: 7.0
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'


### PR DESCRIPTION
I noticed codeclimate is using an old version of bixby and rubocop for style enforcement.  This PR updates to the latest supported versions of each.  

Bixby 5.0.2 uses rubocop 1.28.2 but codeclimate doesn't have a `channel` for that version so I went with the latest since we couldn't back down to the next lower channel without losing ruby 3.2 support.