### PR TITLE
Ensure migration can run to completion even if a collection is manager-less

### DIFF
--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -20,7 +20,7 @@ namespace :avalon do
         next unless collection.collection_managers.blank?
         # initialize to old behavior
         collection.collection_managers = collection.edit_users & ( Avalon::RoleControls.users("manager") | (Avalon::RoleControls.users("administrator") || []) )
-        collection.save!
+        collection.save!(validate: false)
       end
     end
   end


### PR DESCRIPTION
This should lead to less headaches during the upgrade for administrators.