### PR TITLE
Disable transcript tab when there are no transcripts

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -110,9 +110,11 @@ Unless required by applicable law or agreed to in writing, software distributed
           if(transcriptTab) {
             if (transcriptTab.getAttribute('aria-selected') === "true") { detailTab.click(); }
             transcriptTab.style.display = 'none';
+            transcriptTab.classList.add("disabled");
           }
         } else if (transcriptSections.includes(sectionId) && transcriptTab.style.display === 'none') {
           transcriptTab.style.display = '';
+          transcriptTab.classList.remove("disabled");
         }
       }
     });


### PR DESCRIPTION
Original implementation only hid the transcript tab. This resulted in a user being able to navigate to the tab content via arrow key navigation. We can prevent this by adding `disabled` to the class of the tab.