### PR TITLE
Make avalon work with Fedora 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
         default: 4
     docker:
       # Primary container image where all steps run.
-      - image: avalonmediasystem/avalon:7.5.0-dev-ruby3
+      - image: avalonmediasystem/avalon:7.6.0-dev
 
     working_directory: /home/app/avalon
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,7 @@ jobs:
           - POSTGRES_PASSWORD=password
       - image: fcrepo/fcrepo:6.4.0
         environment:
-          JAVA_OPTS: -Dfcrepo.autoversioning.enabled=false -Dfcrepo.external.content.allowed=/fcrepo_allow.txt
-        command: |
-          /bin/bash -c "echo 'http://fedoraAdmin:fedoraAdmin@localhost:8080/' > /fcrepo_allow.txt && catalina.sh run"
+          CATALINA_OPTS: -Dfcrepo.autoversioning.enabled=false
       - image: zookeeper:3.4
       - image: solr:9
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - image: avalonmediasystem/avalon:develop
         environment:
           - DATABASE_URL=postgresql://postgres@localhost:5432/postgres
-          - FEDORA_URL=http://localhost:8080/fcrepo/rest
+          - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@localhost:8080/fcrepo/rest
+          - FEDORA_BASE_PATH=/test
           - FEDORA_TIMEOUT=300
           - RAILS_ENV=test
       # Secondary container image on common network.
@@ -17,9 +18,11 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=avalon
           - POSTGRES_PASSWORD=password
-      - image: ualbertalib/docker-fcrepo4:4.7
+      - image: fcrepo/fcrepo:6.4.0
         environment:
-          CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
+          JAVA_OPTS: -Dfcrepo.autoversioning.enabled=false -Dfcrepo.external.content.allowed=/fcrepo_allow.txt
+        command: |
+          /bin/bash -c "echo 'http://fedoraAdmin:fedoraAdmin@localhost:8080/' > /fcrepo_allow.txt && catalina.sh run"
       - image: zookeeper:3.4
       - image: solr:9
         environment:

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,10 @@ gem 'uglifier', '>= 1.3.0'
 gem 'shakapacker'
 
 # Core Samvera
-gem 'active-fedora', '~> 14.0', '>= 14.0.1'
-gem 'active_fedora-datastreams', '~> 0.5'
+#gem 'active-fedora', '~> 14.0', '>= 14.0.1'
+#gem 'active_fedora-datastreams', '~> 0.5'
+gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', branch: 'fedora6-cjcolvar-rebase'
+gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams.git', branch: 'fedora6_rebase'
 gem 'hydra-head', '~> 12.0'
 gem 'ldp', '~> 1.1.0'
 gem 'noid-rails', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/active_fedora-datastreams.git
-  revision: 3fe267ad5facbb2b66c74471ad7ed8732364711b
+  revision: 3e1b54f60e6d6316e114f608ee5c50c85d6598c6
   branch: fedora6_rebase
   specs:
     active_fedora-datastreams (0.5.0)
@@ -89,7 +89,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/active_fedora.git
-  revision: f242d45eefa5799c74a7dcebc37a7ab46a3b5760
+  revision: 3a8ff7b0384dba852ee70fc337c11c778afd7b58
   branch: fedora6-cjcolvar-rebase
   specs:
     active-fedora (14.0.1)
@@ -737,7 +737,7 @@ GEM
     rdf-turtle (3.2.1)
       ebnf (~> 2.3)
       rdf (~> 3.2)
-    rdf-vocab (3.2.3)
+    rdf-vocab (3.2.4)
       rdf (~> 3.2, >= 3.2.4)
     rdf-xsd (3.2.1)
       rdf (~> 3.2)
@@ -932,8 +932,9 @@ GEM
     sxp (1.2.3)
       matrix (~> 0.4)
       rdf (~> 3.2)
+    temple (0.10.0)
     thor (1.2.2)
-    tilt (2.0.11)
+    tilt (2.1.0)
     timeout (0.3.2)
     trailblazer-option (0.1.2)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,37 @@ GIT
     iiif_manifest (1.3.1)
       activesupport (>= 4)
 
