### PR TITLE
Fix input field for series autocomplete

### DIFF
--- a/app/assets/javascripts/autocomplete.js.coffee
+++ b/app/assets/javascripts/autocomplete.js.coffee
@@ -36,7 +36,7 @@
     limit: 10
   ).on("typeahead:selected typeahead:autocompleted", (event, suggestion, dataset) ->
     target = $("##{$t.data('target')}")
-    target.val suggestion["id"]
+    target.val suggestion["id"] || suggestion["display"]
     $t.data('matched_val',suggestion["display"])
     return
   ).on("keypress", (e) ->

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -393,7 +393,7 @@ class MediaObject < ActiveFedora::Base
     # value = count and then only looking at the keys.
     search_array = ActiveFedora::SolrService.instance.conn.get('select', params: param).dig("facet_counts", "facet_fields", "series_ssim").each_slice(2).to_h.keys
 
-    search_array.map { |value| { display: value } }
+    search_array.map { |value| { id: value, display: value } }
   end
 
   private

--- a/app/views/media_objects/_resource_description.html.erb
+++ b/app/views/media_objects/_resource_description.html.erb
@@ -74,7 +74,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <%= render partial: 'text_field',
              locals: {form: form, field: :series,
-                      options: {multivalued: true,
+                      options: {display_label: "Series",
+                                multivalued: true,
                                 autocomplete_model: 'mediaObject',
                                 autocomplete_validate: false}} %>
 

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1130,23 +1130,23 @@ describe MediaObject do
 
 
     it "should return all series within the parent collection's unit that include the query string" do
-      expect(MediaObject.autocomplete('Test', mo1.id)).to include({ display: 'Test 1' })
-      expect(MediaObject.autocomplete('Test', mo1.id)).to include({ display: 'Test 2' })
-      expect(MediaObject.autocomplete('Test', mo1.id)).not_to include({ display: 'Alpha'})
-      expect(MediaObject.autocomplete('Test', mo1.id)).not_to include({ display: 'Test 3' })
+      expect(MediaObject.autocomplete('Test', mo1.id)).to include({ id: 'Test 1', display: 'Test 1' })
+      expect(MediaObject.autocomplete('Test', mo1.id)).to include({ id: 'Test 2', display: 'Test 2' })
+      expect(MediaObject.autocomplete('Test', mo1.id)).not_to include({ id: 'Alpha', display: 'Alpha'})
+      expect(MediaObject.autocomplete('Test', mo1.id)).not_to include({ id: 'Test 3', display: 'Test 3' })
     end
 
     it 'should return results without duplicates' do
-      expect(MediaObject.autocomplete('Test', mo1.id).count({ display: 'Test 1' })).to eq 1
+      expect(MediaObject.autocomplete('Test', mo1.id).count({ id: 'Test 1', display: 'Test 1' })).to eq 1
     end
 
     it "should wildcard match" do
-      expect(MediaObject.autocomplete('ph', mo1.id)).to include({ display: 'Alpha' })
+      expect(MediaObject.autocomplete('ph', mo1.id)).to include({ id: 'Alpha', display: 'Alpha' })
     end
 
     it "should be case insensitive" do
-      expect(MediaObject.autocomplete('tes', mo1.id)).to include({ display: 'Test 1' })
-      expect(MediaObject.autocomplete('te', mo1.id)).to include({ display: 'Test 2' })
+      expect(MediaObject.autocomplete('tes', mo1.id)).to include({ id: 'Test 1', display: 'Test 1' })
+      expect(MediaObject.autocomplete('te', mo1.id)).to include({ id: 'Test 2', display: 'Test 2' })
     end
   end
 end


### PR DESCRIPTION
This PR fixes [the save bug](https://github.com/avalonmediasystem/avalon/issues/5275#issuecomment-1687040715) encountered by @joncameron. Also included is a small fix to avoid unnecessary pluralization in the "Series" form label.

The issue was that the series autocomplete suggestion only returns `suggestion['display']`, but the JS was setting the input field off `suggestion['id']` resulting in `nil` being the input value. 