### PR TITLE
Reduce ffmpeg timeout to 1 minute

### DIFF
--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -88,7 +88,7 @@ private
   def get_wave_io(uri)
     headers = "-headers $'Referer: #{Rails.application.routes.url_helpers.root_url}\r\n'" if uri.starts_with? "http"
     normalized_uri = uri.starts_with?("file") ? Addressable::URI.unencode(uri) : uri
-    timeout = 3600000000 # Must be in microseconds. Current value = 1 hour.
+    timeout = 60000000 # Must be in microseconds. Current value = 1 minute.
     cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 - 2> /dev/null"
     IO.popen(cmd)
   end

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -67,7 +67,7 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 3600000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
 
       it "should call ffmpeg with headers" do
         service.send(:get_wave_io, uri)
@@ -77,7 +77,7 @@ describe WaveformService, type: :service do
 
     context "local file" do
       let(:uri) { "file:///path/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 3600000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
 
       it "should call ffmpeg without headers" do
         service.send(:get_wave_io, uri)
@@ -87,7 +87,7 @@ describe WaveformService, type: :service do
       context 'with spaces in filename' do
         let(:uri) { 'file:///path/to/special%20video%20file.mp4' }
         let(:unencoded_uri) { 'file:///path/to/special video file.mp4' }
-        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 3600000000 -i '#{unencoded_uri}' -f wav -ar 44100 - 2> /dev/null"}
+        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{unencoded_uri}' -f wav -ar 44100 - 2> /dev/null"}
 
         it "should call ffmpeg without url encoding" do
           service.send(:get_wave_io, uri)


### PR DESCRIPTION
In a manual test using the same ffmpeg commands outside of ruby and without the timeout it took 7 seconds to run for a 1 hour audio file and 25 seconds for a 2 hour video file.  Given this I think a 1 minute timeout should be enough and keeps the queue from getting clogged as much when the stream doesn't close nicely for ffmpeg.

Locally, this would help us move through the backlog created by the mass push (https://github.iu.edu/AvalonIU/Avalon/issues/176).