### PR TITLE
Invoke transcript switch on player ready event

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -91,10 +91,12 @@ Unless required by applicable law or agreed to in writing, software distributed
       }
 
       function addPlayerEventListeners(player) {
-        player.player.on('loadedmetadata', () => {
-          let canvasindex = player.dataset['canvasindex'];
-          transcriptCheck(canvasindex);
-        });
+        if (player && player.player != undefined) {
+          player.player.ready(() => {
+            let canvasindex = player.dataset['canvasindex'];
+            transcriptCheck(canvasindex);
+          });
+        }
       }
 
       function transcriptCheck(canvasindex) {


### PR DESCRIPTION
Trigger transcript tab show/hide on VideoJS player's `player.ready` event instead of `player.loadedmetadata` event which takes longer to fire with HLS streaming.