### PR TITLE
Fix read group assignment on overwrite

### DIFF
--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -213,34 +213,37 @@ module BulkActionJobs
           media_object.lending_period = collection.default_lending_period
         end
 
-        # If MediaObject visibility is different than Collection, the collection visibility
-        # overwrites, or is added to, the media object read groups. This can result in the media object
-        # read groups containing the wrong visibilty or multiple visibilities.
-        # Remove visibility from the default_read_groups array to protect against this.
-        collection_read_groups = collection.default_read_groups.to_a - [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED,
-                                                                        Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,
-                                                                        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE]
 
-        # When overwriting the read group, we have to add the media object visibility back into the array,
-        # otherwise the media object will default to private.
-        media_object_visibility_group = if media_object.visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-                                          [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
-                                        elsif media_object.visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-                                          [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED]
-                                        else
-                                          [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE]
-                                        end
+        if save_field == "special_access"
+          # If MediaObject visibility is different than Collection, the collection visibility
+          # overwrites, or is added to, the media object read groups. This can result in the media object
+          # read groups containing the wrong visibilty or multiple visibilities.
+          # Remove visibility from the default_read_groups array to protect against this.
+          collection_read_groups = collection.default_read_groups.to_a - [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED,
+                                                                          Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,
+                                                                          Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE]
 
-        # Special access
-        if overwrite && save_field == "special_access"
-          media_object.read_groups = collection_read_groups
-          media_object.read_groups += media_object_visibility_group
-          media_object.read_users = collection.default_read_users.to_a
-        elsif !overwrite && save_field == "special_access"
-          media_object.read_groups += collection_read_groups
-          media_object.read_groups.uniq!
-          media_object.read_users += collection.default_read_users.to_a
-          media_object.read_users.uniq!
+          # When overwriting the read group, we have to add the media object visibility back into the array,
+          # otherwise the media object will default to private.
+          media_object_visibility_group = if media_object.visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+                                            [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+                                          elsif media_object.visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+                                            [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED]
+                                          else
+                                            [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE]
+                                          end
+
+          # Special access
+          if overwrite
+            media_object.read_groups = collection_read_groups
+            media_object.read_groups += media_object_visibility_group
+            media_object.read_users = collection.default_read_users.to_a
+          else
+            media_object.read_groups += collection_read_groups
+            media_object.read_groups.uniq!
+            media_object.read_users += collection.default_read_users.to_a
+            media_object.read_users.uniq!
+          end
         end
 
         if media_object.save

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -128,7 +128,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                            lending_period: @collection.default_lending_period,
                            cdl: @collection.cdl_enabled } %>
 
-  <h3>Set Default Access Control for New Items</h3>
+  <h3 style="padding-top: 3rem;">Set Default Access Control for New Items</h3>
   <%= render "discovery_visibility_form", { object: @collection,
                                             visibility: @collection.default_visibility,
                                             hidden: @collection.default_hidden } %>


### PR DESCRIPTION
@elynema found a bug in the access settings work when performing an overwrite that caused media object visibility to change. This PR ensures that the media object visibility read group is maintained through an overwrite and that the media object does not end up with multiple or no visibility read groups assigned.

This PR also adds increased whitespace above the "Set Default Access Control" heading per discussion in #5227 