### PR TITLE
Do not change playlist item title on media end

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -74,10 +74,6 @@ const Ramp = ({
           setActiveItemTitle(activeElements[canvasIndex].textContent);
         }
       });
-
-      playerInst.on('ended', () => {
-        setActiveItemTitle("Inaccesible Item")
-      });
     }
   }
 


### PR DESCRIPTION
The original implementation changed the playlist item title to "Inaccessible item" on video end as a workaround for when the next autoplay playlist item was inaccessible. This is because the title does not otherwise update when an item has a blank canvas. This workaround was insufficient and caused unintended behavior when autoplay was not on. Issues with item title not updating will be handled in #5497.