### PR TITLE
Fix search result pagination color contrast accessibility issues

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -57,3 +57,7 @@
   color: white !important;
   background-color: #f44336 !important;
 }
+
+.page-item span.page-link {
+  color: $dark !important;
+}

--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -1,0 +1,17 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if current_page.last? %>
+    <li class="page-item disabled">
+      <%= link_to raw(t 'views.pagination.next'), '#', :rel => 'next', :onclick=>'return false;', class: 'page-link', aria: { label: t('views.pagination.aria.go_to_next_page'), disabled: true } %>
+    </li>
+<% else %>
+    <li class="page-item">
+      <%= link_to raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_next_page') } %>
+    </li>
+<% end %>

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -1,0 +1,18 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if current_page.first? %>
+    <li class="page-item disabled">
+      <%= link_to raw(t 'views.pagination.previous'), '#', :rel => 'prev', :onclick=>'return false;', class: 'page-link', aria: { label: t('views.pagination.aria.go_to_previous_page'), disabled: true } %>
+    </li>
+<% else %>
+    <li class="page-item">
+      <%= link_to raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_previous_page') } %>
+    </li>
+<% end %>
+


### PR DESCRIPTION
Override blacklight kaminari views to add aria-disabled for disabled links and override bootstrap styles to ensure dark text color is used for spans in pagination (current page and ellipsis gap)

Resolves #5573 