### PR TITLE
Set tabbed nav columns to fill height

### DIFF
--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -245,7 +245,7 @@ const Ramp = ({
               <MetadataDisplay showHeading={false} displayTitle={false}/>
             </Tab>
             { (cdl.can_stream && master_files_count != 0 && has_transcripts) &&
-              <Tab eventKey="transcripts" title="Transcripts" className="ramp-transcripts-tab">
+              <Tab eventKey="transcripts" title="Transcripts" className="ramp--transcripts_tab">
                 <Transcript
                   playerID="iiif-media-player"
                   manifestUrl={manifestUrl}

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -160,25 +160,25 @@
   .ramp--tabs-panel {
     display: flex;
     flex-direction: column;
+    flex-basis: auto;
 
     .tab-content {
       display: flex;
-      flex: 1;
-      height: 100%;
+      flex-grow: 1;
+      height: 70vh;
     }
   
     .tab-pane {
-      flex: 1;
+      flex-grow: 1;
       padding:1rem;
       border-bottom-left-radius: 0.25rem;
       border-bottom-right-radius: 0.25rem;
-      max-height: inherit;
       overflow: auto;
     }
   }
 
   // Remove double scroll-bar for transcripts tab
-  .ramp-transcripts-tab {
+  .ramp--transcripts_tab {
     overflow: hidden;
   }
 
@@ -193,23 +193,22 @@
   /* Override Ramp styling */
   .ramp--metadata-display {
     min-width: fit-content !important;
-    height: 100%;
 
     .ramp--metadata-display-content {
       padding: 0;
-      max-height: 50rem;
+      max-height: 100%;
     }
   }
 
   .ramp--transcript_nav {
-    max-height: 50rem;
+    max-height: 100%;
     display: flex;
     flex-direction: column;
     padding: 0;
   }
 
   .ramp--transcript_nav div.transcript_content {
-    height: fit-content !important;
+    height: fit-content;
   }
 
   .vjs-track-scrubber-container {

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -95,7 +95,31 @@ Unless required by applicable law or agreed to in writing, software distributed
           player.player.ready(() => {
             let canvasindex = player.dataset['canvasindex'];
             transcriptCheck(canvasindex);
+            setColumnHeights();
           });
+        }
+      }
+
+      /*
+        Set tabbed nav column height based on the content
+      */
+      function setColumnHeights() {
+        let activeTab = $('.tab-pane.active.show');
+        // When the active tab is transcripts, check the transcript content height to
+        // check there is overflowing content to set the column height. This is handled
+        // seperately because the height check in the else block doesn't identify this since
+        // since this content is set dynamically based on user selection in dropdown menu. 
+        if(activeTab.hasClass('ramp--transcripts_tab')) {
+          let transcriptContent = $('.transcript_content');
+          if(transcriptContent[0].scrollHeight > transcriptContent[0].clientHeight) {
+            activeTab[0].style.height = 'unset';
+          }
+        } else {
+          if (activeTab[0].scrollHeight > activeTab[0].clientHeight) {
+            activeTab[0].style.height = 'unset';
+          } else {
+            activeTab[0].style.height = 'fit-content';
+          }
         }
       }
 


### PR DESCRIPTION
Details tab with overflowing content:
![Details_tab_no-overflow](https://github.com/avalonmediasystem/avalon/assets/1331659/61a0177a-ae3b-4c4d-9403-9f43330bdc9b)

Details tab with no overflowing content:
![Details_tab_overflow](https://github.com/avalonmediasystem/avalon/assets/1331659/2aff56e3-28a5-4d52-aa43-a79619a64747)

Transcripts tab with no overflowing content: 
![Transcripts_tab_no-overflow](https://github.com/avalonmediasystem/avalon/assets/1331659/cc2745a3-8fd2-4c43-b81f-6200cbf15256)

Transcripts tab with overflowing content:
![Transcripts_tab_overflow](https://github.com/avalonmediasystem/avalon/assets/1331659/dae3bed0-ffef-4201-9a39-25614f3b23b5)

Files tab with no overflowing content:
![Files_tab_not-overflow](https://github.com/avalonmediasystem/avalon/assets/1331659/88f687b4-f48d-470f-89d4-97c6c60cd5f9)

Related issue: #5498 