### PR TITLE
Move administrative buttons to top of page and outside of scope of Ramp

### DIFF
--- a/app/javascript/components/Ramp.jsx
+++ b/app/javascript/components/Ramp.jsx
@@ -34,11 +34,9 @@ const Ramp = ({
   master_files_count,
   title,
   expand_structure,
-  admin_links,
   share,
   timeline,
   playlist,
-  thumbnail,
   in_progress,
   cdl
 }) => {
@@ -93,10 +91,6 @@ const Ramp = ({
                                     Share
                                 </button>
                               }
-                            </Col>
-                            <Col className="ramp-button-group-2">
-                              { admin_links.canUpdate && <div className="mr-1" dangerouslySetInnerHTML={{ __html: admin_links.content }} /> }
-                              { thumbnail.canCreate && <div className="mr-1" dangerouslySetInnerHTML={{ __html: thumbnail.content }} /> }
                             </Col>
                           </div>
                           <Row className="mx-0">

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if can? :update, @media_object %>
-  <div id="administrative_options" style="display: inline-block">
+  <div id="administrative_options" class="d-inline-block">
     <%= link_to 'Edit', edit_media_object_path(@media_object), class: 'btn btn-primary' %>
 
     <% if @media_object.published? %>

--- a/app/views/media_objects/_administrative_links.html.erb
+++ b/app/views/media_objects/_administrative_links.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if can? :update, @media_object %>
-  <div id="administrative_options">
+  <div id="administrative_options" style="display: inline-block">
     <%= link_to 'Edit', edit_media_object_path(@media_object), class: 'btn btn-primary' %>
 
     <% if @media_object.published? %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -28,7 +28,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="col-sm-12">
     <%= render 'workflow_progress' %>
   </div>
-  <div class="col-sm-12" style="margin-bottom: 0.5rem">
+  <div class="col-sm-12 mb-2">
     <%= render 'administrative_links' %>
     <% if current_ability.can? :edit, @media_object %>
       <% if lending_enabled?(@media_object) %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -25,8 +25,18 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% in_progress = show_progress?(@masterFiles) %>
 <div class="row">
-  <div class="col-sm-8">
+  <div class="col-sm-12">
     <%= render 'workflow_progress' %>
+  </div>
+  <div class="col-sm-12" style="margin-bottom: 0.5rem">
+    <%= render 'administrative_links' %>
+    <% if current_ability.can? :edit, @media_object %>
+      <% if lending_enabled?(@media_object) %>
+        <%= render 'thumbnail' if can_stream %>
+      <% else %>
+        <%= render 'thumbnail' %>
+      <% end %>
+    <% end %>
   </div>
   <div class="<%= in_progress || !@currentStream ? 'col-sm-4' : 'col-sm-12' %>">
     <%= react_component("Ramp",
@@ -36,10 +46,8 @@ Unless required by applicable law or agreed to in writing, software distributed
         master_files_count: @media_object.master_files.size,
         title: { content: render('title') },
         expand_structure: { content: render('expand_structure') }, 
-        admin_links: { canUpdate: (current_ability.can? :update, @media_object), content: render('administrative_links') },
         share: { canShare: (will_partial_list_render? :share), content: lending_enabled?(@media_object) ? (render('share') if can_stream) : render('share') },
         timeline: { canCreate: (current_ability.can? :create, Timeline), content: lending_enabled?(@media_object) ? (render('timeline') if can_stream) : render('timeline') },
-        thumbnail: { canCreate: (current_ability.can? :edit, @media_object), content: lending_enabled?(@media_object) ? (render('thumbnail') if can_stream) : render('thumbnail') },
         playlist: { canCreate: (current_ability.can? :create, Playlist), tab: render('add_to_playlist') },
         in_progress: in_progress,
         cdl: { enabled: lending_enabled?(@media_object), can_stream: can_stream, embed: render('embed_checkout'), destroy: render('destroy_checkout') }

--- a/app/views/media_objects/_thumbnail.html.erb
+++ b/app/views/media_objects/_thumbnail.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<div id="thumbnail-button" style="display: inline-block;">
+<div id="thumbnail-button" style="display: inline-block">
   <button type="button" class="btn btn-outline" id="create-thumbnail-btn" data-toggle="modal" data-target="#thumbnailModal" disabled>
     Create Thumbnail
   </button>

--- a/app/views/media_objects/_thumbnail.html.erb
+++ b/app/views/media_objects/_thumbnail.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<div id="thumbnail-button" style="display: inline-block">
+<div id="thumbnail-button" class="d-inline-block">
   <button type="button" class="btn btn-outline" id="create-thumbnail-btn" data-toggle="modal" data-target="#thumbnailModal" disabled>
     Create Thumbnail
   </button>


### PR DESCRIPTION
I chose to put the buttons below the workflow progress because it is a panel that looks like a flash message which feels like it should be at the top of the page.

Resolves #5405 

Before:
![Screenshot from 2023-11-01 15-32-04](https://github.com/avalonmediasystem/avalon/assets/1053603/692807d4-ceae-49fa-b8e9-f05396d51641)

After:
![Screenshot from 2023-11-01 15-23-53](https://github.com/avalonmediasystem/avalon/assets/1053603/067db9dc-cd22-4315-9047-522d37ca9a40)