### PR TITLE
Ensure method signature matches when overriding as_json

### DIFF
--- a/app/models/structural_metadata.rb
+++ b/app/models/structural_metadata.rb
@@ -44,7 +44,7 @@ class StructuralMetadata < ActiveFedora::File
     xpath('/Item/@label').text()
   end
 
-  def as_json
+  def as_json(_options = {})
     root_node = xpath('//Item')[0]
     root_node.present? ? node_xml_to_json(root_node) : {}
   end

--- a/app/presenters/speedy_af/proxy/structural_metadata.rb
+++ b/app/presenters/speedy_af/proxy/structural_metadata.rb
@@ -23,7 +23,7 @@ class SpeedyAF::Proxy::StructuralMetadata < SpeedyAF::Base
     xpath('/Item/@label').text
   end
 
-  def as_json
+  def as_json(_options = {})
     root_node = xpath('//Item')[0]
     root_node.present? ? node_xml_to_json(root_node) : {}
   end


### PR DESCRIPTION
Fixes as issue where calling `structuralMetadata.to_json` was erroring because it was passing options to `as_json` but `as_json` wasn't accepting any.  This PR ensures the method signatures match (and subsequently disregards the passed params).