### PR TITLE
Avoid enqueuing many copies of the media object indexing job unnecessarily

### DIFF
--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -883,6 +883,7 @@ describe MasterFile do
       # Force creation of master_file and then clear queue of byproduct jobs
       master_file
       ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+      ActiveJob::Uniqueness.unlock!
     end
 
     it 'enqueues indexing of parent media object' do


### PR DESCRIPTION
When an object with many sections is saved it can cause hundreds of these jobs to be enqueued which will take a long time to clear out and clogs up the background worker.  This uniqueness check would allow for enqueuing the same job again as soon as the job starts running since the in memory copy of the object might be out of date by the time it finishes running.

See https://github.com/veeqo/activejob-uniqueness#job-uniqueness-for-activejob

Steps for testing:
1. Create a 100-section item
2. Delete a section
3. As an admin go to Manage Worker Jobs
4. Check that only one or two media object indexing jobs are enqueued for that item