+GIT
+  remote: https://github.com/samvera-labs/active_fedora-datastreams.git
+  revision: 3fe267ad5facbb2b66c74471ad7ed8732364711b
+  branch: fedora6_rebase
+  specs:
+    active_fedora-datastreams (0.5.0)
+      active-fedora (>= 11.0.0.pre)
+      activemodel (>= 5.2)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (~> 3.2)
+      rdf-rdfa (= 3.2.0)
+      rdf-rdfxml (~> 3.2)
+
+GIT
+  remote: https://github.com/samvera/active_fedora.git
+  revision: f242d45eefa5799c74a7dcebc37a7ab46a3b5760
+  branch: fedora6-cjcolvar-rebase
+  specs:
+    active-fedora (14.0.1)
+      active-triples (>= 0.11.0, < 2.0.0)
+      activemodel (>= 5.1)
+      activesupport (>= 5.1)
+      deprecation
+      faraday (>= 2.0)
+      faraday-encoding (>= 0.0.5)
+      faraday-follow_redirects
+      ldp (>= 0.7.0, < 2)
+      rsolr (>= 1.1.2, < 3)
+      ruby-progressbar (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -121,16 +152,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active-fedora (14.0.1)
-      active-triples (>= 0.11.0, < 2.0.0)
-      activemodel (>= 5.1)
-      activesupport (>= 5.1)
-      deprecation
-      faraday (>= 1.0)
-      faraday-encoding (>= 0.0.5)
-      ldp (>= 0.7.0, < 2)
-      rsolr (>= 1.1.2, < 3)
-      ruby-progressbar (~> 1.0)
     active-triples (1.2.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -146,13 +167,6 @@ GEM
     active_encode (1.2.1)
       addressable (~> 2.8)
       rails
-    active_fedora-datastreams (0.5.0)
-      active-fedora (>= 11.0.0.pre)
-      activemodel (>= 5.2)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf (~> 3.2)
-      rdf-rdfxml (~> 3.2)
     activejob (7.0.4.3)
       activesupport (= 7.0.4.3)
       globalid (>= 0.3.6)
@@ -432,6 +446,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-encoding (0.0.5)
       faraday
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     fastimage (2.2.7)
     fcrepo_wrapper (0.9.0)
@@ -977,11 +993,11 @@ PLATFORMS
 
 DEPENDENCIES
   about_page!
-  active-fedora (~> 14.0, >= 14.0.1)
+  active-fedora!
   active_annotations (~> 0.4)
   active_elastic_job
   active_encode (~> 1.2)
-  active_fedora-datastreams (~> 0.5)
+  active_fedora-datastreams!
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -241,7 +241,15 @@ class MediaObjectsController < ApplicationController
         master_file.date_digitized = DateTime.parse(file_spec[:date_digitized]).to_time.utc.iso8601 if file_spec[:date_digitized].present?
         master_file.identifier += Array(params[:files][index][:other_identifier])
         master_file.comment += Array(params[:files][index][:comment])
-        master_file.media_object = @media_object
+        begin
+          master_file.media_object = @media_object
+        rescue ActiveFedora::Rollback => e
+          file_location = file_spec.dig(:file_location) || '<unknown>'
+          message = "Problem saving MasterFile for #{file_location}:"
+          error_messages += [message]
+          error_messages += [e.message]
+          break
+        end
         if file_spec[:files].present?
           if master_file.update_derivatives(file_spec[:files], false)
             master_file.update_stills_from_offset!

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -241,12 +241,11 @@ class MediaObjectsController < ApplicationController
         master_file.date_digitized = DateTime.parse(file_spec[:date_digitized]).to_time.utc.iso8601 if file_spec[:date_digitized].present?
         master_file.identifier += Array(params[:files][index][:other_identifier])
         master_file.comment += Array(params[:files][index][:comment])
-        master_file._media_object = @media_object
+        master_file.media_object = @media_object
         if file_spec[:files].present?
           if master_file.update_derivatives(file_spec[:files], false)
             master_file.update_stills_from_offset!
             WaveformJob.perform_later(master_file.id)
-            @media_object.ordered_master_files += [master_file]
           else
             file_location = file_spec.dig(:file_location) || '<unknown>'
             message = "Problem saving MasterFile for #{file_location}:"
@@ -260,10 +259,7 @@ class MediaObjectsController < ApplicationController
       if error_messages.empty?
         if api_params[:replace_masterfiles]
           old_ordered_master_files.each do |mf|
-            p = MasterFile.find(mf)
-            @media_object.master_files.delete(p)
-            @media_object.ordered_master_files.delete(p)
-            p.destroy
+            MasterFile.find(mf).destroy
           end
         end
 

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -249,6 +249,7 @@ class MasterFile < ActiveFedora::Base
     self._media_object=(mo)
     unless self.media_object.nil?
       self.media_object.ordered_master_files += [self]
+      self.media_object.master_files = self.media_object.ordered_master_files.to_a
       self.media_object.save
     end
   end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -241,9 +241,10 @@ class MasterFile < ActiveFedora::Base
   def media_object=(mo)
     # Removes existing association
     if self.media_object.present?
-      self.media_object.master_files = self.media_object.master_files.to_a.reject { |mf| mf.id == self.id }
-      self.media_object.ordered_master_files = self.media_object.ordered_master_files.to_a.reject { |mf| mf.id == self.id }
-      self.media_object.save
+      old_mo = self.media_object
+      old_mo.master_files = old_mo.master_files.to_a.reject { |mf| mf.id == self.id }
+      old_mo.ordered_master_files = old_mo.ordered_master_files.to_a.reject { |mf| mf.id == self.id }
+      old_mo.save
     end
 
     self._media_object=(mo)

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -250,7 +250,6 @@ class MasterFile < ActiveFedora::Base
     self._media_object=(mo)
     unless self.media_object.nil?
       self.media_object.ordered_master_files += [self]
-      self.media_object.master_files = self.media_object.ordered_master_files.to_a
       self.media_object.save
     end
   end

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -770,8 +770,8 @@ class MasterFile < ActiveFedora::Base
 
   def update_parent!
     return unless media_object.present?
+    media_object.master_files.delete(self)
     media_object.ordered_master_files.delete(self)
-    media_object.master_files = media_object.ordered_master_files.to_a
     media_object.set_media_types!
     media_object.set_duration!
     if !media_object.save

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -140,8 +140,8 @@ class MediaObject < ActiveFedora::Base
 
   def destroy
     # attempt to stop the matterhorn processing job
-    self.master_files.each(&:destroy)
-    self.master_files.clear
+    self.master_files.each(&:stop_processing!)
+    self.master_files.each(&:delete)
     Bookmark.where(document_id: self.id).destroy_all
     super
   end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -129,15 +129,6 @@ class MediaObject < ActiveFedora::Base
     !avalon_publisher.blank?
   end
 
-  alias_method :'_master_files=', :'master_files='
-  define_attribute_methods :master_files
-  def master_files=(mfs)
-    master_files_will_change!
-    ids = mfs.map(&:id).reject(&:blank?)
-    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, ids)
-    self._master_files = mfs
-  end
-
   def destroy
     # attempt to stop the matterhorn processing job
     self.master_files.each(&:stop_processing!)

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -125,6 +125,19 @@ class MediaObject < ActiveFedora::Base
 
   accepts_nested_attributes_for :master_files, :allow_destroy => true
 
+  def published?
+    !avalon_publisher.blank?
+  end
+
+  alias_method :'_master_files=', :'master_files='
+  define_attribute_methods :master_files
+
+  def master_files=(mfs)
+    master_files_will_change!
+    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, mfs.map(&:id))
+    self._master_files = mfs
+  end
+
   def destroy
     # attempt to stop the matterhorn processing job
     self.master_files.each(&:destroy)

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -131,10 +131,10 @@ class MediaObject < ActiveFedora::Base
 
   alias_method :'_master_files=', :'master_files='
   define_attribute_methods :master_files
