### PR TITLE
Use blank canvas to represent inaccesible playlist items

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -248,11 +248,11 @@ class PlaylistsController < ApplicationController
 
     canvas_presenters = @playlist.items.collect do |item|
       @master_file = item.clip.master_file
-      if @master_file.nil?
-        stream_info = nil
-      else
-        stream_info = secure_streams(@master_file.stream_details, @master_file.media_object_id)
-      end
+      stream_info = if @master_file.nil?
+                      nil
+                    else
+                      secure_streams(@master_file.stream_details, @master_file.media_object_id)
+                    end
       IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info, user: current_user)
     end
     presenter = IiifPlaylistManifestPresenter.new(playlist: @playlist, items: canvas_presenters)

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -247,13 +247,14 @@ class PlaylistsController < ApplicationController
     authorize! :read, @playlist
 
     canvas_presenters = @playlist.items.collect do |item|
+      cannot_read_item = cannot? :read, @master_file
       @master_file = item.clip.master_file
       stream_info = if @master_file.nil?
                       nil
                     else
                       secure_streams(@master_file.stream_details, @master_file.media_object_id)
                     end
-      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info, user: current_user)
+      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info, cannot_read_item: cannot_read_item)
     end
     presenter = IiifPlaylistManifestPresenter.new(playlist: @playlist, items: canvas_presenters)
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -247,10 +247,13 @@ class PlaylistsController < ApplicationController
     authorize! :read, @playlist
 
     canvas_presenters = @playlist.items.collect do |item|
-      next if item.clip.master_file.nil?
       @master_file = item.clip.master_file
-      stream_info = secure_streams(@master_file.stream_details, @master_file.media_object_id)
-      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info)
+      if @master_file.nil?
+        stream_info = nil
+      else
+        stream_info = secure_streams(@master_file.stream_details, @master_file.media_object_id)
+      end
+      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info, user: current_user)
     end
     presenter = IiifPlaylistManifestPresenter.new(playlist: @playlist, items: canvas_presenters)
 

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -16,7 +16,7 @@ class IiifPlaylistCanvasPresenter
   attr_reader :playlist_item, :stream_info, :cannot_read_item
   attr_accessor :media_fragment
 
-  def initialize(playlist_item:, stream_info:, cannot_read_item: nil, media_fragment: nil)
+  def initialize(playlist_item:, stream_info:, cannot_read_item: false, media_fragment: nil)
     @playlist_item = playlist_item
     @stream_info = stream_info
     @cannot_read_item = cannot_read_item

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -63,24 +63,23 @@ class IiifPlaylistCanvasPresenter
 
   def placeholder_content
     if restricted?
-      IIIFManifest::V3::DisplayContent.new( nil,
-                                            label: 'You do not have permission to playback this item.',
-                                            type: 'Text',
-                                            format: 'text/plain')
+      IIIFManifest::V3::DisplayContent.new(nil,
+                                           label: 'You do not have permission to playback this item.',
+                                           type: 'Text',
+                                           format: 'text/plain')
     elsif master_file.nil?
-      IIIFManifest::V3::DisplayContent.new( nil,
-                                            label: 'The source for this playlist item has been deleted.',
-                                            type: 'Text',
-                                            format: 'text/plain')
+      IIIFManifest::V3::DisplayContent.new(nil,
+                                           label: 'The source for this playlist item has been deleted.',
+                                           type: 'Text',
+                                           format: 'text/plain')
     end
   end
 
   private
 
     def restricted?
-      if user.present?
-        Ability.new( User.find user.id ).cannot? :read, master_file
-      end
+      return unless user.present?
+      Ability.new(User.find(user.id)).cannot? :read, master_file
     end
 
     def video_content

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -29,10 +29,7 @@ describe IiifPlaylistCanvasPresenter do
     end
 
     context 'when a user does not have access to a restricted item' do
-      let(:owner) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user) }
-      let(:media_object) { FactoryBot.create(:media_object, creator: owner, visibility: 'private') }
-      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, user: user) }
+      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, cannot_read_item: true) }
 
       it 'return "Restricted item"' do
         expect(presenter.to_s).to eq "Restricted item"
@@ -101,10 +98,7 @@ describe IiifPlaylistCanvasPresenter do
     end
 
     context 'when a user does not have access to a restricted item' do
-      let(:owner) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user) }
-      let(:media_object) { FactoryBot.create(:media_object, creator: owner, visibility: 'private') }
-      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, user: user) }
+      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, cannot_read_item: true) }
 
       it 'does not serialize the content' do
         expect(presenter.display_content).to be_nil
@@ -143,10 +137,7 @@ describe IiifPlaylistCanvasPresenter do
     end
 
     context 'when a user does not have access to a restricted item' do
-      let(:owner) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user) }
-      let(:media_object) { FactoryBot.create(:media_object, creator: owner, visibility: 'private') }
-      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, user: user) }
+      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, cannot_read_item: true) }
 
       it 'does not serialize the content' do
         expect(presenter.annotation_content).to be_nil
@@ -190,10 +181,7 @@ describe IiifPlaylistCanvasPresenter do
     end
 
     context 'when a user does not have access to a restricted item' do
-      let(:owner) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user) }
-      let(:media_object) { FactoryBot.create(:media_object, creator: owner, visibility: 'private') }
-      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, user: user) }
+      let(:presenter) { described_class.new(playlist_item: playlist_item, stream_info: stream_info, cannot_read_item: true) }
 
       it 'generates placeholder canvas' do
         expect(subject).to be_present


### PR DESCRIPTION
The PlaceHolder Canvas generation may still need work. With this implementation, the placeholder is created with a body section that just has a label within it:
`{ type: Annotation, motivation: painting, body: { label: "You do not have access to this item", type: Text, format: text/plain} }`.

I don't think this conflicts with the spec, but there may be a better way to serialize the messages into the placeholder. Making those changes will likely require more changes in IIIF Manifest because the placeholder serialization in place in the gem is pretty specific.
