### PR TITLE
Store http sources as tempfiles on disk to avoid issue with ffmpeg blocking

### DIFF
--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -67,11 +67,16 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 /tmp"}
+
+      before do
+        allow(Kernel).to receive(:system).and_return(nil)
+      end
 
       it "should call ffmpeg with headers" do
-        service.send(:get_wave_io, uri)
-        expect(IO).to have_received(:popen).with(cmd)
+        io = service.send(:get_wave_io, uri)
+        expect(Kernel).to have_received(:system).with(start_with(cmd))
+        expect(io).to be_a Tempfile
       end
     end
 


### PR DESCRIPTION
Another attempt at resolving the issue with intercom push spawning WaveformJobs which run for hours.

Note: While testing I noticed that in the docker development environment the ffmpeg command for streaming urls doesn't work because of localhost not resolving.  This shouldn't be a problem in IU's production environment and probably won't be an issue at all because preference is given to using derivative files which are available via minio in the docker environment.  I wanted to mention this in case we find a scenario where it is an issue in the future.