### PR TITLE
Add canvas reference to empty ranges

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -128,6 +128,8 @@ class IiifCanvasPresenter
     end
 
     def div_to_iiif_range(div_node)
+      return simple_iiif_range(div_node[:label]) unless div_node.children.present?
+      
       items = div_node.children.select(&:element?).collect do |node|
         if node.name == "Div"
           div_to_iiif_range(node)

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -95,6 +95,32 @@ describe IiifCanvasPresenter do
         expect(subject.items.first.media_fragment).to eq 't=0,'
       end
     end
+
+    context 'with childless div' do
+      let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Div 1"/></Item>'}
+
+      it 'autogenerates a basic range' do
+        expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+      	expect(subject.items.size).to eq 1
+        expect(subject.items.first.label.to_s).to eq '{"none"=>["Div 1"]}'
+        expect(subject.items.first.items.size).to eq 1
+      	expect(subject.items.first.items.first).to be_a IiifCanvasPresenter
+        expect(subject.items.first.items.first.media_fragment).to eq 't=0,'
+        expect { subject.items.first.items.first.items }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'with childless item' do
+      let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"/>'}
+
+      it 'autogenerates a basic range' do
+        expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+      	expect(subject.items.size).to eq 1
+      	expect(subject.items.first).to be_a IiifCanvasPresenter
+        expect(subject.items.first.media_fragment).to eq 't=0,'
+        expect { subject.items.first.items }.to raise_error(NoMethodError)
+      end
+    end
   end
 
   describe '#placeholder_content' do

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -108,6 +108,22 @@ describe IiifCanvasPresenter do
         expect(subject.items.first.items.first.media_fragment).to eq 't=0,'
         expect { subject.items.first.items.first.items }.to raise_error(NoMethodError)
       end
+
+      context 'with sibling spans' do
+        let(:structure_xml) { '<?xml version="1.0"?><Item label="Test"><Div label="Div 1"/><Span label="Span 1" begin="00:00:00.000" end="00:00:01.235"/></Item>'}
+
+        it 'generates a range for the span' do
+          expect(subject.label.to_s).to eq '{"none"=>["Test"]}'
+        	expect(subject.items.size).to eq 2
+          expect(subject.items.first.label.to_s).to eq '{"none"=>["Div 1"]}'
+          expect(subject.items.first.items.size).to eq 1
+          expect { subject.items.first.items.first.items }.to raise_error(NoMethodError)
+          expect(subject.items.second.label.to_s).to eq '{"none"=>["Span 1"]}'
+          expect(subject.items.second.items.size).to eq 1
+          expect(subject.items.second.items.first).to be_a IiifCanvasPresenter
+          expect(subject.items.second.items.first.media_fragment).to eq 't=0.0,1.235'
+        end
+      end
     end
 
     context 'with childless item' do


### PR DESCRIPTION
Closes #5350, Closes #5368 

The bug encountered in #5350 is a variant of the childless div bugs we have been encountering. If a user saves a structure without making any edits at all an XML file is still created with a completely childless element: `<Item label='label'/>`. This was generating a range with `item: [ ]` just like we see with childless divs.

This PR adds a fallback to generate a range `item` referencing the parent canvas for any empty structure element.