### PR TITLE
Use SpeedyAF on playlist and bookmarks routes

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -68,9 +68,8 @@ class BookmarksController < CatalogController
     @response, @documents = action_documents
     @valid_user_actions = [:delete, :unpublish, :publish, :merge, :move, :update_access_control, :add_to_playlist]
     @valid_user_actions += [:intercom_push] if Settings.intercom.present?
-    mos = @documents.collect { |doc| MediaObject.find( doc.id ) }
     @documents.each do |doc|
-      mo = MediaObject.find(doc.id)
+      mo = SpeedyAF::Proxy::MediaObject.find(doc.id)
       @valid_user_actions.delete :delete if @valid_user_actions.include? :delete and cannot? :destroy, mo
       @valid_user_actions.delete :unpublish if @valid_user_actions.include? :unpublish and cannot? :unpublish, mo
       @valid_user_actions.delete :publish if @valid_user_actions.include? :publish and cannot? :update, mo
@@ -124,7 +123,7 @@ class BookmarksController < CatalogController
     errors = []
     success_ids = []
     Array(documents.map(&:id)).each do |id|
-      media_object = MediaObject.find(id)
+      media_object = SpeedyAF::Proxy::MediaObject.find(id)
       if cannot? :update_access_control, media_object
         errors += ["#{media_object.title} (#{id}) #{t('blacklight.messages.permission_denied')}."]
       else
@@ -141,7 +140,7 @@ class BookmarksController < CatalogController
   def add_to_playlist_action documents
     playlist = Playlist.find(params[:target_playlist_id])
     Array(documents.map(&:id)).each do |id|
-      media_object = MediaObject.find(id)
+      media_object = SpeedyAF::Proxy::MediaObject.find(id)
       media_object.ordered_master_files.to_a.each do |mf|
         clip = AvalonClip.create(master_file: mf)
         PlaylistItem.create(clip: clip, playlist: playlist)
@@ -152,7 +151,7 @@ class BookmarksController < CatalogController
   def status_action documents
     errors, success_ids = [], [], []
     Array(documents.map(&:id)).each do |id|
-      media_object = MediaObject.find(id)
+      media_object = SpeedyAF::Proxy::MediaObject.find(id)
       if cannot? :update, media_object
         errors += ["#{media_object.title} (#{id}) #{t('blacklight.messages.permission_denied')}."]
       else
@@ -181,7 +180,7 @@ class BookmarksController < CatalogController
     errors = []
     success_ids = []
     Array(documents.map(&:id)).each do |id|
-      media_object = MediaObject.find(id)
+      media_object = SpeedyAF::Proxy::MediaObject.find(id)
       if can? :destroy, media_object
         success_ids << id
       else
@@ -194,14 +193,14 @@ class BookmarksController < CatalogController
   end
 
   def move_action documents
-    collection = Admin::Collection.find( params[:target_collection_id] )
+    collection = SpeedyAF::Proxy::Admin::Collection.find( params[:target_collection_id] )
     if cannot? :read, collection
       flash[:error] =  t("blacklight.move.error", collection_name: collection.name)
     else
       errors = []
       success_ids = []
       Array(documents.map(&:id)).each do |id|
-        media_object = MediaObject.find(id)
+        media_object = SpeedyAF::Proxy::MediaObject.find(id)
         if cannot? :update, media_object
           errors += ["#{media_object.title} (#{id}) #{t('blacklight.messages.permission_denied')}."]
         else
@@ -222,7 +221,7 @@ class BookmarksController < CatalogController
     session[:intercom_collections] = collections
     if intercom.collection_valid?(params[:collection_id])
       Array(documents.map(&:id)).each do |id|
-        media_object = MediaObject.find(id)
+        media_object = SpeedyAF::Proxy::MediaObject.find(id)
         if cannot? :intercom_push, media_object
           errors += ["#{media_object.title} (#{id}) #{t('blacklight.messages.permission_denied')}."]
         else
@@ -242,10 +241,10 @@ class BookmarksController < CatalogController
 
   def merge_action documents
     errors = []
-    target = MediaObject.find params[:media_object]
+    target = SpeedyAF::Proxy::MediaObject.find params[:media_object]
     subject_ids = documents.collect(&:id)
     subject_ids.delete(target.id)
-    subject_ids.map { |id| MediaObject.find id }.each do |media_object|
+    subject_ids.map { |id| SpeedyAF::Proxy::MediaObject.find id }.each do |media_object|
       if cannot? :destroy, media_object
         errors += ["#{media_object.title || id} #{t('blacklight.messages.permission_denied')}."]
       end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -109,7 +109,7 @@ class MediaObjectsController < ApplicationController
 
   # POST /media_objects/avalon:1/add_to_playlist_form
   def add_to_playlist_form
-    @media_object = MediaObject.find(params[:id])
+    @media_object = SpeedyAF::Proxy::MediaObject.find(params[:id])
     authorize! :read, @media_object
     respond_to do |format|
       format.html do
@@ -120,7 +120,7 @@ class MediaObjectsController < ApplicationController
 
   # POST /media_objects/avalon:1/add_to_playlist
   def add_to_playlist
-    @media_object = MediaObject.find(params[:id])
+    @media_object = SpeedyAF::Proxy::MediaObject.find(params[:id])
     authorize! :read, @media_object
     masterfile_id = params[:post][:masterfile_id]
     playlist_id = params[:post][:playlist_id]
