### PR TITLE
Add safe navigator to captions check

### DIFF
--- a/app/views/master_files/hls_manifest.m3u8.erb
+++ b/app/views/master_files/hls_manifest.m3u8.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 #EXTM3U
 <% if @master_file.has_captions? %>
 <% captions_list = @master_file.supplemental_file_captions %>
-<% captions_list.append(@master_file.captions) if @master_file.captions.content %>
+<% captions_list.append(@master_file.captions) if @master_file.captions&.content %>
 <% captions_list.each_with_index do |caption, index| %>
 <% label = caption.is_a?(SupplementalFile) ? caption.label : 'English' %>
 <% language = caption.is_a?(SupplementalFile) ? caption.language : 'en' %>


### PR DESCRIPTION
Encountered an issue on avalon-dev where `@master_file.captions` returned nil instead of an empty Indexed file so the subsequent check for content errored. This prevents the HLS manifest from generating, causing streaming to fail. I think this will be encountered with any item created after we changed how captions are created/stored. Adding the safe navigator should take care of the issue.