-
   def master_files=(mfs)
     master_files_will_change!
-    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, mfs.map(&:id))
+    ids = mfs.map(&:id).reject(&:blank?)
+    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, ids)
     self._master_files = mfs
   end
 

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -113,3 +113,36 @@ ActiveFedora::Persistence.module_eval do
 		    end
     end
 end
+
+# Override to add handling of :master_files relations since the predicate is stored in a different place
+ActiveFedora::ChangeSet.class_eval do
+    # @return [Hash<RDF::URI, RDF::Queryable::Enumerator>] hash of predicate uris to statements
+    def changes
+      @changes ||= changed_attributes.each_with_object({}) do |key, result|
+        if object.association(key.to_sym).present?
+          # ActiveFedora::Reflection::RDFPropertyReflection
+          predicate = object.association(key.to_sym).reflection.predicate
+          # ActiveFedora::Reflection::IndirectlyContainsReflection for ordered_aggregation
+          predicate ||= object.association(key.to_sym).reflection&.options[:has_member_relation]
+          values = graph.query({ subject: object.rdf_subject, predicate: predicate })
+          result[predicate] = values if predicate.present?
+        elsif object.class.properties.keys.include?(key)
+          predicate = graph.reflections.reflect_on_property(key).predicate
+          results = graph.query({ subject: object.rdf_subject, predicate: predicate })
+          new_graph = child_graphs(results.map(&:object))
+          results.each do |res|
+            new_graph << res
+          end
+          result[predicate] = new_graph
+        elsif key == 'type'.freeze
+          # working around https://github.com/ActiveTriples/ActiveTriples/issues/122
+          predicate = ::RDF.type
+          result[predicate] = graph.query({ subject: object.rdf_subject, predicate: predicate }).select do |statement|
+            !statement.object.to_s.start_with?("http://fedora.info/definitions/v4/repository#", "http://www.w3.org/ns/ldp#")
+          end
+        elsif object.local_attributes.include?(key)
+          raise "Unable to find a graph predicate corresponding to the attribute: \"#{key}\""
+        end
+      end
+    end
+end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -91,3 +91,11 @@ Hydra::AccessControls::Permissions.module_eval do
       end
 end
 # End of overrides for AccessControl dirty tracking and autosaving
