### PR TITLE
Stream token optimization for media object IIIF manifest endpoint

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -464,11 +464,8 @@ class MediaObjectsController < ApplicationController
     @media_object = SpeedyAF::Proxy::MediaObject.find(params[:id])
     authorize! :read, @media_object
 
-    master_files = master_file_presenters
-    canvas_presenters = master_files.collect do |mf|
-      stream_info = secure_streams(mf.stream_details, @media_object.id)
-      IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info)
-    end
+    stream_info_hash = secure_stream_infos(master_file_presenters, @media_object.id)
+    canvas_presenters = master_file_presenters.collect { |mf| IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info_hash[mf.id]) }
     presenter = IiifManifestPresenter.new(media_object: @media_object, master_files: canvas_presenters, lending_enabled: lending_enabled?(@media_object))
 
     manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h

--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -41,8 +41,8 @@ class StreamToken < ActiveRecord::Base
   end
 
   def self.purge_expired!(session)
-    purged = expired.each(&:delete)
-    Array(session[:hash_tokens]).reject! { |token| !StreamToken.exists?(token: token) }
+    purged = expired.delete_all
+    session[:hash_tokens] = StreamToken.where(token: Array(session[:hash_tokens])).pluck(:token)
     purged
   end
 

--- a/app/services/security_service.rb
+++ b/app/services/security_service.rb
@@ -28,7 +28,7 @@ class SecurityService
       end
     else
       session = context[:session] || { media_token: nil }
-      token = StreamToken.find_or_create_session_token(session, context[:target])
+      token = context[:token] || StreamToken.find_or_create_session_token(session, context[:target])
       "#{url}?token=#{token}"
     end
   end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1840,7 +1840,8 @@ describe MediaObjectsController, type: :controller do
 
   describe '#manifest' do
     context 'read from solr' do
-      let!(:media_object) { FactoryBot.create(:published_media_object, :with_master_file, visibility: 'public') }
+      let!(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
+      let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
       it 'should not read from fedora' do
         perform_enqueued_jobs(only: MediaObjectIndexingJob)
         WebMock.reset_executed_requests!

--- a/spec/helpers/security_helper_spec.rb
+++ b/spec/helpers/security_helper_spec.rb
@@ -103,7 +103,7 @@ describe SecurityHelper, type: :helper do
 
   context 'when using non-AWS streaming server' do
     describe '#add_stream_cookies' do
-      it 'adds security tokens to cookies' do
+      it 'does not add security tokens to cookies' do
         expect { helper.add_stream_cookies(stream_info) }.not_to change { controller.cookies.sum {|k,v| 1} }
       end
     end
@@ -149,6 +149,61 @@ describe SecurityHelper, type: :helper do
 
           it 'does not rewrite urls in the stream_info' do
             expect { helper.secure_streams(stream_info, media_object.id) }.not_to change { stream_info.slice(:stream_flash, :stream_hls).values.flatten.collect {|v| v[:url]} }
+            [:stream_hls].each do |protocol|
+              stream_info[protocol].each do |quality|
+                expect(quality[:url]).not_to eq secure_url
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe '#secure_stream_infos' do
+      let(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
+      let(:token) { 'dcba-4321' }
+      let(:secure_url_with_token) { secure_url + "?token=#{token}" }
+
+      before do
+        allow(SecurityHandler).to receive(:secure_url).with(String, token: token).and_return(secure_url_with_token)
+      end
+
+      context 'controlled digital lending is disabled' do
+        before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(false) }
+
+        it 'rewrites urls in the stream_infos' do
+          stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+          stream_info = stream_info_hash[master_file.id]
+          [:stream_hls].each do |protocol|
+            stream_info[protocol].each do |quality|
+              expect(quality[:url]).to eq secure_url
+            end
+          end
+        end
+      end
+
+      context 'controlled digital lending is enabled' do
+        before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(true) }
+        before { allow(Settings.controlled_digital_lending).to receive(:collections_enabled).and_return(true) }
+
+        context 'the user has the item checked out' do
+          before { FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: user.id)}
+
+          it 'rewrites urls in the stream_infos' do
+            stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+            stream_info = stream_info_hash[master_file.id]
+            [:stream_hls].each do |protocol|
+              stream_info[protocol].each do |quality|
+                expect(quality[:url]).to eq secure_url
+              end
+            end
+          end
+        end
+
+        context 'the user does not have the item checked out' do
+          it 'does not rewrite urls in the stream_info' do
+            stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+            stream_info = stream_info_hash[master_file.id]
             [:stream_hls].each do |protocol|
               stream_info[protocol].each do |quality|
                 expect(quality[:url]).not_to eq secure_url

