### PR TITLE
Add message for empty playlists

### DIFF
--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -119,7 +119,8 @@ const Ramp = ({
   }
 
   return (
-    <IIIFPlayer manifestUrl={manifestUrl}>
+    <IIIFPlayer manifestUrl={manifestUrl} 
+      customErrorMessage='This page encountered an error. Please refresh or contact an administrator.'>
       <Row className="ramp--all-components">
         <Col sm={8}>
           { (cdl.enabled && !cdl.can_stream)

--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -77,7 +77,7 @@ const Ramp = ({
   }
 
   return (
-    <IIIFPlayer manifestUrl={manifestUrl}>
+    <IIIFPlayer manifestUrl={manifestUrl} customErrorMessage='This playlist is empty.'>
       <Row className="ramp--all-components ramp--playlist">
         <Col sm={8}>
           <MediaPlayer enableFileDownload={false} />


### PR DESCRIPTION
This PR has both item view and playlist page custom error messages changes from the error boundary work done in https://github.com/samvera-labs/ramp/issues/280