### PR TITLE
Fix alignments of the edit forms and labels for supplemental file editing

### DIFF
--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -37,7 +37,8 @@ $('button[name="cancel_edit_label"]').on('click', (e) => {
 
   $row.removeClass('is-editing');
 
-  if(document.getElementsByClassName('is-editing').length === 1){
+  // Remove form label row
+  if($('.captions').find('.is-editing').length === 1){
     $('#edit-label-row').removeClass('is-editing');
   }
 });
@@ -49,7 +50,8 @@ $('button[name="save_label"]').on('click', (e) => {
 
   $row.removeClass('is-editing');
 
-  if(document.getElementsByClassName('is-editing').length === 1){
+  // Remove form label row
+  if($('.captions').find('.is-editing').length === 1){
     $('#edit-label-row').removeClass('is-editing');
   }
 
@@ -58,7 +60,9 @@ $('button[name="save_label"]').on('click', (e) => {
     var alert = $row.find(
       'small[name="flash-message-' + masterfileId + '-' + fileId + '"]'
     );
-    alert.html('');
+    $row.find('.icon-success').addClass('d-none');
+    $row.find('.icon-error').addClass('d-none');
+    $row.find('.message-content').html();
     alert.removeClass();
     alert.addClass('visible-inline');
   }, 5000);
@@ -85,15 +89,17 @@ $('.supplemental-file-form')
       .text(newLabel);
 
     // Show flash message for success
-    $row.find('.visible-inline').html('Successfully updated.');
+    $row.find('.message-content').html('Successfully updated.');
+    $row.find('.icon-success').removeClass('d-none');
     $row.find('.visible-inline').addClass('alert');
   })
   .on('ajax:error', (event, xhr, status, error) => {
-    var alert = $(event.currentTarget.parentElement).find('.visible-inline');
+    var $row = $(event.currentTarget.parentElement)
 
     // Show flash warning for failed attempt
-    alert.html('Failed to update.');
-    alert.addClass('alert');
+    $row.find('.message-content').html('Failed to update.');
+    $row.find('.icon-error').removeClass('d-none');
+    $row.find('.visible-inline').addClass('alert');
   });
 
 /* Store collapsed section ids in localStorage */

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -925,9 +925,8 @@ h5.card-title {
     }
 
     .caption-form-label {
-      display: inline-block;
-      margin-left: 10px;
-      width: 48%;
+      font-style: italic;
+      font-weight: bold;
     }
 
     div.supplemental-file-data {
@@ -951,8 +950,11 @@ h5.card-title {
       margin-top: 0.75rem;
 
       .visible-inline {
-        margin-left: 30px;
         display: none;
+
+        .icon-success, .icon-error {
+          font-size: 1.2rem;
+        }
       }
 
       .alert {

--- a/app/views/media_objects/_supplemental_files_list.html.erb
+++ b/app/views/media_objects/_supplemental_files_list.html.erb
@@ -18,11 +18,11 @@ Unless required by applicable law or agreed to in writing, software distributed
             <div class="file_view <% if tag == "caption" %>captions<% end %>">
               <% if tag == "caption" %>
                 <div class="row supplemental-file-data edit-item" id="edit-label-row">
-                  <div class="col-md-3 col">
-                    <label>Label</label>
+                  <div class="col-md-4 col-4">
+                    <label class="caption-form-label">Label</label>
                   </div>
-                  <div class="col-md-3 col">
-                    <label>Language</label>
+                  <div class="col-md-4 col-4">
+                    <label class="caption-form-label">Language</label>
                   </div>
                 </div>
               <% end %>
@@ -32,12 +32,12 @@ Unless required by applicable law or agreed to in writing, software distributed
                     <%= form_for :supplemental_file, url: object_supplemental_file_path(section, file), remote: true,
                           html: { method: "put", class: "supplemental-file-form edit-item", id: "form-#{file.id}" },
                           data: { file_id: file.id, masterfile_id: section.id } do |form| %>
-                        <div class="col-sm-6 col form-row">
-                          <div class="form-group col-md-6 col">
+                        <div class="col-sm-9 col-md-8 col-9 form-row p-0">
+                          <div class="form-group col-md-6 col-sm-6 col-6">
                             <%= form.text_field :label, id: "supplemental_file_input_#{section.id}_#{file.id}", value: file.label %>
                           </div>
                           <% if tag == 'transcript' %>
-                            <span class="form-group col-md-6 col">
+                            <span class="form-group col-md-6 col-sm-6 col-6 p-0">
                               <%= label_tag "machine_generated_#{file.id}", class: "ml-3" do %>
                                 <%= check_box_tag "machine_generated_#{file.id}", '1', file.machine_generated? %>
                                 Machine Generated
@@ -45,14 +45,14 @@ Unless required by applicable law or agreed to in writing, software distributed
                             </span>
                           <% end %>
                           <% if tag == 'caption' %>
-                            <div class="form-group col-md-6 col">
+                            <div class="form-group col-md-6 col p-0">
                               <%= form.text_field :language, id: "supplemental_file_language_#{section.id}_#{file.id}", value: LanguageTerm.find(file.language).text,
                                   class: "typeahead from-model form-control",
                                   data: { model: 'languageTerm', validate: false } %>
                             </div>
                           <% end %>
                         </div>
-                        <div class="col-sm-6 col">
+                        <div class="col-sm-3 col-md-4 col-3 p-0">
                           <div class="btn-toolbar">
                             <%= button_tag name: 'save_label', :class => "btn btn-outline btn-sm edit-item" do %>
                               <i class="fa fa-check" title="Save"></i> <span class="sm-hidden">Save</span>
@@ -63,13 +63,19 @@ Unless required by applicable law or agreed to in writing, software distributed
                           </div>
                         </div>
                     <% end %>
-                    <small class="visible-inline" name="flash-message-<%= section.id %>-<%= file.id %>"></small>
+                    <small class="visible-inline" name="flash-message-<%= section.id %>-<%= file.id %>">
+                      <i class="fa fa-check-circle icon-success d-none" title="Success"></i>
+                      <i class="fa fa-times-circle icon-error d-none" title="Error"></i>
+                      <span class="sm-hidden message-content"></span>
+                    </small>
                     <div class="btn-toolbar float-right">
                       <%# Update button %>
                       <%= button_tag name: 'edit_label', class:'btn btn-outline btn-sm edit_label display-item', type: 'button' do %>
                         <i class="fa fa-edit" title="Edit"></i> <span class="sm-hidden">Edit</span>
                       <% end %>
-                      <%= link_to("Remove", object_supplemental_file_path(section, file), title: 'Remove', method: :delete, class: "btn btn-danger btn-sm file-remove btn-confirmation") %>
+                      <%= link_to(object_supplemental_file_path(section, file), title: 'Remove', method: :delete, class: "btn btn-danger btn-sm file-remove btn-confirmation") do %>
+                        <i class="fa fa-trash" title="Delete"></i> <span class="sm-hidden">Delete</span>
+                      <% end %>
                     </div>
                 </div>
               <% end %>


### PR DESCRIPTION
Closes #5224 

With the CSS changes in the PR the edit forms now looks as follows;
In medium size devices (desktop/iPad):
![Screenshot from 2023-07-10 13-53-36](https://github.com/avalonmediasystem/avalon/assets/1331659/ce6374c5-306c-4258-aa90-1b8099c27b07)
![Screenshot from 2023-07-10 13-55-14](https://github.com/avalonmediasystem/avalon/assets/1331659/d3a558ca-8dcd-4589-8df0-75ded30ca59e)

In smaller devices (phones):
![Screenshot from 2023-07-10 14-47-23](https://github.com/avalonmediasystem/avalon/assets/1331659/0b4d53e2-71fd-4809-930e-2deadd26df2e)
![Screenshot from 2023-07-10 13-54-47](https://github.com/avalonmediasystem/avalon/assets/1331659/ec3fbbce-0f11-4244-97fc-c7efa215a4f4)