### PR TITLE
Move playlist action buttons out of ramp context

### DIFF
--- a/app/assets/stylesheets/avalon/_playlists.scss
+++ b/app/assets/stylesheets/avalon/_playlists.scss
@@ -1,12 +1,12 @@
-/* 
+/*
  * Copyright 2011-2023, The Trustees of Indiana University and Northwestern
  *   University.  Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed
  *   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -40,8 +40,9 @@
   }
 }
 
-.playlist-action-button-row {
-  margin-bottom: 2rem;
+.playlist-action-button-row.col-sm-4 {
+  padding-left: 0.75rem;
+  padding-right:0px;
 }
 
 .playlist-autoplay-wrapper {

--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -41,8 +41,7 @@ const Ramp = ({
   base_url,
   playlist_id,
   share,
-  comment_tag,
-  action_buttons
+  comment_tag
 }) => {
   const [manifestUrl, setManifestUrl] = React.useState('');
   const [activeItemTitle, setActiveItemTitle] = React.useState();
@@ -117,7 +116,6 @@ const Ramp = ({
           </Card>
         </Col>
         <Col sm={4}>
-          <div dangerouslySetInnerHTML={{ __html: action_buttons.content }} />
           <Row>
             <Col sm={6}>
               <AutoAdvanceToggle />

--- a/app/views/playlists/_action_buttons.html.erb
+++ b/app/views/playlists/_action_buttons.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<div class="row playlist-action-button-row">
+<div class="row playlist-action-buttons">
   <div class="col-sm-6">
     <% if current_ability.can? :edit, @playlist %>
     <div id="edit-playlist-button">
@@ -40,15 +40,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
 <script>
   $(document).ready(function () {
-    let timeCheck = setInterval(initCopyBtn, 500);
-
-    function initCopyBtn() {
-      let player = document.getElementById('iiif-media-player');
-      if(player) {
-        window.add_copy_playlist_button_event()
-        clearInterval(timeCheck);
-      }
-    }
+    window.add_copy_playlist_button_event()
   });
 </script>
 <% end %>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -16,9 +16,15 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% @page_title = t('media_objects.show.title', :media_object_title => @playlist.title, :application_name => application_name) %>
 
 <div class="playlist-view-wrapper row">
-  <div class="page-title-wrapper playlist-title">
-    <%= icon_only_visibility @playlist.visibility %>
-    <h1 class="page-title"><%= @playlist.title %></h1>
+  <div class="page-title-wrapper playlist-title col-sm-12">
+    <div class="col-sm-8">
+      <%= icon_only_visibility @playlist.visibility %>
+      <h1 class="page-title"><%= @playlist.title %></h1>
+    </div>
+
+    <div class="playlist-action-button-row col-sm-4">
+      <%= render partial: 'action_buttons' %>
+    </div>
   </div>
 
   <div class="col-sm-12">
@@ -27,8 +33,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         base_url: request.protocol+request.host_with_port,
         playlist_id: @playlist.id,
         share: { canShare: (will_partial_list_render? :share), content: render('share') },
-        comment_tag: { content: render('comments_and_tags') },
-        action_buttons: { content: render('action_buttons') }
+        comment_tag: { content: render('comments_and_tags') }
       }
     ) %>
   </div>


### PR DESCRIPTION
The "Copy Playlist" modal relies on some functions which do not trigger/interact properly when the buttons are being rendered by/within the Ramp context. Rather than try to get the functions to interact with Ramp properly or move the functions into the Ramp context, it felt simpler to pull the action button partial back out of Ramp. This has the added benefit(?) of bringing the page styling closer inline with the non-Ramp based playlist show page.