### PR TITLE
Return array of ids for SpeedyAF::Proxy::MediaObject.sections_with_files

### DIFF
--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -149,7 +149,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
   end
 
   def sections_with_files(tag: '*')
-    master_files.select { |master_file| master_file.supplemental_files(tag: tag).present? }
+    master_file_ids.select { |m| SpeedyAF::Proxy::MasterFile.find(m).supplemental_files(tag: tag).present? }
   end
 
   def permalink_with_query(query_vars = {})

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -149,7 +149,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
   end
 
   def sections_with_files(tag: '*')
-    master_file_ids.select { |m| SpeedyAF::Proxy::MasterFile.find(m).supplemental_files(tag: tag).present? }
+    master_files.select { |master_file| master_file.supplemental_files(tag: tag).present? }.map(&:id)
   end
 
   def permalink_with_query(query_vars = {})


### PR DESCRIPTION
The transcript check function to hide/display the transcript tab has been broken for a little bit. This was caused by the media object presenter returning an array of full master files from the `#sections_with_files` method instead of an array of master file IDs which is what should be getting returned. This discrepancy caused the check of the active section ID against the list of sections with files to always fail, thus never rendering the transcript tab.