### PR TITLE
Index collection#cdl_enabled as singular boolean

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -69,7 +69,7 @@ class Admin::Collection < ActiveFedora::Base
     index.as :stored_sortable
   end
   property :cdl_enabled, predicate: Avalon::RDFVocab::Collection.cdl_enabled, multiple: false do |index|
-    index.as :symbol
+    index.as ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed)
   end
 
   has_subresource 'poster', class_name: 'IndexedFile'

--- a/spec/presenters/speedy_af/proxy/admin/collection_spec.rb
+++ b/spec/presenters/speedy_af/proxy/admin/collection_spec.rb
@@ -1,0 +1,51 @@
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe SpeedyAF::Proxy::Admin::Collection do
+  let(:collection) { FactoryBot.create(:collection) }
+  let(:presenter) { described_class.find(collection.id) }
+
+  describe 'cdl_enabled' do
+    context 'collections disabled at the application level' do
+      before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(false) }
+      it 'sets collection cdl to be disabled by default' do
+        expect(presenter.cdl_enabled?).to be false
+      end
+      context 'turned on for collection' do
+        let(:collection2) { FactoryBot.create(:collection, cdl_enabled: true) }
+        let(:presenter2) { described_class.find(collection2.id) }
+        it 'does not affect other collections' do
+          expect(presenter.cdl_enabled?).to be false
+          expect(presenter2.cdl_enabled?).to be true
+        end
+      end
+    end
+    context 'collections enabled at the application level' do
+      before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(true) }
+      it 'sets collection cdl to be enabled by default' do
+        expect(presenter.cdl_enabled?).to be true
+      end 
+      context 'turned off for collection' do
+        let(:collection2) { FactoryBot.create(:collection, cdl_enabled: false) }
+        let(:presenter2) { described_class.find(collection2.id) }
+        it 'does not affect other collections' do
+          expect(presenter.cdl_enabled?).to be true
+          expect(presenter2.cdl_enabled?).to be false 
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Existing Behavior
`Admin::Collection` objects index `cdl_enabled` as a string using the `_ssim` suffix.  When this gets turned into a SpeedyAF proxy it becomes a string (e.g. `"false"`).  Before this fix, the proxy was returning exactly what `cdl_enabled` was and `"false"` evaluates to `true` in an `if` statement which was making all MediaObject's behave as CDL enabled.

This PR change the indexing of `cdl_enabled` to use the `_bsi` suffix.  This will require reindexing all collections which shouldn't be too hard, but will need to be included in the upgrade instructions.

Fixes #5255 