### PR TITLE
Include original supplemental filenames in iiif manifest

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -211,14 +211,16 @@ class IiifCanvasPresenter
         label = file.tags.include?('machine_generated') ? file.label + ' (machine generated)' : file.label
         format = file.file.content_type
         language = file.language || 'en'
+        filename = file.file.filename.to_s
       else
         label = 'English'
         format = file.mime_type
         language = 'en'
+        filename = file.original_name.to_s
       end
       {
         motivation: 'supplementing',
-        label: label,
+        label: { language => [label], 'none' => [filename] },
         type: 'Text',
         format: format,
         language: language

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -80,6 +80,7 @@ FactoryBot.define do
     trait :with_captions do
       after(:create) do |mf|
         mf.captions.content = File.read('spec/fixtures/captions.vtt')
+        mf.captions.original_name = 'captions.vtt'
         mf.save
       end
     end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -242,14 +242,22 @@ describe IiifCanvasPresenter do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}/ }).to eq true
       end
 
+      it 'includes original filenames' do
+        expect(subject.any? { |content| content.label['none'] == [caption_file.file.filename.to_s] }).to eq true
+      end
+
+      it 'includes label' do
+        expect(subject.any? { |content| content.label['eng'] == [caption_file.label] }).to eq true
+      end
+
       it 'differentiates between transcript and caption files' do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{transcript_file.id}\/transcripts/ }).to eq true
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}\/captions/ }).to eq true
       end
 
       it 'does not add " (machine generated)" to label of non-generated files' do
-        expect(subject.any? { |content| content.label =~ /#{transcript_file.label} \(machine generated\)/ }).to eq false
-        expect(subject.any? { |content| content.label =~ /#{caption_file.label} \(machine generated\)/ }).to eq false
+        expect(subject.any? { |content| content.label['eng'][0] =~ /#{transcript_file.label} \(machine generated\)/ }).to eq false
+        expect(subject.any? { |content| content.label['eng'][0] =~ /#{caption_file.label} \(machine generated\)/ }).to eq false
       end
 
       it 'does not include generic supplemental files or waveform' do
@@ -267,13 +275,17 @@ describe IiifCanvasPresenter do
         it 'includes the master file captions' do
           expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq true
         end
+
+        it 'includes the original filename' do
+          expect(subject.any? { |content| content.label['none'] == [master_file.captions.original_name] }).to eq true
+        end
       end
 
       context 'machine generated transcript' do
         let(:transcript_file) { FactoryBot.create(:supplemental_file, tags: ['transcript', 'machine_generated']) }
 
         it "adds '(machine generated)' to the label" do
-          expect(subject.any? { |content| content.label =~ /#{transcript_file.label} \(machine generated\)/ }).to eq true
+          expect(subject.any? { |content| content.label['eng'][0] =~ /#{transcript_file.label} \(machine generated\)/ }).to eq true
         end
       end
     end


### PR DESCRIPTION
This PR adds an entry to the label field for caption and transcript files so that the original filename can be serialized into the manifest. We serialize the user-defined label into the manifest first, using the language as its key. Then we serialize the original filename without a key.

This will allow us to differentiate the names to facilitate better file handling within the Ramp file downloader.