### PR TITLE
Use SpeedyAF when rendering bulk action modals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,12 +122,12 @@ class ApplicationController < ActionController::Base
     # return all collections to admin, unless specific user is passed in
     if can?(:manage, Admin::Collection)
       if user.blank?
-        Admin::Collection.all
+        SpeedyAF::Proxy::Admin::Collection.where("*:*").to_a
       else
-        Admin::Collection.where("inheritable_edit_access_person_ssim" => user).to_a
+        SpeedyAF::Proxy::Admin::Collection.where("inheritable_edit_access_person_ssim:#{user}").to_a
       end
     else
-      Admin::Collection.where("inheritable_edit_access_person_ssim" => user_key).to_a
+      SpeedyAF::Proxy::Admin::Collection.where("inheritable_edit_access_person_ssim:#{user_key}").to_a
     end
   end
   helper_method :get_user_collections

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -27,6 +27,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     # Handle this case here until a better fix can be found for multiple solr fields which don't have a model property
     @attrs[:section_id] = solr_document["section_id_ssim"]
     @attrs[:date_issued] = solr_document["date_ssi"]
+    @attrs[:hidden?] = solr_document["hidden_bsi"]
     # TODO Need to convert hidden_bsi into discover_groups?
     SINGULAR_FIELDS.each do |field_name|
       @attrs[field_name] = Array(@attrs[field_name]).first

--- a/app/views/bookmarks/delete.html.erb
+++ b/app/views/bookmarks/delete.html.erb
@@ -29,7 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <p><%= t('blacklight.delete.confirm', count: @documents.count) %></p>
           <ul>
             <% @documents.each do |doc| %>
-              <% @mediaobject = MediaObject.find(doc.id)  %>
+              <% @mediaobject = SpeedyAF::Proxy::MediaObject.find(doc.id)  %>
               <% if can? :destroy, @mediaobject  %>
                 <li><%= @mediaobject.title %> (<%= doc.id %>)<%=hidden_field_tag "id[]", doc.id %></li>
               <% else %>

--- a/app/views/bookmarks/merge.html.erb
+++ b/app/views/bookmarks/merge.html.erb
@@ -41,7 +41,7 @@ Unless required by applicable law or agreed to in writing, software distributed
               <div class="form-check">
                 <%= radio_button_tag :media_object, d.id, style: 'width:100%;' %>
                 <%= label_tag "media_object_#{d.id}", "#{d["title_tesi"] || "No title"} - #{d.id}" %>
-                <% t('blacklight.merge.insufficient_rights') if cannot? :destroy, MediaObject.find(d.id) %>
+                <% t('blacklight.merge.insufficient_rights') if cannot? :destroy, SpeedyAF::Proxy::MediaObject.find(d.id) %>
               </div>
             <% end %>
           </fieldset>

--- a/app/views/bookmarks/move.html.erb
+++ b/app/views/bookmarks/move.html.erb
@@ -19,7 +19,6 @@ Unless required by applicable law or agreed to in writing, software distributed
     dropdownParent: $('#blacklight-modal')
   });
 </script>
-
 <% @candidates = get_user_collections %>
 <div class="modal-header">
   <h1><%= t('blacklight.move.form.title') %></h1>

--- a/app/views/bookmarks/update_access_control.html.erb
+++ b/app/views/bookmarks/update_access_control.html.erb
@@ -28,7 +28,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 <% else %>
   <%
-   @media_objects = @documents.collect {|doc| MediaObject.find(doc.id)}
+   @media_objects = @documents.collect {|doc| SpeedyAF::Proxy::MediaObject.find(doc.id)}
    visibility = @media_objects.first.visibility
    @visibility = visibility if @media_objects.all? {|mo| mo.visibility == visibility}
    @shown = @media_objects.all? {|doc| doc.hidden? == false}

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -47,18 +47,18 @@ describe ApplicationController do
   end
 
   describe '#get_user_collections' do
-    let(:collection1) { FactoryBot.create(:collection) }
-    let(:collection2) { FactoryBot.create(:collection) }
+    let!(:collection1) { FactoryBot.create(:collection) }
+    let!(:collection2) { FactoryBot.create(:collection) }
 
     it 'returns all collections for an administrator' do
       login_as :administrator
-      expect(controller.get_user_collections).to include(collection1)
-      expect(controller.get_user_collections).to include(collection2)
+      expect(controller.get_user_collections).to include(have_attributes(id: collection1.id))
+      expect(controller.get_user_collections).to include(have_attributes(id: collection2.id))
     end
     it 'returns only relevant collections for a manager' do
       login_user collection1.managers.first
-      expect(controller.get_user_collections).to include(collection1)
-      expect(controller.get_user_collections).not_to include(collection2)
+      expect(controller.get_user_collections).to include(have_attributes(id: collection1.id))
+      expect(controller.get_user_collections).not_to include(have_attributes(id: collection2.id))
     end
     it 'returns no collections for an end-user' do
       login_as :user
@@ -70,8 +70,8 @@ describe ApplicationController do
     end
     it 'returns requested user\'s collections for an administrator' do
       login_as :administrator
-      expect(controller.get_user_collections collection1.managers.first).to include(collection1)
-      expect(controller.get_user_collections collection1.managers.first).not_to include(collection2)
+      expect(controller.get_user_collections collection1.managers.first).to include(have_attributes(id: collection1.id))
+      expect(controller.get_user_collections collection1.managers.first).not_to include(have_attributes(id: collection2.id))
     end
   end
 

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -61,6 +61,7 @@ describe BookmarksController, type: :controller do
     context 'read from solr' do
       it 'should not read from fedora', :no_perform_enqueued_jobs do
         WebMock.reset_executed_requests!
+        get :delete
         post :delete
         expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
@@ -176,6 +177,7 @@ describe BookmarksController, type: :controller do
     context 'read from solr', :no_perform_enqueued_jobs do
       it 'should not read from fedora' do
         WebMock.reset_executed_requests!
+        get 'move'
         post 'move', params: { target_collection_id: collection2.id }
         expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
@@ -241,6 +243,7 @@ describe BookmarksController, type: :controller do
     context 'read from solr', :no_perform_enqueued_jobs do
       it 'should not read from fedora' do
         WebMock.reset_executed_requests!
+        get 'intercom_push'
         post 'intercom_push', params: { collection_id: 'cupcake_collection' }
         expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
@@ -467,6 +470,7 @@ describe BookmarksController, type: :controller do
     context 'read from solr' do
       it 'should not read from fedora', :no_perform_enqueued_jobs do
         WebMock.reset_executed_requests!
+        get 'update_access_control'
         post 'update_access_control', params: { hidden: "true" }
         expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
@@ -502,6 +506,7 @@ describe BookmarksController, type: :controller do
     context 'read from solr', :no_perform_enqueued_jobs do
       it 'should not read from fedora' do
         WebMock.reset_executed_requests!
+        get 'merge'
         post 'merge', params: { media_object: target.id }
         expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end


### PR DESCRIPTION
Also use SpeedyAF to determine collections a user has manage access (this should resolve local issue 166).