### PR TITLE
Log error for edge case and move on

### DIFF
--- a/lib/avalon/batch.rb
+++ b/lib/avalon/batch.rb
@@ -33,7 +33,7 @@ module Avalon
         return found_files
       end
 
-      args = files.collect { |p| %("#{p}") }.join(' ')
+      args = files.collect(&:to_json).join(' ')
       Dir.chdir(base_directory) do
         begin
           Timeout.timeout(5) do
@@ -42,6 +42,8 @@ module Avalon
           end
         rescue Timeout::Error
           Rails.logger.warn('lsof blocking; continuing without open file checking')
+        rescue Errno::E2BIG
+          Rails.logger.warn('too many files; continuing without open file checking')
         end
       end
       found_files

--- a/spec/lib/avalon/batch_spec.rb
+++ b/spec/lib/avalon/batch_spec.rb
@@ -1,0 +1,38 @@
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+require 'avalon/batch'
+
+
+describe Avalon::Batch do
+  describe "#find_open_files" do
+    # TODO: mock filesystem with open file
+    subject { Avalon::Batch.find_open_files([]) }
+    it 'returns open files' do
+      expect(subject).to include()
+    end
+
+    context "too many arguments" do
+      let(:file) { File.absolute_path("spec/fixtures/meow.wav") }
+      let(:files) { Array.new(5000, file) }
+      subject { Avalon::Batch.find_open_files(files) }
+
+      it 'logs an error and moves on' do
+        expect(Rails.logger).to receive(:warn).with(match("too many files"))
+        expect(subject).to include()
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is easier to do than fix the underlying issue by reworking the code.  While investigating this I found that lsof is blocking for a really long time in the docker container so it is always timing out.  This makes this feature pretty useless which was another reason for this quick solution.

Resolves #5392 