### PR TITLE
Speed up playlist manifest generation

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -464,7 +464,7 @@ class MediaObjectsController < ApplicationController
     @media_object = SpeedyAF::Proxy::MediaObject.find(params[:id])
     authorize! :read, @media_object
 
-    stream_info_hash = secure_stream_infos(master_file_presenters, @media_object.id)
+    stream_info_hash = secure_stream_infos(master_file_presenters, [@media_object])
     canvas_presenters = master_file_presenters.collect { |mf| IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info_hash[mf.id]) }
     presenter = IiifManifestPresenter.new(media_object: @media_object, master_files: canvas_presenters, lending_enabled: lending_enabled?(@media_object))
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -261,8 +261,8 @@ class PlaylistsController < ApplicationController
 
     canvas_presenters = @playlist.items.collect do |item|
       master_file = master_files.find { |mf| mf.id == item.clip.master_file_id }
-      cannot_read_item = cannot_read_hash[master_file.media_object_id]
-      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info_hash[master_file.id], cannot_read_item: cannot_read_item, master_file: master_file)
+      cannot_read_item = master_file.nil? || cannot_read_hash[master_file.media_object_id]
+      IiifPlaylistCanvasPresenter.new(playlist_item: item, stream_info: stream_info_hash[master_file&.id], cannot_read_item: cannot_read_item, master_file: master_file)
     end
 
     can_edit_playlist = can? :edit, @playlist

--- a/app/models/avalon_annotation.rb
+++ b/app/models/avalon_annotation.rb
@@ -56,9 +56,13 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
     self.title = master_file.embed_title if self.title.nil? && master_file.present?
   end
 
+  def master_file_id
+    @master_file_id ||= CGI::unescape(self.source.split('/').last) if self.source
+  end
+
   # Sets the class variable @master_file by finding the master referenced in the source uri
   def master_file
-    @master_file ||= SpeedyAF::Proxy::MasterFile.find(CGI::unescape(self.source.split('/').last)) if self.source
+    @master_file ||= SpeedyAF::Proxy::MasterFile.find(master_file_id) if master_file_id
   end
 
   def master_file=(value)
@@ -74,5 +78,4 @@ class AvalonAnnotation < ActiveAnnotations::Annotation
   rescue
     "#{master_file&.rdf_uri}?t=#{start_time},#{end_time}"
   end
-
 end

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -16,11 +16,12 @@ class IiifPlaylistCanvasPresenter
   attr_reader :playlist_item, :stream_info, :cannot_read_item
   attr_accessor :media_fragment
 
-  def initialize(playlist_item:, stream_info:, cannot_read_item: false, media_fragment: nil)
+  def initialize(playlist_item:, stream_info:, cannot_read_item: false, media_fragment: nil, master_file: nil)
     @playlist_item = playlist_item
     @stream_info = stream_info
     @cannot_read_item = cannot_read_item
     @media_fragment = media_fragment
+    @master_file = master_file
   end
 
   delegate :id, to: :playlist_item
@@ -36,7 +37,7 @@ class IiifPlaylistCanvasPresenter
   end
 
   def master_file
-    playlist_item.clip.master_file
+    @master_file ||= playlist_item.clip.master_file
   end
 
   def part_of
@@ -142,7 +143,7 @@ class IiifPlaylistCanvasPresenter
       IiifManifestRange.new(
         label: { "none" => [label] },
         items: [
-          IiifPlaylistCanvasPresenter.new(playlist_item: playlist_item, stream_info: stream_info, media_fragment: fragment_identifier)
+          IiifPlaylistCanvasPresenter.new(playlist_item: playlist_item, stream_info: stream_info, media_fragment: fragment_identifier, master_file: master_file)
         ]
       )
     end

--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -57,7 +57,8 @@ class StreamToken < ActiveRecord::Base
       # all attributes must be present for all items in upsert array
       attrs[:id] = existing_token_hash[attrs[:token]] if existing_token_hash[attrs[:token]].present?
     end
-    result = StreamToken.upsert_all(token_attributes)
+
+    result = token_attributes.present? ? StreamToken.upsert_all(token_attributes) : []
 
     # Fetch StreamToken fresh so they can be put into session and returned
     tokens = StreamToken.where(id: result.to_a.pluck("id"))

--- a/spec/helpers/security_helper_spec.rb
+++ b/spec/helpers/security_helper_spec.rb
@@ -172,7 +172,7 @@ describe SecurityHelper, type: :helper do
         before { allow(Settings.controlled_digital_lending).to receive(:enable).and_return(false) }
 
         it 'rewrites urls in the stream_infos' do
-          stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+          stream_info_hash = helper.secure_stream_infos([master_file], [media_object])
           stream_info = stream_info_hash[master_file.id]
           [:stream_hls].each do |protocol|
             stream_info[protocol].each do |quality|
@@ -190,7 +190,7 @@ describe SecurityHelper, type: :helper do
           before { FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: user.id)}
 
           it 'rewrites urls in the stream_infos' do
-            stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+            stream_info_hash = helper.secure_stream_infos([master_file], [media_object])
             stream_info = stream_info_hash[master_file.id]
             [:stream_hls].each do |protocol|
               stream_info[protocol].each do |quality|
@@ -202,7 +202,7 @@ describe SecurityHelper, type: :helper do
 
         context 'the user does not have the item checked out' do
           it 'does not rewrite urls in the stream_info' do
-            stream_info_hash = helper.secure_stream_infos([master_file], media_object.id)
+            stream_info_hash = helper.secure_stream_infos([master_file], [media_object])
             stream_info = stream_info_hash[master_file.id]
             [:stream_hls].each do |protocol|
               stream_info[protocol].each do |quality|


### PR DESCRIPTION
Resolves #5496 

This handles low hanging fruit by reducing solr calls by:
- Fetching all MasterFiles backing playlist items in a single SpeedyAF::Base.where
- Using `#secure_stream_infos` to avoid multiple sql calls for stream tokens
- Performing `cannot? :read` checks on parent MediaObjects to optimize case where multiple playlist items come from the same MediaObject

With these changes a 125 section playlist manifest generation time dropped from about 60 seconds to 8-10 seconds.  Still slow but a big improvement.  Playlist view page renders very quickly <1s so I didn't look into optimizing it at all.

Future optimizations could include:
- Leveraging bulk SpeedyAF calls and the SpeedyAF proxies to avoid solr calls in `test_edit` and `test_read` in the Ability
- Fetch all of the markers for the playlist in a single SQL call
- Optimize (possibly via memoization) active_annotation parsing of RDF for `source`, `start_time`, and `end_time` of `AvalonAnnotation`s