### PR TITLE
Fix bugs with collection manager move to new property

### DIFF
--- a/app/presenters/admin/collection_presenter.rb
+++ b/app/presenters/admin/collection_presenter.rb
@@ -43,7 +43,7 @@ class Admin::CollectionPresenter
   end
 
   def managers
-    @managers ||= document["edit_access_person_ssim"] & (Avalon::RoleControls.users("manager") | (Avalon::RoleControls.users("administrator") || []))
+    @managers ||= document["edit_access_person_ssim"] & (document["collection_managers_ssim"] || [])
   end
 
   def editors

--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -19,7 +19,7 @@ namespace :avalon do
       Admin::Collection.all.each do |collection|
         next unless collection.collection_managers.blank?
         # initialize to old behavior
-        collection.collection_managers = edit_users & ( Avalon::RoleControls.users("manager") | (Avalon::RoleControls.users("administrator") || []) )
+        collection.collection_managers = collection.edit_users & ( Avalon::RoleControls.users("manager") | (Avalon::RoleControls.users("administrator") || []) )
         collection.save!
       end
     end

--- a/spec/presenters/admin_collection_presenter_spec.rb
+++ b/spec/presenters/admin_collection_presenter_spec.rb
@@ -21,7 +21,7 @@ describe Admin::CollectionPresenter do
   let(:unit) { "Default Unit" }
   let(:description) { "The long form description of this collection." }
   let(:managers) { [manager.to_s] }
-  let(:editors) { [editor.to_s] }
+  let(:editors) { [editor.to_s, FactoryBot.create(:manager)] }
   let(:depositors) { [depositor.to_s] }
   let(:manager) { FactoryBot.create(:manager) }
   let(:editor) { FactoryBot.create(:user) }
@@ -33,7 +33,8 @@ describe Admin::CollectionPresenter do
       "unit_ssi": unit,
       "description_tesim": [description],
       "edit_access_person_ssim": managers + editors,
-      "read_access_person_ssim": depositors
+      "read_access_person_ssim": depositors,
+      "collection_managers_ssim": managers
     )
   end
   subject(:presenter) { described_class.new(solr_doc) }


### PR DESCRIPTION
When testing #5265 on avalon-dev I found a couple bugs which this PR addresses.
1. The Manage Content page uses a presenter to display the number of managers and missed getting updated in the previous PR.
2. The migration rake task had a bug.