### PR TITLE
Use #update instead of deprecated #update_attributes

### DIFF
--- a/app/controllers/samvera/persona/users_controller.rb
+++ b/app/controllers/samvera/persona/users_controller.rb
@@ -129,7 +129,7 @@ module Samvera
       end
 
       respond_to do |format|
-        if @user.update_attributes(user_params)
+        if @user.update(user_params)
           @user.save
 
           format.html { redirect_to main_app.persona_users_path, notice: 'User was successfully updated.' }#move to locales

--- a/spec/controllers/samvera/persona/user_controller_spec.rb
+++ b/spec/controllers/samvera/persona/user_controller_spec.rb
@@ -208,4 +208,17 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
       end
     end
   end
+
+  describe "#update" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:admin) { FactoryBot.create(:admin) }
+
+    before do
+      sign_in(admin)
+    end
+
+    it 'updates email' do
+      expect { put :update, params: { id: user.id, user: { username: user.username, email: "new_email@example.com" } } }.to change { user.reload.email }.to("new_email@example.com")
+    end
+  end
 end


### PR DESCRIPTION
Fix for https://github.com/avalonmediasystem/avalon-terraform/issues/43

This should be contributed back upstream to Persona.  There were no tests for this and the `#update_attributes` method was removed in Rails 6.1.