### PR TITLE
Use SpeedyAF::Proxy for faster ability checks in MasterFilesController

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -389,7 +389,7 @@ protected
     if params[:id].blank? || (not MasterFile.exists?(params[:id]))
       flash[:notice] = "MasterFile #{params[:id]} does not exist"
     end
-    @master_file = MasterFile.find(params[:id])
+    @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id])
   end
 
   # return deflated waveform content. deflate only if necessary

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -21,7 +21,8 @@ class MasterFilesController < ApplicationController
   include NoidValidator
 
   before_action :authenticate_user!, :only => [:create]
-  before_action :set_masterfile, except: [:create, :oembed]
+  before_action :set_masterfile_proxy, except: [:create, :oembed, :attach_structure, :attach_captions, :delete_structure, :delete_captions, :destroy, :update]
+  before_action :set_masterfile, only: [:attach_structure, :attach_captions, :delete_structure, :delete_captions, :destroy, :update]
   before_action :ensure_readable_filedata, :only => [:create]
   skip_before_action :verify_authenticity_token, only: [:set_structure, :delete_structure]
 
@@ -387,6 +388,13 @@ class MasterFilesController < ApplicationController
 protected
   def set_masterfile
     if params[:id].blank? || (not MasterFile.exists?(params[:id]))
+      flash[:notice] = "MasterFile #{params[:id]} does not exist"
+    end
+    @master_file = MasterFile.find(params[:id])
+  end
+
+  def set_masterfile_proxy
+    if params[:id].blank? || SpeedyAF::Proxy::MasterFile.find(params[:id]).nil?
       flash[:notice] = "MasterFile #{params[:id]} does not exist"
     end
     @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,15 @@ class Ability
                          :timeline_permissions,
                          :checkout_permissions]
 
+  # Override to add handling of SpeedyAF proxy objects
+  def read_permissions
+    super
+
+    can :read, SpeedyAF::Base do |obj|
+      test_read(obj.id)
+    end
+  end
+
   def encode_dashboard_permissions
     can :read, :encode_dashboard if is_administrator?
   end
@@ -68,7 +77,15 @@ class Ability
         !(test_read(media_object.id) && media_object.published?) && !test_edit(media_object.id)
       end
 
+      cannot :read, SpeedyAF::Proxy::MediaObject do |media_object|
+        !(test_read(media_object.id) && media_object.published?) && !test_edit(media_object.id)
+      end
+
       can :read, MasterFile do |master_file|
+        can? :read, master_file.media_object
+      end
+
+      can :read, SpeedyAF::Proxy::MasterFile do |master_file|
         can? :read, master_file.media_object
       end
 

--- a/app/presenters/speedy_af/proxy/structural_metadata.rb
+++ b/app/presenters/speedy_af/proxy/structural_metadata.rb
@@ -22,4 +22,28 @@ class SpeedyAF::Proxy::StructuralMetadata < SpeedyAF::Base
   def section_title
     xpath('/Item/@label').text
   end
+
+  def as_json
+    root_node = xpath('//Item')[0]
+    root_node.present? ? node_xml_to_json(root_node) : {}
+  end
+
+  protected
+
+    def node_xml_to_json(node)
+      if node.name.casecmp("div").zero? || node.name.casecmp('item').zero?
+        {
+          type: 'div',
+          label: node.attribute('label').value,
+          items: node.children.reject(&:blank?).collect { |n| node_xml_to_json n }
+        }
+      elsif node.name.casecmp('span').zero?
+        {
+          type: 'span',
+          label: node.attribute('label').value,
+          begin: node.attribute('begin').present? ? node.attribute('begin').value : '0',
+          end: node.attribute('end').present? ? node.attribute('end').value : '0'
+        }
+      end
+    end
 end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -615,11 +615,11 @@ describe MasterFilesController do
 
     context 'master file has been deleted' do
       before do
-        allow(MasterFile).to receive(:find).and_raise(Ldp::Gone)
+        master_file.destroy
       end
 
       it 'returns gone (403)' do
-        expect(get('hls_manifest', params: { id: "deleted", quality: 'auto' })).to have_http_status(:gone)
+        expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:unauthorized)
       end
     end
 
@@ -652,11 +652,11 @@ describe MasterFilesController do
 
     context 'master file has been deleted' do
       before do
-        allow(MasterFile).to receive(:find).and_raise(Ldp::Gone)
+        master_file.destroy
       end
 
-      it 'returns gone (403)' do
-        expect(get('caption_manifest', params: { id: master_file.id }, xhr: true)).to have_http_status(:gone)
+      it 'returns unauthorized (401)' do
+        expect(get('caption_manifest', params: { id: master_file.id }, xhr: true)).to have_http_status(:unauthorized)
       end
     end
 


### PR DESCRIPTION
The proxy may need to be reified for non end-user actions but this is much faster for items with many sections when fetching the HLS manifest.  The speedup comes from a faster ability check where `can? :read, @master_file` ends up checking `can? :read, @master_file.media_object`.  For non-SpeedyAF objects this will fetch the large media object from fedora which could be very slow.

For example, with a section from a 173 section item it is a 200x speedup for the ability check:
```
irb(main):002:1* Benchmark.measure do
irb(main):003:1*   mf = MasterFile.find('vq2806057')
irb(main):004:1*   Ability.new(nil).can? :read, mf
irb(main):005:0> end
=> #<Benchmark::Tms:0x00007fa785f9b828 @cstime=0.0, @cutime=0.0, @label="", @real=1.5468747541308403, @stime=0.018735999999999975, @total=0.24486900000000078, @utime=0.2261330000000008>
irb(main):006:1* Benchmark.measure do
irb(main):007:1*   mf = SpeedyAF::Proxy::MasterFile.find('vq2806057')
irb(main):008:1*   Ability.new(nil).can? :read, mf
irb(main):009:0> end
=> #<Benchmark::Tms:0x00007fa7861a9930 @cstime=0.0, @cutime=0.0, @label="", @real=0.07299692928791046, @stime=2.4000000000024002e-05, @total=0.004274000000000777, @utime=0.004250000000000753>
```