### PR TITLE
Fix files tab height alternating between unset and fit-content

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -115,7 +115,9 @@ Unless required by applicable law or agreed to in writing, software distributed
             activeTab[0].style.height = 'unset';
           }
         } else {
-          if (activeTab[0].scrollHeight > activeTab[0].clientHeight) {
+          // Use a 10 point margin when checking for overflowing content as the interval
+          // can set the height back and forth between 'unset' and 'fit-content'
+          if (activeTab[0].scrollHeight > activeTab[0].clientHeight + 10) {
             activeTab[0].style.height = 'unset';
           } else {
             activeTab[0].style.height = 'fit-content';


### PR DESCRIPTION
Fix for the following UI bug;

[files_tab_height.webm](https://github.com/avalonmediasystem/avalon/assets/1331659/76fb1278-fb95-4f3a-8e07-c662e00ba4a4)
