### PR TITLE
Use fragment_identifier in playlist item ranges

### DIFF
--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -134,7 +134,7 @@ class IiifPlaylistCanvasPresenter
       IiifManifestRange.new(
         label: { "none" => [label] },
         items: [
-          IiifPlaylistCanvasPresenter.new(playlist_item: playlist_item, stream_info: stream_info, media_fragment: "t=0,#{stream_info[:duration]}")
+          IiifPlaylistCanvasPresenter.new(playlist_item: playlist_item, stream_info: stream_info, media_fragment: fragment_identifier)
         ]
       )
     end

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -161,7 +161,7 @@ describe IiifPlaylistCanvasPresenter do
     	expect(subject.label.to_s).to eq "{\"none\"=>[\"#{playlist_item.title}\"]}"
     	expect(subject.items.size).to eq 1
     	expect(subject.items.first).to be_a IiifPlaylistCanvasPresenter
-      expect(subject.items.first.media_fragment).to eq "t=0,#{(master_file.duration.to_f)/1000}"
+      expect(subject.items.first.media_fragment).to eq "t=#{playlist_item.start_time / 1000},#{playlist_item.end_time / 1000}"
     end
   end
 


### PR DESCRIPTION
Media fragments in playlist structure should use the fragments of the corresponding playlist item, not the full duration of the parent item.