@@ -132,7 +132,7 @@ class MediaObjectsController < ApplicationController
     # If a single masterfile_id wasn't in the request, then create playlist_items for all masterfiles
     masterfile_ids = masterfile_id.present? ? [masterfile_id] : @media_object.ordered_master_file_ids
     masterfile_ids.each do |mf_id|
-      mf = MasterFile.find(mf_id)
+      mf = SpeedyAF::Proxy::MasterFile.find(mf_id)
       if playlistitem_scope=='structure' && mf.has_structuralMetadata? && mf.structuralMetadata.xpath('//Span').present?
         #create individual items for spans within structure
         mf.structuralMetadata.xpath('//Span').each do |s|

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -162,4 +162,18 @@ module MasterFileBehavior
       label: label
     }
   end
+
+  # Supplies the route to the master_file as an rdf formatted URI
+  # @return [String] the route as a uri
+  # @example uri for a mf on avalon.iu.edu with a id of: avalon:1820
+  #   "my_master_file.rdf_uri" #=> "https://www.avalon.iu.edu/master_files/avalon:1820"
+  def rdf_uri
+    master_file_url(id)
+  end
+
+  # Returns the dctype of the master_file
+  # @return [String] either 'dctypes:MovingImage' or 'dctypes:Sound'
+  def rdf_type
+    is_video? ? 'dctypes:MovingImage' : 'dctypes:Sound'
+  end
 end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -461,20 +461,6 @@ class MasterFile < ActiveFedora::Base
     structuralMetadata.xpath('//@label').collect{|a|a.value}
   end
 
-  # Supplies the route to the master_file as an rdf formatted URI
-  # @return [String] the route as a uri
-  # @example uri for a mf on avalon.iu.edu with a id of: avalon:1820
-  #   "my_master_file.rdf_uri" #=> "https://www.avalon.iu.edu/master_files/avalon:1820"
-  def rdf_uri
-    master_file_url(id)
-  end
-
-  # Returns the dctype of the master_file
-  # @return [String] either 'dctypes:MovingImage' or 'dctypes:Sound'
-  def rdf_type
-    is_video? ? 'dctypes:MovingImage' : 'dctypes:Sound'
-  end
-
   def self.post_processing_move_filename(oldpath, options = {})
     prefix = options[:id].tr(':', '_')
     if File.basename(oldpath).start_with?(prefix)

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -57,6 +57,14 @@ describe BookmarksController, type: :controller do
       expect(flash[:success]).to eq(I18n.t("blacklight.delete.success", count: 11))
       media_objects.each {|mo| expect(MediaObject.exists?(mo.id)).to be_falsey }
     end
+
+    context 'read from solr' do
+      it 'should not read from fedora', :no_perform_enqueued_jobs do
+        WebMock.reset_executed_requests!
+        post :delete
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe "#update_status" do
@@ -104,6 +112,14 @@ describe BookmarksController, type: :controller do
         end
       end
     end
+
+    context 'read from solr' do
+      it 'should not read from fedora', :no_perform_enqueued_jobs do
+        WebMock.reset_executed_requests!
+        post 'publish'
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe "index" do
@@ -123,6 +139,14 @@ describe BookmarksController, type: :controller do
         expect(response.body).not_to have_css('#publishLink')
         expect(response.body).not_to have_css('#unpublishLink')
         expect(response.body).not_to have_css('#deleteLink')
+      end
+    end
+
+    context 'read from solr' do
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        get 'index'
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
     end
   end
@@ -146,6 +170,14 @@ describe BookmarksController, type: :controller do
           mo.reload
           expect(mo.collection).to eq(collection2)
         end
+      end
+    end
+
+    context 'read from solr', :no_perform_enqueued_jobs do
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        post 'move', params: { target_collection_id: collection2.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
     end
   end
@@ -203,6 +235,14 @@ describe BookmarksController, type: :controller do
         expect_any_instance_of(Avalon::Intercom).to receive(:push_media_object).exactly(3).times.and_call_original
         post 'intercom_push', params: { collection_id: 'cupcake_collection' }
         expect(flash[:success]).to eq('Sucessfully started push of 3 media objects.')
+      end
+    end
+
+    context 'read from solr', :no_perform_enqueued_jobs do
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        post 'intercom_push', params: { collection_id: 'cupcake_collection' }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
     end
   end
@@ -423,6 +463,14 @@ describe BookmarksController, type: :controller do
         end
       end
     end
+
+    context 'read from solr' do
+      it 'should not read from fedora', :no_perform_enqueued_jobs do
+        WebMock.reset_executed_requests!
+        post 'update_access_control', params: { hidden: "true" }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe "#merge", :no_perform_enqueued_jobs do
@@ -448,6 +496,14 @@ describe BookmarksController, type: :controller do
         subject_ids = media_objects.collect(&:id) - [target.id]
         expect { post 'merge', params: { media_object: target.id } }.to have_enqueued_job(BulkActionJobs::Merge).with(target.id, subject_ids.sort)
         expect(flash[:success]).to start_with("Merging 2 items into")
+      end
+    end
+
+    context 'read from solr', :no_perform_enqueued_jobs do
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        post 'merge', params: { media_object: target.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
     end
   end


### PR DESCRIPTION
Also update the ability to use either ActiveFedora or SpeedyAF proxy objects throughout.  This was needed for bookmark routes but can also be used for some more media objects routes.