### PR TITLE
Allow users in manager group to be added to collection with editor role

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -71,6 +71,9 @@ class Admin::Collection < ActiveFedora::Base
   property :cdl_enabled, predicate: Avalon::RDFVocab::Collection.cdl_enabled, multiple: false do |index|
     index.as ActiveFedora::Indexing::Descriptor.new(:boolean, :stored, :indexed)
   end
+  property :collection_managers, predicate: Avalon::RDFVocab::Collection.collection_managers, multiple: true do |index|
+    index.as :symbol
+  end
 
   has_subresource 'poster', class_name: 'IndexedFile'
 
@@ -95,6 +98,7 @@ class Admin::Collection < ActiveFedora::Base
 
   def add_manager user
     raise ArgumentError, "User #{user} does not belong to the manager group." unless (Avalon::RoleControls.users("manager") + (Avalon::RoleControls.users("administrator") || []) ).include?(user)
+    self.collection_managers += [user]
     self.edit_users += [user]
     self.inherited_edit_users += [user]
   end
@@ -103,6 +107,7 @@ class Admin::Collection < ActiveFedora::Base
     return unless managers.include? user
     raise ArgumentError, "At least one manager is required." if self.managers.size == 1
 
+    self.collection_managers = self.collection_managers.to_a - [user]
     self.edit_users -= [user]
     self.inherited_edit_users -= [user]
   end

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -65,6 +65,7 @@ module Avalon
       property :default_visibility,       "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
       property :default_hidden,           "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
       property :cdl_enabled,              "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
+      property :collection_managers,       "rdfs:isDefinedBy" => %(avr-collection:).freeze, type: "rdfs:Class".freeze
     end
 
     class EBUCore < RDF::StrictVocabulary("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#")

--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -12,21 +12,16 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-# This module contains methods which transform stored values for use either on Admin::Collection or the SpeedyAF presenter
-module AdminCollectionBehavior
-  def managers
-    edit_users & collection_managers.to_a
-  end
-
-  def editors
-    edit_users - managers
-  end
-
-  def editors_and_managers
-    edit_users
-  end
-
-  def depositors
-    read_users
+namespace :avalon do
+  namespace :migrate do
+    desc "Set new collection managers property on collection model as part of bugfix allowing users that belong to the manager group to be given the editor role"
+    task collection_managers: :environment do
+      Admin::Collection.all.each do |collection|
+        next unless collection.collection_managers.blank?
+        # initialize to old behavior
+        collection.collection_managers = edit_users & ( Avalon::RoleControls.users("manager") | (Avalon::RoleControls.users("administrator") || []) )
+        collection.save!
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #5241 

The fix to this long standing bug was to add a new property to the model.  Because of this a migration rake task was added to avoid existing managers becoming editors.

Administrators can now also be added as editors but it wouldn't have any effect since they are still administrators and can still do anything in the system.