### PR TITLE
Speedy improvements to MasterFile

### DIFF
--- a/app/presenters/speedy_af/proxy/indexed_file.rb
+++ b/app/presenters/speedy_af/proxy/indexed_file.rb
@@ -12,38 +12,17 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
-  def to_model
-    self
+class SpeedyAF::Proxy::IndexedFile < SpeedyAF::Base
+  # If necessary, decode binary content that is base 64 encoded
+  def content
+    binary_content? ? Base64.decode64(attrs[:content]) : attrs[:content]
   end
 
-  def persisted?
-    id.present?
+  def has_content?
+    attrs[:content].present?
   end
 
-  def model_name
-    ActiveModel::Name.new(MediaObject)
-  end
-
-  def to_param
-    id
-  end
-
-  def published?
-    !avalon_publisher.blank?
-  end
-
-  # @return [SupplementalFile]
-  def supplemental_files(tag: '*')
-    return [] if supplemental_files_json.blank?
-    files = JSON.parse(supplemental_files_json).collect { |file_gid| GlobalID::Locator.locate(file_gid) }
-    case tag
-    when '*'
-      files
-    when nil
-      files.select { |file| file.tags.empty? }
-    else
-      files.select { |file| Array(tag).all? { |t| file.tags.include?(t) } }
-    end
+  def binary_content?
+    has_content? && mime_type !~ /(^text\/)|([\/\+]xml$)/
   end
 end

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -26,6 +26,11 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
     klass if klass&.ancestors&.include?(ActiveEncode::Base)
   end
 
+  # We know that title will be indexed if present so return presence to avoid reifying
+  def title
+    attrs[:title].presence
+  end
+
   def display_title
     mf_title = if has_structuralMetadata?
                  structuralMetadata.section_title


### PR DESCRIPTION
Follows on to #5221 
When testing on avalon-dev I found a few places where reification was happening.  
This PR takes care of calls to MediaObject#published? (called from ability checks) and MasterFile#title (called from stream_details).  It also avoids reification to return thumbnail and poster images by base64 encoding them.  This should help with overall speed by avoiding calls to fedora to render search results and on item view pages.

When testing make sure that thumbnails and poster images (and other `IndexedFile`s) fallback to proxying from fedora when they aren't indexed into solr.

Still probably need to do a lot of work on the MediaObject proxy in order to use it exclusively without reifying on item view page. (See #5235)