+
+class UUIDIdentifierService
+  def mint
+    SecureRandom.uuid
+  end
+end
+ActiveFedora::Base.identifier_service_class = UUIDIdentifierService
+

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -152,30 +152,32 @@ ActiveFedora::ChangeSet.class_eval do
 end
 
 ActiveFedora::Associations::IndirectlyContainsAssociation.class_eval do
-      def insert_record(record, force = true, validate = true)
-        container.save!
-        if force
-          record.save!
-        else
-          return false unless record.save(validate: validate)
-        end
+  def insert_record(record, force = true, validate = true)
+    container.save!
+    if force
+      record.save!
+    else
+      return false unless record.save(validate: validate)
+    end
 
-        save_through_record(record)
+    save_through_record(record)
 
-        owner.send(:attribute_will_change!, reflection.name)
-        owner.resource << ::RDF::Statement(owner.resource, reflection.predicate, record.id)
-        owner.save
+    # Add triples to the parent object
+    owner.send(:attribute_will_change!, reflection.name)
+    owner.resource << ::RDF::Statement(owner.resource, reflection.predicate, record.id)
+    owner.save
 
-        true
-      end
+    true
+  end
 
   private
 
-        def delete_record(record)
-          record_proxy_finder.find(record).delete
+    def delete_record(record)
+      record_proxy_finder.find(record).delete
 
-          owner.send(:attribute_will_change!, reflection.name)
-          owner.resource.delete({ predicate: reflection.predicate, object: record.id})
-          owner.save
-        end
+      # Remove triples from the parent object
+      owner.send(:attribute_will_change!, reflection.name)
+      owner.resource.delete({ predicate: reflection.predicate, object: record.id})
+      owner.save
+    end
 end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -99,3 +99,17 @@ class UUIDIdentifierService
 end
 ActiveFedora::Base.identifier_service_class = UUIDIdentifierService
 
+ActiveFedora::Persistence.module_eval do
+    # This is only used when creating a new record. If the object doesn't have an id
+    # and assign_id can mint an id for the object, then assign it to the resource.
+    # Otherwise the resource will have the id assigned by the LDP server
+    def assign_rdf_subject
+      @ldp_source = if !id && new_id = assign_id
+		      subject_uri = base_path_for_resource + self.class.id_to_uri(new_id).gsub(ActiveFedora.fedora.base_uri, '') if base_path_for_resource != ActiveFedora.fedora.base_uri
+		      subject_uri ||= self.class.id_to_uri(new_id)
+		      ActiveFedora::LdpResource.new(ActiveFedora.fedora.connection, subject_uri, @resource)
+		    else
+		      ActiveFedora::LdpResource.new(ActiveFedora.fedora.connection, @ldp_source.subject, @resource, base_path_for_resource)
+		    end
+    end
+end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -114,6 +114,12 @@ ActiveFedora::Persistence.module_eval do
     end
 end
 
+ActiveFedora::Reflection::IndirectlyContainsReflection.class_eval do
+  def predicate
+    options[:has_member_relation] || ::RDF::Vocab::LDP.contains
+  end
+end
+
 # Override to add handling of :master_files relations since the predicate is stored in a different place
 ActiveFedora::ChangeSet.class_eval do
     # @return [Hash<RDF::URI, RDF::Queryable::Enumerator>] hash of predicate uris to statements
@@ -122,8 +128,6 @@ ActiveFedora::ChangeSet.class_eval do
         if object.association(key.to_sym).is_a? ActiveFedora::Associations::Association
           # ActiveFedora::Reflection::RDFPropertyReflection
           predicate = object.association(key.to_sym).reflection.predicate
