### PR TITLE
Avoid reifying when to_key is called on MediaObject

### DIFF
--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -51,6 +51,10 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     id
   end
 
+  def to_key
+    [id]
+  end
+
   # @return [SupplementalFile]
   def supplemental_files(tag: '*')
     return [] if supplemental_files_json.blank?


### PR DESCRIPTION
Seen when testing on avalon-dev.  This should hopefully avoid reifying.
```
Reifying MediaObject because to_key called from /usr/local/bundle/gems/actionview-7.0.4.3/lib/action_view/record_identifier.rb:107:in `record_key_for_dom_id'
```