### PR TITLE
Add implementation of permalink_with_query 

### DIFF
--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -64,4 +64,12 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
   def captions
     load_subresource_content(:captions) rescue nil
   end
+
+  def permalink_with_query(query_vars = {})
+    val = permalink
+    if val && query_vars.present?
+      val = "#{val}?#{query_vars.to_query}"
+    end
+    val ? val.to_s : nil
+  end
 end

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -152,6 +152,14 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     master_files.select { |master_file| master_file.supplemental_files(tag: tag).present? }
   end
 
+  def permalink_with_query(query_vars = {})
+    val = permalink
+    if val && query_vars.present?
+      val = "#{val}?#{query_vars.to_query}"
+    end
+    val ? val.to_s : nil
+  end
+
   protected
 
   # Overrides from SpeedyAF::Base


### PR DESCRIPTION
`permalink_with_query` is defined in the Permalink concern in the model but it isn't in the proxy which can lead to reifying from fedora in `embed_code`.