### PR TITLE
Overwrite flag needed in order to write to new tempfile since it already exists on disk

### DIFF
--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -95,7 +95,7 @@ private
     normalized_uri = uri.starts_with?("file") ? Addressable::URI.unencode(uri) : uri
     timeout = 60000000 # Must be in microseconds. Current value = 1 minute.
     tmpfile = Tempfile.new if uri.starts_with?("http")
-    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 #{tmpfile&.path || "-"} 2> /dev/null"
+    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 -y #{tmpfile&.path || "-"} 2> /dev/null"
     Rails.logger.debug("Getting wav file for waveform generation using ffmpeg command: #{cmd}")
     if tmpfile
       Kernel.system(cmd)

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -67,7 +67,7 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 /tmp"}
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 -y /tmp"}
 
       before do
         allow(Kernel).to receive(:system).and_return(nil)
@@ -82,7 +82,7 @@ describe WaveformService, type: :service do
 
     context "local file" do
       let(:uri) { "file:///path/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 -y - 2> /dev/null"}
 
       it "should call ffmpeg without headers" do
         service.send(:get_wave_io, uri)
@@ -92,7 +92,7 @@ describe WaveformService, type: :service do
       context 'with spaces in filename' do
         let(:uri) { 'file:///path/to/special%20video%20file.mp4' }
         let(:unencoded_uri) { 'file:///path/to/special video file.mp4' }
-        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{unencoded_uri}' -f wav -ar 44100 - 2> /dev/null"}
+        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{unencoded_uri}' -f wav -ar 44100 -y - 2> /dev/null"}
 
         it "should call ffmpeg without url encoding" do
           service.send(:get_wave_io, uri)


### PR DESCRIPTION
Found this when testing this fix on mco-staging.  This flag doesn't do anything when streaming to stdout.  With this flag in place the tempfile is written to and cleaned up correctly when running as a background job.