### PR TITLE
Unfocus player on page load

### DIFF
--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -119,7 +119,7 @@ const Ramp = ({
   }
 
   return (
-    <IIIFPlayer manifestUrl={manifestUrl} 
+    <IIIFPlayer manifestUrl={manifestUrl}
       customErrorMessage='This page encountered an error. Please refresh or contact an administrator.'>
       <Row className="ramp--all-components">
         <Col sm={8}>

--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -72,6 +72,10 @@ const Ramp = ({
         if(activeElements != undefined && activeElements?.length > 0) {
           setActiveItemTitle(activeElements[canvasIndex].textContent);
         }
+        // Remove focus from player so that tab order is correct
+        if (document.activeElement == player) {
+          document.activeElement.blur();
+        }
       });
     }
   }

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -94,6 +94,11 @@ Unless required by applicable law or agreed to in writing, software distributed
       function addPlayerEventListeners(player) {
         player.on('loadedmetadata', () => {
           transcriptCheck();
+
+          // Remove focus from player so that tab order is correct
+          if (document.activeElement.id == player.id_) {
+            document.activeElement.blur();
+          }
         });
       }
 
@@ -102,7 +107,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         let transcriptTab = document.evaluate('//a[text()="Transcripts"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
         let detailTab = document.evaluate('//a[text()="Details"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 
-        if(!transcriptSections.includes(sectionId)) {
+        if(transcriptTab && !transcriptSections.includes(sectionId)) {
           // If transcript tab is the active tab when it is hidden, the tab goes away but the box still displays
           // the missing transcript file message. Force change over to a different tab to avoid this case.
           if (transcriptTab.getAttribute('aria-selected') === "true") { detailTab.click(); }
@@ -111,6 +116,10 @@ Unless required by applicable law or agreed to in writing, software distributed
           transcriptTab.style.display = '';
         }
       }
+
+      document.addEventListener("keydown", function() {
+        rampHotKeys();
+      });
     });
 </script>
 <% end %>

--- a/app/views/media_objects/_share.html.erb
+++ b/app/views/media_objects/_share.html.erb
@@ -28,7 +28,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <script>
   let canvasIndex = 0;
   $(document).ready(function() {
-    const mediaObjectId = <% @media_object.id %>
+    const mediaObjectId = "<%= @media_object.id %>";
     const sectionIds = <%= @media_object.ordered_master_file_ids.to_json.html_safe %>;
     const event = new CustomEvent('canvasswitch', { detail: { lti_share_link: '', link_back_url: '', embed_code: '' } })
     function canvasIndexListener() {
@@ -75,7 +75,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           $('.share-tabs a').attr('aria-selected', false);
           $(this).attr('aria-selected', true);
         });
-      }      
+      }
     }
     setInterval(canvasIndexListener, 500);
   });

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -38,3 +38,13 @@ Unless required by applicable law or agreed to in writing, software distributed
     ) %>
   </div>
 </div>
+
+<% content_for :page_scripts do %>
+<script>
+  $(document).ready(function() {
+    document.addEventListener("keydown", function() {
+      rampHotKeys();
+    });
+  });
+</script>
+<% end %>


### PR DESCRIPTION
Ramp applies focus to the player element when initializing so that hot keys will be functional. Avalon needs to have the window retain focus so that the tab order starts with the 'Skip to main content' link. We can achieve this by unfocusing the player after it loads and then listen for keydown events and assign them the proper hotkey actions to maintain hotkey functionality.

This commit also includes a couple minor changes to remove console errors encountered while testing.