### PR TITLE
Switch out calls to open() with Faraday

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -14,7 +14,6 @@
 
 require 'fileutils'
 require 'hooks'
-require 'open-uri'
 require 'avalon/file_resolver'
 require 'avalon/m3u8_reader'
 
@@ -576,7 +575,10 @@ class MasterFile < ActiveFedora::Base
     # Fixes https://github.com/avalonmediasystem/avalon/issues/3474
     target_location = File.basename(details[:location]).split('?')[0]
     target = File.join(Dir.tmpdir, target_location)
-    File.open(target,'wb') { |f| open(details[:location]) { |io| f.write(io.read) } }
+    File.open(target,'wb') do |f|
+      resp = Faraday.get(details[:location])
+      f.write(resp.body)
+    end
     return target, details[:offset]
   end
 

--- a/lib/avalon/m3u8_reader.rb
+++ b/lib/avalon/m3u8_reader.rb
@@ -12,9 +12,6 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-require 'open-uri'
-require 'uri'
-
 module Avalon
   class M3U8Reader
     attr_reader :playlist
@@ -24,7 +21,8 @@ module Avalon
         new(io.read, recursive: recursive)
       elsif io.is_a?(String)
         if io =~ /^https?:/
-          open(io, "Referer" => Rails.application.routes.url_helpers.root_url) { |resp| new(resp, Addressable::URI.parse(io), recursive: recursive) }
+          resp = Faraday.get(io, {}, { "Referer" => Rails.application.routes.url_helpers.root_url })
+          new(resp.body, Addressable::URI.parse(io), recursive: recursive)
         elsif io =~ /\.m3u8?$/i
           new(File.read(io), io, recursive: recursive)
         else

--- a/spec/lib/avalon/m3u8_read_spec.rb
+++ b/spec/lib/avalon/m3u8_read_spec.rb
@@ -16,21 +16,84 @@ require 'rails_helper'
 require 'avalon/m3u8_reader'
 
 describe Avalon::M3U8Reader do
-  let(:m3u_file)  { File.expand_path('../../../fixtures/The_Fox.mp4.m3u',__FILE__) }
-  let(:m3u)       { Avalon::M3U8Reader.read(m3u_file) }
+  let(:m3u_filename)  { File.expand_path('../../../fixtures/The_Fox.mp4.m3u',__FILE__) }
+  let(:m3u)       { Avalon::M3U8Reader.read(m3u_filename) }
   let(:framespec) { m3u.at(127000) }
 
-  it "should know how many files it has" do
-    expect(m3u.files.length).to eq(23)
+  context 'with a filepath' do
+    it "should know how many files it has" do
+      expect(m3u.files.length).to eq(23)
+    end
+
+    it "should know its duration" do
+      expect(m3u.duration.round(2)).to eq(225.14)
+    end
+
+    it "should be able to locate a frame" do
+      expect(framespec[:location]).to match(%r{/The_Fox.mp4-012.ts$})
+      expect(framespec[:filename]).to eq('The_Fox.mp4-012.ts')
+      expect(framespec[:offset].round(2)).to eq(6818.91)
+    end
   end
 
-  it "should know its duration" do
-    expect(m3u.duration.round(2)).to eq(225.14)
+  context 'with a url' do
+    let(:m3u_url) { Rails.application.routes.url_helpers.hls_manifest_master_file_url(id: 1, quality: "auto") }
+    let(:m3u) { Avalon::M3U8Reader.read(m3u_url) }
+
+    before do
+      stub_request(:get, m3u_url).to_return(body: File.read(m3u_filename))
+    end
+
+    it "should know how many files it has" do
+      expect(m3u.files.length).to eq(23)
+    end
+
+    it "should know its duration" do
+      expect(m3u.duration.round(2)).to eq(225.14)
+    end
+
+    it "should be able to locate a frame" do
+      expect(framespec[:location]).to match(%r{/The_Fox.mp4-012.ts$})
+      expect(framespec[:filename]).to eq('The_Fox.mp4-012.ts')
+      expect(framespec[:offset].round(2)).to eq(6818.91)
+    end
   end
 
-  it "should be able to locate a frame" do
-    expect(framespec[:location]).to match(%r{/The_Fox.mp4-012.ts$})
-    expect(framespec[:filename]).to eq('The_Fox.mp4-012.ts')
-    expect(framespec[:offset].round(2)).to eq(6818.91)
+  context 'with a file' do
+    let(:m3u_file) { File.open(m3u_filename) }
+    let(:m3u) { Avalon::M3U8Reader.read(m3u_file) }
+
+    it "should know how many files it has" do
+      expect(m3u.files.length).to eq(23)
+    end
+
+    it "should know its duration" do
+      expect(m3u.duration.round(2)).to eq(225.14)
+    end
+
+    it "should be able to locate a frame" do
+      expect(framespec[:location]).to match(%r{/The_Fox.mp4-012.ts$})
+      expect(framespec[:filename]).to eq('The_Fox.mp4-012.ts')
+      expect(framespec[:offset].round(2)).to eq(6818.91)
+    end
+  end
+
+  context 'with a string' do
+    let(:m3u_file_contents) { File.read(m3u_filename) }
+    let(:m3u) { Avalon::M3U8Reader.read(m3u_file_contents) }
+
+    it "should know how many files it has" do
+      expect(m3u.files.length).to eq(23)
+    end
+
+    it "should know its duration" do
+      expect(m3u.duration.round(2)).to eq(225.14)
+    end
+
+    it "should be able to locate a frame" do
+      expect(framespec[:location]).to match(%r{/The_Fox.mp4-012.ts$})
+      expect(framespec[:filename]).to eq('The_Fox.mp4-012.ts')
+      expect(framespec[:offset].round(2)).to eq(6818.91)
+    end
   end
 end


### PR DESCRIPTION
Resolves #5286 

This is a fix which we made in IU production that I thought was maybe specific to us so I didn't pull it back into core but @sgurnick ran into it as well in #5286.