-          # ActiveFedora::Reflection::IndirectlyContainsReflection for ordered_aggregation
-          predicate ||= object.association(key.to_sym).reflection&.options[:has_member_relation]
           values = graph.query({ subject: object.rdf_subject, predicate: predicate })
           result[predicate] = values if predicate.present?
         elsif object.class.properties.keys.include?(key)

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -119,7 +119,7 @@ ActiveFedora::ChangeSet.class_eval do
     # @return [Hash<RDF::URI, RDF::Queryable::Enumerator>] hash of predicate uris to statements
     def changes
       @changes ||= changed_attributes.each_with_object({}) do |key, result|
-        if object.association(key.to_sym).present?
+        if object.association(key.to_sym).is_a? ActiveFedora::Associations::Association
           # ActiveFedora::Reflection::RDFPropertyReflection
           predicate = object.association(key.to_sym).reflection.predicate
           # ActiveFedora::Reflection::IndirectlyContainsReflection for ordered_aggregation

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -98,6 +98,10 @@ Rails.application.config.to_prepare do
 	ng_xml.xpath(*args)
       end
     end
+
+    sp.config IndexedFile do
+      self.defaults = { original_name: nil }
+    end
   end
 
   SpeedyAF::Base.class_eval do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
     volumes: []
 
   fedora: &fedora
-    image: avalonmediasystem/fedora:4.7.5
+    image: fcrepo/fcrepo:6.4.0
     depends_on:
       - db
     volumes:
       - fedora:/data
     environment:
-      - JAVA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json -Dfcrepo.home=/data
+      - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
     networks:
       internal:
     ulimits:
@@ -100,7 +100,8 @@ services:
       - DATABASE_URL=postgres://postgres:password@db/avalon
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - FEDORA_NAMESPACE=avalon
-      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
+      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fcrepo/rest
+      - FEDORA_BASE_PATH=/test
       - RAILS_ENV=development
       - RAILS_ADDITIONAL_HOSTS=avalon
       - SETTINGS__REDIS__HOST=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,14 @@ services:
     environment:
       - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
     networks:
+      external:
       internal:
+    ports:
+      - '8080:8080'
     ulimits:
       nofile:
-        soft: 65536
-        hard: 65536
+        soft: "65536"
+        hard: "65536"
   fedora-test:
     <<: *fedora
     volumes: []
@@ -56,6 +59,10 @@ services:
       - /opt/solr/avalon_conf
     networks:
       internal:
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
   solr-test:
     <<: *solr
     volumes:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "unset-value": "^2.0.1",
     "nth-check": "^2.1.1",
     "set-value": "^4.1.0",
-    "kind-of": "^6.0.3"
+    "kind-of": "^6.0.3",
+    "htmlparser2": "7.0.0"
   },
   "scripts": {
     "start-collection-index": "webpack-dev-server --mode development --config config/webpack/collection_index.js --host 0.0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2588,6 +2588,11 @@ deepmerge@^4.0, deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 default-gateway@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
@@ -3265,15 +3270,15 @@ html-webpack-plugin@^5.3.2:
     pretty-error "^3.0.4"
     tapable "^2.0.0"
 
-htmlparser2@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
-  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+htmlparser2@7.0.0, htmlparser2@^6.1.0, htmlparser2@^8.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.0.0.tgz#ba2d1f7aea9838abd8158bb76c4f3b56d4170b43"
+  integrity sha512-IhdltX9BWhYQft4UPA92jFasNajskja0om6vU0DaIEL4OseCg5zE+mHAMr51AT89TbzzECrQWJ4CZ5NVYTPlKw==
   dependencies:
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
     domutils "^2.5.2"
-    entities "^2.0.0"
+    entities "^3.0.1"
 
 htmlparser2@^8.0.0:
   version "8.0.2"
@@ -4247,6 +4252,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
 
 parse-srcset@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
It might be possible that these changes to Avalon would still work with Fedora 4 without the overrides.  That might be useful for implementors who aren't ready to upgrade Fedora but want to upgrade their avalon.

TODO:
- [x] Manual testing to ensure it really works
- [ ] Write passing tests in ActiveFedora for Fedora 4 to prove hasPart triples were automatically managed before
- [ ] Port tests to ActiveFedora for Fedora 6 and port code that adds management of hasPart triples
- [ ] Port rest of overrides to Fedora 6 ActiveFedora branch
- [ ] Remove overrides from initializer

Supersedes #5150