### PR TITLE
Strip trailing slashes from uris to avoid odd case in AF/LDP/AT

### DIFF
--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -4,7 +4,7 @@ ActiveFedora::Base.translate_uri_to_id = lambda do |uri|
                                            uri.to_s.sub(baseurl, '').split('/', baseparts).last
                                          end
 ActiveFedora::Base.translate_id_to_uri = lambda do |id|
-                                           "#{baseurl}/#{Noid::Rails.treeify(id).sub(/\/$/, '')}"
+                                           "#{baseurl}/#{Noid::Rails.treeify(id).sub(/\/+$/, '')}"
                                          end
 ActiveFedora::Base.logger = Rails.logger
 

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -4,7 +4,7 @@ ActiveFedora::Base.translate_uri_to_id = lambda do |uri|
                                            uri.to_s.sub(baseurl, '').split('/', baseparts).last
                                          end
 ActiveFedora::Base.translate_id_to_uri = lambda do |id|
-                                           "#{baseurl}/#{Noid::Rails.treeify(id)}"
+                                           "#{baseurl}/#{Noid::Rails.treeify(id).sub(/\/$/, '')}"
                                          end
 ActiveFedora::Base.logger = Rails.logger
 

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -23,6 +23,17 @@ describe MediaObject do
     expect { media_object.assign_id! }.to change { media_object.id }.from(nil).to(String)
   end
 
+  describe 'find' do
+    it 'returns an object' do
+      expect(MediaObject.find(media_object.id)).to eq media_object
+    end
+    context 'with trailing slash' do
+      it 'returns an object' do
+        expect(MediaObject.find(media_object.id + '/')).to eq media_object
+      end
+    end
+  end
+
   describe 'validations' do
     # Force the validations to run by being on the resource-description workflow step
     let(:media_object) { FactoryBot.build(:media_object).tap {|mo| mo.workflow.last_completed_step = "resource-description"} }


### PR DESCRIPTION
Resolves #5283 

The problem we encountered is that ActiveFedora will return an initialized but empty object of the correct class when requesting an object with a trailing slash on it's id.  I was originally thinking of patching ActiveFedora, but after digging it seems like the easiest solution is to strip the trailing slash when converting the id to a uri before it is used to make the LDP request.  I was thinking that a more correct fix would be to have LDP/ActiveTriples update the subject instance variable to match what the server returned in the RDF in the response body (instead of what was passed into the initializer) but I wasn't quite sure where the best place to make that change.