### PR TITLE
Original names can be nil so use safe navigator

### DIFF
--- a/app/models/indexed_file.rb
+++ b/app/models/indexed_file.rb
@@ -17,6 +17,6 @@ class IndexedFile < ActiveFedora::File
 
   # Override
   def original_name
-    super.force_encoding("UTF-8")
+    super&.force_encoding("UTF-8")
   end
 end


### PR DESCRIPTION
Found this when attempting to reindex in production.