--- a/spec/models/stream_token_spec.rb
+++ b/spec/models/stream_token_spec.rb
@@ -37,6 +37,33 @@ describe StreamToken do
       expect(token).to eq token2
       expect(session[:hash_tokens].count(token)).to eq 1
     end
+
+    context '#get_session_tokens_for' do
+      let(:targets) { ['D1452CB7-4DC2-4A26-AC2C-FBCE943C164C', target] }
+
+      it 'should create the tokens' do
+        expect(StreamToken.get_session_tokens_for(session: session, targets: targets)).to match_array([be_instance_of(StreamToken), be_instance_of(StreamToken)])
+      end
+
+      it 'stores the tokens in the session' do
+        tokens = StreamToken.get_session_tokens_for(session: session, targets: targets)
+        expect(session[:hash_tokens]).to include *tokens.pluck(:token)
+      end
+
+      it 'stores the tokens once in the session' do
+        tokens = StreamToken.get_session_tokens_for(session: session, targets: targets)
+        tokens2 = StreamToken.get_session_tokens_for(session: session, targets: targets)
+        expect(tokens).to eq tokens2
+        expect(session[:hash_tokens].count(tokens.first.token)).to eq 1
+        expect(session[:hash_tokens].count(tokens.second.token)).to eq 1
+      end
+
+      it 'updates expires' do
+        StreamToken.get_session_tokens_for(session: session, targets: targets)
+        expect { StreamToken.get_session_tokens_for(session: session, targets: targets) }.not_to change { StreamToken.count }
+        expect { StreamToken.get_session_tokens_for(session: session, targets: targets) }.to change { StreamToken.pluck(:expires) }
+      end
+    end
   end
 
   describe 'valid_token?' do

--- a/spec/services/security_service_spec.rb
+++ b/spec/services/security_service_spec.rb
@@ -71,6 +71,14 @@ Lw03eHTNQghS0A==
       it 'adds a StreamToken param' do
         expect(subject.rewrite_url(url, context)).to start_with "http://example.com/streaming/id?token="
       end
+
+      context 'when token provided' do
+        let(:context) {{ session: {}, target: 'abcd1234', protocol: :stream_hls, token: 'dcba-4321' }}
+
+        it 'adds token param' do
+          expect(subject.rewrite_url(url, context)).to eq "http://example.com/streaming/id?token=dcba-4321"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #5476

There are two StreamToken methods at the heart of this PR:
- #purge_expired!
- #get_stream_tokens_for 

In `purge_expired!` the first loop is avoided by using `delete_all`.  The second loop is avoided by inverting the logic: finding the existing tokens in the DB instead of removing ones that no longer exist.

`get_stream_tokens_for` is a new batch alternative to `find_or_create_session_token`.  This new method uses `upsert_all` to update existing records and create ones that do not exist yet.  It takes a little bit of special handling to create the array of attribute hashes that upsert requires.  Ids need to be added to that hash in order for upsert to find existing records without a unique index in the DB.

The rest of the PR is refactoring to utilize `get_stream_tokens_for`.

Future Work:
- Refactor playlist manifest endpoint to use optimized methods
- Remove unnecessary initialization of instance variables in media object view page (#5477)