### PR TITLE
Avoid expensive calls when rendering item show view page

### DIFF
--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -97,15 +97,15 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     # This is important otherwise speedy_af will reify from fedora when trying to access this field.
     # When adding a new property to the master file model that will be used in the interface,
     # add it to the default below to avoid reifying for master files lacking a value for the property.
-    SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{id}",
-                                      order: -> { master_file_ids },
-                                      load_reflections: true)
+    @master_files ||= SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{id}",
+                                                        order: -> { master_file_ids },
+                                                        load_reflections: true)
   end
   alias_method :indexed_master_files, :master_files
   alias_method :ordered_master_files, :master_files
 
   def collection
-    SpeedyAF::Proxy::Admin::Collection.find(collection_id)
+    @collection ||= SpeedyAF::Proxy::Admin::Collection.find(collection_id)
   end
 
   def lending_period
@@ -149,7 +149,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
   end
 
   def sections_with_files(tag: '*')
-    ordered_master_file_ids.select { |m| SpeedyAF::Proxy::MasterFile.find(m).supplemental_files(tag: tag).present? }
+    master_files.select { |master_file| master_file.supplemental_files(tag: tag).present? }
   end
 
   protected

--- a/app/views/media_objects/_share.html.erb
+++ b/app/views/media_objects/_share.html.erb
@@ -28,7 +28,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 <script>
   let canvasIndex = 0;
   $(document).ready(function() {
-    const mediaObject = <%= @media_object.to_json.html_safe %>;
+    const mediaObjectId = <% @media_object.id %>
+    const sectionIds = <%= @media_object.ordered_master_file_ids.to_json.html_safe %>;
     const event = new CustomEvent('canvasswitch', { detail: { lti_share_link: '', link_back_url: '', embed_code: '' } })
     function canvasIndexListener() {
       let player = document.getElementById('iiif-media-player');
@@ -36,9 +37,9 @@ Unless required by applicable law or agreed to in writing, software distributed
         player.player.on("loadedmetadata", () => {
           if (player.dataset.canvasindex != canvasIndex) {
             canvasIndex = parseInt(player.dataset.canvasindex);
-            const sectionId = mediaObject.files[canvasIndex].id;
+            const sectionId = sectionIds[canvasIndex];
             $.ajax({
-              url: '/media_objects/' + mediaObject.id + '/section/' + sectionId + '/stream',
+              url: '/media_objects/' + mediaObjectId + '/section/' + sectionId + '/stream',
               type: 'GET',
               success: function(data) {
                 event.detail.lti_share_link = data.lti_share_link;


### PR DESCRIPTION
Resolves #5509 

I think the changes to these two files are all of the low hanging fruit that I could find.  It's still slow but much improved since we aren't trying to fetch the MasterFile objects from solr 4 or 5 times.

With https://avalon-dev.dlib.indiana.edu/media_objects/3f462541v
Before: 9.9s (page) + 6.6s (manifest) = 16.5s total
After: 1.9s (page) + 5.2s (manifest) = 7.1s total