### PR TITLE
Avoid reading from fedora when loading playlist and playlist_items

### DIFF
--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -58,7 +58,7 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
 
   # Sets the class variable @master_file by finding the master referenced in the source uri
   def master_file
-    @master_file ||= MasterFile.find(CGI::unescape(self.source.split('/').last)) rescue nil if self.source
+    @master_file ||= SpeedyAF::Proxy::MasterFile.find(CGI::unescape(self.source.split('/').last)) if self.source
   end
 
   def master_file=(value)

--- a/app/views/playlist_items/_current_item.html.erb
+++ b/app/views/playlist_items/_current_item.html.erb
@@ -15,8 +15,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <% @current_playlist_item = @playlist_item %>
 <% @current_clip = AvalonClip.find(@current_playlist_item.clip_id) %>
-<% @current_masterfile = MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
-<% @current_mediaobject = MediaObject.find(@current_masterfile.media_object_id) %>
+<% @current_masterfile = SpeedyAF::Proxy::MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
+<% @current_mediaobject = SpeedyAF::Proxy::MediaObject.find(@current_masterfile.media_object_id) %>
 <div id="metadata_header">
   <h3>
     <%= link_to master_file_path(@current_masterfile.id) do %>

--- a/app/views/playlists/_info.html.erb
+++ b/app/views/playlists/_info.html.erb
@@ -15,8 +15,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <%# @current_playlist_item ||= @playlist_item %>
 <%# @current_clip ||= AvalonClip.find(@current_playlist_item.clip_id) %>
-<%# @current_masterfile ||= MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
-<%# @current_mediaobject ||= MediaObject.find(@current_masterfile.media_object_id) %>
+<%# @current_masterfile ||= SpeedyAF::Proxy::MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
+<%# @current_mediaobject ||= SpeedyAF::Proxy::MediaObject.find(@current_masterfile.media_object_id) %>
 
 <% if can? :read, @current_masterfile %>
 

--- a/app/views/playlists/refresh_info.js.erb
+++ b/app/views/playlists/refresh_info.js.erb
@@ -15,8 +15,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <% @current_playlist_item = @playlist_item %>
 <% @current_clip = AvalonClip.find(@current_playlist_item.clip_id) %>
-<% @current_masterfile = MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
-<% @current_mediaobject = MediaObject.find(@current_masterfile.media_object_id) %>
+<% @current_masterfile = SpeedyAF::Proxy::MasterFile.find(@current_playlist_item.clip.source.split('/').last) %>
+<% @current_mediaobject = SpeedyAF::Proxy::MediaObject.find(@current_masterfile.media_object_id) %>
 <% clip_start = @current_clip.start_time / 1000.0 %>
 <% clip_end = @current_clip.end_time / 1000.0 %>
 <% clip_frag = "?t=#{clip_start},#{clip_end}" %>

--- a/spec/controllers/playlist_items_controller_spec.rb
+++ b/spec/controllers/playlist_items_controller_spec.rb
@@ -179,6 +179,16 @@ RSpec.describe PlaylistItemsController, type: :controller do
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:_current_item)
     end
+
+    context 'read from solr' do
+      render_views
+      it 'should not read from fedora' do
+        playlist_item
+        WebMock.reset_executed_requests!
+        get :source_details, params: { playlist_id: playlist.to_param, playlist_item_id: playlist_item.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe 'GET #markers' do
@@ -186,6 +196,16 @@ RSpec.describe PlaylistItemsController, type: :controller do
       get :markers, params: { playlist_id: playlist.to_param, playlist_item_id: playlist_item.id }
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:_markers)
+    end
+
+    context 'read from solr' do
+      render_views
+      it 'should not read from fedora' do
+        playlist_item
+        WebMock.reset_executed_requests!
+        get :markers, params: { playlist_id: playlist.to_param, playlist_item_id: playlist_item.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
     end
   end
 
@@ -195,6 +215,17 @@ RSpec.describe PlaylistItemsController, type: :controller do
       get :related_items, params: { playlist_id: playlist.to_param, playlist_item_id: playlist_item.id }
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:_related_items)
+    end
+
+    context 'read from solr' do
+      render_views
+      it 'should not read from fedora' do
+        playlist_item
+        WebMock.reset_executed_requests!
+        allow_any_instance_of(Playlist).to receive(:related_clips).and_return([clip]);
+        get :related_items, params: { playlist_id: playlist.to_param, playlist_item_id: playlist_item.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
Builds on #5235 