### PR TITLE
Override Ramp css for details and transcript tabs in itemview page

### DIFF
--- a/app/javascript/components/Ramp.jsx
+++ b/app/javascript/components/Ramp.jsx
@@ -51,7 +51,7 @@ const Ramp = ({
 
   return (
     <IIIFPlayer manifestUrl={manifestUrl}>
-      <Row>
+      <Row className="ramp--all-components">
         {!in_progress &&
           <Col sm={8}>
             { (cdl.enabled && !cdl.can_stream)

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -14,167 +14,196 @@
  * ---  END LICENSE_HEADER BLOCK  ---
 */
 
-.iiif-player {
-  .ramp--structured-nav {
-    float: left;
-    width: 40%;
-    margin-top: 20px;
-  }
-  .ramp--transcript_nav {
-    float: right;
-    width: 60%;
-    margin-left: -20px;
-    margin-top: 20px;
-  }
+[class*="ramp--"] {
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-.ramp--rails-title {
-  font-size: 2rem !important;
-  margin-top: 1rem !important;
-}
+.ramp--all-components {
 
-.ramp--rails-content {
-  display: flex;
-
-  #administrative_options {
-    text-align: right !important;
+  .iiif-player {
+    .ramp--structured-nav {
+      float: left;
+      width: 40%;
+      margin-top: 20px;
+    }
+    .ramp--transcript_nav {
+      float: right;
+      width: 60%;
+      margin-left: -20px;
+      margin-top: 20px;
+    }
   }
-
-  .btn-sm {
-    padding: 0 0;
+  
+  .ramp--rails-title {
+    font-size: 2rem !important;
+    margin-top: 1rem !important;
   }
-
-  .share-tabs {
-    flex-grow: 2;
-  }
-
-  #share-list {
-    margin-left: -9.25rem;
-  }
-
-  .svg-add-to-playlist {
-    width: 35px;
-    margin: 0;
-  }
-
-  .bgColor {
-    fill: white;
-  }
-
-  #add-to-playlist-btn:hover {
+  
+  .ramp--rails-content {
+    display: flex;
+  
+    #administrative_options {
+      text-align: right !important;
+    }
+  
+    .btn-sm {
+      padding: 0 0;
+    }
+  
+    .share-tabs {
+      flex-grow: 2;
+    }
+  
+    #share-list {
+      margin-left: -9.25rem;
+    }
+  
+    .svg-add-to-playlist {
+      width: 35px;
+      margin: 0;
+    }
+  
     .bgColor {
-      fill: #f2f2f2;
+      fill: white;
+    }
+  
+    #add-to-playlist-btn:hover {
+      .bgColor {
+        fill: #f2f2f2;
+      }
+    }
+  
+    .foregroundColor {
+      fill: none;
+      stroke: #2a5459;
+      stroke-width: 2;
+      stroke-miterlimit: 10;
+    }
+  }
+  
+  .ramp--supplemental-files {
+    .ramp--supplemental-files-display-content {
+      padding-left: 0;
+    }
+  
+    h4 {
+      border-bottom: 0.1rem solid #ddd;
+      padding-bottom: 0.75rem;
+      font-size: 1.25rem;
+    }
+  }
+  
+  .nav.nav-tabs {
+    background-color:#fff;
+    border:1px solid #e2e7e9;
+    border-top-left-radius:.5rem;
+    border-top-right-radius:.5rem;
+    display:-ms-flexbox;
+    display:flex;
+    -ms-flex-wrap:wrap;
+    flex-wrap:wrap;
+  
+    .nav-item {
+      border:none;
+      background-color:transparent;
+      border-bottom:1px solid #e2e7e9;
+      color:#243142;
+      cursor:pointer;
+      -ms-flex-positive:1;
+      flex-grow:1;
+      line-height:1;
+      padding:1rem;
+      position:relative;
+      z-index:100;
+    }
+    .nav-item:not(:first-child) {
+      border-left:1px solid #e2e7e9;
+      margin-left:-1px;
+    }
+    .nav-item:hover {
+      background-color:#f8f9fa;
+      color:#0e1825;
+    }
+    .nav-item:hover:after {
+      background-color:#e2e7e9;
+      bottom:0;
+      content:"";
+      display:block;
+      height:.25rem;
+      left:0;
+      position:absolute;
+      width:100%;
+    }
+    .nav-item:focus {
+      outline:.125rem solid #328bb8;
+      outline-offset:.125rem;
+      background-color:#edfafd;
+    }
+    .nav-item:focus:not(:focus-visible) {
+      outline:none;
+    }
+    .nav-item[aria-selected=true] {
+      background-color:#f8f9fa;
+    }
+    .nav-item[aria-selected=true]:after {
+      bottom:0;
+      background-color:#2a5459;
+      content:"";
+      display:block;
+      height:.25rem;
+      left:0;
+      position:absolute;
+      width:100%;
+    }
+  }
+  
+  .tab-pane {
+    padding:1rem;
+    border-bottom-left-radius:.5rem;
+    border-bottom-right-radius:.5rem;
+    max-height: 75vh;
+    overflow: auto;
+  }
+  .tab-pane:focus {
+    outline:.125rem solid #006298;
+    outline-offset:-.125rem;
+  }
+  .tab-pane:focus:not(:focus-visible) {
+    outline:none;
+  }
+  
+  #expand_all_sections {
+    display: flex !important;
+    justify-content: flex-end;
+    padding-bottom: .5rem !important;
+  }
+  
+  .accordion-toggle-icon {
+    align-items: center;
+    color: #4c5a69;
+  }
+  
+  .icn-expand-all {
+    width: 20px;
+  }
+  
+  /* Override Ramp styling */
+  .ramp--metadata-display {
+    min-width: fit-content !important;
+  
+    .ramp--metadata-display-content {
+      padding: 0;
+      max-height: inherit;
     }
   }
 
-  .foregroundColor {
-    fill: none;
-    stroke: #2a5459;
-    stroke-width: 2;
-    stroke-miterlimit: 10;
-  }
-}
-
-.ramp--supplemental-files {
-  .ramp--supplemental-files-display-content {
-    padding-left: 0;
+  .ramp--transcript_nav {
+    max-height: 72vh;
+    display: flex;
+    flex-direction: column;
   }
 
-  h4 {
-    border-bottom: 0.1rem solid #ddd;
-    padding-bottom: 0.75rem;
-    font-size: 1.25rem;
+  .ramp--transcript_nav div.transcript_content {
+    height: fit-content !important;
   }
-}
-
-.nav.nav-tabs {
-  background-color:#fff;
-  border:1px solid #e2e7e9;
-  border-top-left-radius:.5rem;
-  border-top-right-radius:.5rem;
-  display:-ms-flexbox;
-  display:flex;
-  -ms-flex-wrap:wrap;
-  flex-wrap:wrap;
-
-  .nav-item {
-    border:none;
-    background-color:transparent;
-    border-bottom:1px solid #e2e7e9;
-    color:#243142;
-    cursor:pointer;
-    -ms-flex-positive:1;
-    flex-grow:1;
-    line-height:1;
-    padding:1rem;
-    position:relative;
-    z-index:100;
-  }
-  .nav-item:not(:first-child) {
-    border-left:1px solid #e2e7e9;
-    margin-left:-1px;
-  }
-  .nav-item:hover {
-    background-color:#f8f9fa;
-    color:#0e1825;
-  }
-  .nav-item:hover:after {
-    background-color:#e2e7e9;
-    bottom:0;
-    content:"";
-    display:block;
-    height:.25rem;
-    left:0;
-    position:absolute;
-    width:100%;
-  }
-  .nav-item:focus {
-    outline:.125rem solid #328bb8;
-    outline-offset:.125rem;
-    background-color:#edfafd;
-  }
-  .nav-item:focus:not(:focus-visible) {
-    outline:none;
-  }
-  .nav-item[aria-selected=true] {
-    background-color:#f8f9fa;
-  }
-  .nav-item[aria-selected=true]:after {
-    bottom:0;
-    background-color:#2a5459;
-    content:"";
-    display:block;
-    height:.25rem;
-    left:0;
-    position:absolute;
-    width:100%;
-  }
-}
-
-.tab-pane {
-  padding:1rem;
-  border-bottom-left-radius:.5rem;
-  border-bottom-right-radius:.5rem;
-}
-.tab-pane:focus {
-  outline:.125rem solid #006298;
-  outline-offset:-.125rem;
-}
-.tab-pane:focus:not(:focus-visible) {
-  outline:none;
-}
-
-#expand_all_sections {
-  display: flex !important;
-  justify-content: flex-end;
-  padding-bottom: .5rem !important;
-}
-
-.accordion-toggle-icon {
-  align-items: center;
-  color: #4c5a69;
-}
-
-.icn-expand-all {
-  width: 20px;
 }


### PR DESCRIPTION
Details tab with long metadata makes the container scroll-able:             |  Details tab with reduced width and content height shorter than `max-height` of the container:
:-------------------------:|:-------------------------:
![image](https://github.com/avalonmediasystem/avalon/assets/1331659/2d01be9e-a6b6-4782-8e80-f90e1ffa9c49)  |  ![image](https://github.com/avalonmediasystem/avalon/assets/1331659/43b098d2-21e3-4acd-807f-71a5964460cc)

Transcripts tab with long transcript makes the container reach the `max-height` and make it scroll-able:             |  Transcripts tab with short transcript makes the container height fit the transcript content without making the container scroll-able:
:-------------------------:|:-------------------------:
![image](https://github.com/avalonmediasystem/avalon/assets/1331659/bac3d663-5434-4c6c-ae84-4a728605458f)  |  ![image](https://github.com/avalonmediasystem/avalon/assets/1331659/6550ab76-cc3a-4b1a-ab5f-0d980011b849)
