### PR TITLE
Revert waveform tempfile commits

### DIFF
--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -95,7 +95,7 @@ private
     normalized_uri = uri.starts_with?("file") ? Addressable::URI.unencode(uri) : uri
     timeout = 60000000 # Must be in microseconds. Current value = 1 minute.
     tmpfile = Tempfile.new if uri.starts_with?("http")
-    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 -y #{tmpfile&.path || "-"} 2> /dev/null"
+    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 #{tmpfile&.path || "-"} 2> /dev/null"
     Rails.logger.debug("Getting wav file for waveform generation using ffmpeg command: #{cmd}")
     if tmpfile
       Kernel.system(cmd)

--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -82,27 +82,15 @@ private
     factor = max_peak.zero? ? 1 : res / max_peak.to_f
     peaks.map { |peak| peak.collect { |num| (num * factor).to_i } }
   ensure
-    if wave_io.is_a? Tempfile
-      wave_io.close
-      wave_io.unlink
-    else
-      Process.wait(wave_io.pid) if wave_io&.pid
-    end
+    Process.wait(wave_io.pid) if wave_io&.pid
   end
 
   def get_wave_io(uri)
     headers = "-headers $'Referer: #{Rails.application.routes.url_helpers.root_url}\r\n'" if uri.starts_with? "http"
     normalized_uri = uri.starts_with?("file") ? Addressable::URI.unencode(uri) : uri
     timeout = 60000000 # Must be in microseconds. Current value = 1 minute.
-    tmpfile = Tempfile.new if uri.starts_with?("http")
-    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 #{tmpfile&.path || "-"} 2> /dev/null"
-    Rails.logger.debug("Getting wav file for waveform generation using ffmpeg command: #{cmd}")
-    if tmpfile
-      Kernel.system(cmd)
-      tmpfile
-    else
-      IO.popen(cmd)
-    end
+    cmd = "#{Settings.ffmpeg.path} #{headers} -rw_timeout #{timeout} -i '#{normalized_uri}' -f wav -ar 44100 - 2> /dev/null"
+    IO.popen(cmd)
   end
 
   def gather_peaks(wav_file)

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -67,7 +67,7 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 -y /tmp"}
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 /tmp"}
 
       before do
         allow(Kernel).to receive(:system).and_return(nil)
@@ -82,7 +82,7 @@ describe WaveformService, type: :service do
 
     context "local file" do
       let(:uri) { "file:///path/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 -y - 2> /dev/null"}
+      let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
 
       it "should call ffmpeg without headers" do
         service.send(:get_wave_io, uri)
@@ -92,7 +92,7 @@ describe WaveformService, type: :service do
       context 'with spaces in filename' do
         let(:uri) { 'file:///path/to/special%20video%20file.mp4' }
         let(:unencoded_uri) { 'file:///path/to/special video file.mp4' }
-        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{unencoded_uri}' -f wav -ar 44100 -y - 2> /dev/null"}
+        let(:cmd) {"#{Settings.ffmpeg.path}  -rw_timeout 60000000 -i '#{unencoded_uri}' -f wav -ar 44100 - 2> /dev/null"}
 
         it "should call ffmpeg without url encoding" do
           service.send(:get_wave_io, uri)

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -67,16 +67,11 @@ describe WaveformService, type: :service do
 
     context "http file" do
       let(:uri) { "http://domain/to/video.mp4" }
-      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 /tmp"}
-
-      before do
-        allow(Kernel).to receive(:system).and_return(nil)
-      end
+      let(:cmd) {"#{Settings.ffmpeg.path} -headers $'Referer: http://test.host/\r\n' -rw_timeout 60000000 -i '#{uri}' -f wav -ar 44100 - 2> /dev/null"}
 
       it "should call ffmpeg with headers" do
-        io = service.send(:get_wave_io, uri)
-        expect(Kernel).to have_received(:system).with(start_with(cmd))
-        expect(io).to be_a Tempfile
+        service.send(:get_wave_io, uri)
+        expect(IO).to have_received(:popen).with(cmd)
       end
     end
 


### PR DESCRIPTION
Reverts #5546 and #5555 since there were found to not be effective in avoiding waveform job blocking in certain cases.  The original streaming implementation should be more efficient since it doesn't require writing to disk and using disk space.