### PR TITLE
Fix production environment builds

### DIFF
--- a/.github/workflows/podman-image.yml
+++ b/.github/workflows/podman-image.yml
@@ -22,6 +22,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
     - uses: actions/checkout@v3
     - name: Determine DockerHub image tags
       id: determine_dockerhub_tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,6 @@ COPY        --from=node-modules --chown=app:app /node_modules ./node_modules
 USER        app
 ENV         RAILS_ENV=production
 
-RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') bundle exec rake webpacker:compile
 RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') bundle exec rake assets:precompile
 RUN         cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Verifies that versions and hashed value of the package contents in the project's package.json
-  config.webpacker.check_yarn_integrity = false
+  # config.webpacker.check_yarn_integrity = false
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
When deploying the `sandbox` branch I ran into a couple issues that broke the Github Actions workflow.
- Webpacker references - We moved off of webpacker to shakapacker so these needed to be cleaned up.
- Out of disk space - The container used by the Github Actions workflow ran out of disk space so I added a 3rd party action to clean up disk space at the beginning of the workflow.  This step takes a decent amount of time so we may want to try configuring it differently or finding a different solution.