### PR TITLE
Fix copy timeline modal actions

### DIFF
--- a/app/assets/javascripts/avalon_timelines/timelines.js.coffee
+++ b/app/assets/javascripts/avalon_timelines/timelines.js.coffee
@@ -65,17 +65,19 @@ $('#copy-timeline-form').submit(
 )
 
 $('#copy-timeline-form').bind('ajax:success',
-  (event, data, status, xhr) ->
-    if (data?.errors)
+  (event) ->
+    [data, status, xhr] = event.detail
+    if (data.errors)
       console.log(data.errors.title[0])
     else
       if (submit_edit)
-        window.location.href = event.detail[0].path
+        window.location.href = data.path
       else
         if ( $('#with_refresh').val() )
           location.reload()
 ).bind('ajax:error',
-  (e, xhr, status, error) ->
+  (event) ->
+    [data, status, xhr] = event.detail
     console.log(xhr.responseJSON.errors)
 )
 

--- a/app/assets/javascripts/avalon_timelines/timelines.js.coffee
+++ b/app/assets/javascripts/avalon_timelines/timelines.js.coffee
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -66,11 +66,11 @@ $('#copy-timeline-form').submit(
 
 $('#copy-timeline-form').bind('ajax:success',
   (event, data, status, xhr) ->
-    if (data.errors)
+    if (data?.errors)
       console.log(data.errors.title[0])
     else
       if (submit_edit)
-        window.location.href = data.path
+        window.location.href = event.detail[0].path
       else
         if ( $('#with_refresh').val() )
           location.reload()


### PR DESCRIPTION
Fixes #5528

The code handling the submit action for copying timelines was looking for attributes from the `data` variable but the copy action did not have that variable populated. ~~Added safe navigation for the error check and changed the redirect link to be pulled from the event variable.~~ Changed the variable assignment to populate from `event.detail`.