### PR TITLE
Add credentials cors headers for playlist marker edit operations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,7 @@ module Avalon
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins { |source| true }
-        resource '/avalon_marker/*', headers: :any, methods: [:get, :post, :put, :delete]
+        resource '/avalon_marker/*', headers: :any, credentials: true, methods: [:get, :post, :put, :delete]
         resource '/media_objects/*/manifest*', headers: :any, methods: [:get]
         resource '/master_files/*/thumbnail', headers: :any, methods: [:get]
         resource '/master_files/*/transcript/*/*', headers: :any, methods: [:get]
@@ -51,7 +51,7 @@ module Avalon
         resource '/master_files/*/caption_manifest/*', headers: :any, methods: [:get]
         resource '/master_files/*/captions', headers: :any, methods: [:get]
         resource '/master_files/*/supplemental_files/*', headers: :any, methods: [:get]
-        resource '/playlists/*/manifest.json', headers: :any, methods: [:get]
+        resource '/playlists/*/manifest.json', headers: :any, credentials: true, methods: [:get]
         resource '/timelines/*/manifest.json', headers: :any, methods: [:get, :post]
       end
     end


### PR DESCRIPTION
Might not be necessary when ramp is used within avalon since the requests will be same-site/same-origin.