### PR TITLE
Fix reference to supplemental_files in view

### DIFF
--- a/app/views/media_objects/_supplemental_files_list.html.erb
+++ b/app/views/media_objects/_supplemental_files_list.html.erb
@@ -13,8 +13,8 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-          <% if section.supplemental_files.present? %>
-            <% files=tag.empty? ? supplemental_files(tag: nil) : supplemental_files(tag: tag) %>
+          <% if section.supplemental_files_json.present? %>
+            <% files=tag.empty? ? section.supplemental_files(tag: nil) : section.supplemental_files(tag: tag) %>
             <div class="file_view">
               <% files.each do |file| %>
                 <div class="supplemental-file-data" data-file-id="<%= file.id %>" data-masterfile-id="<%= section.id %>" >


### PR DESCRIPTION
When testing on avalon-dev I noticed this error after adding a item-level supplemental file on the manage files page.

```
NoMethodError in MediaObjects#edit

Showing /home/app/avalon/app/views/media_objects/_supplemental_files_list.html.erb where line #17 raised:

undefined method `supplemental_files' for #<ActionView::Base:0x00000000124dc8>
```