### PR TITLE
Fix incorrect logic in localStorage detection

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
+++ b/app/assets/javascripts/media_player_wrapper/avalon_player_new.es6
@@ -618,7 +618,7 @@ class MEJSPlayer {
     let jumpInterval = 5;
     let startVolume = 1.0;
     let startLanguage = '';
-    if (!this.localStorage) {
+    if (this.localStorage) {
       startVolume = this.localStorage.getItem('startVolume') || 1.0;
       startLanguage = this.localStorage.getItem('captions') || '';
       // Set default quality value in localStorage


### PR DESCRIPTION
Maybe this isn't really needed anymore with ramp being used on the view page?