### PR TITLE
Force embedded player to render within container

### DIFF
--- a/app/views/modules/player/_video_js_element.html.erb
+++ b/app/views/modules/player/_video_js_element.html.erb
@@ -42,14 +42,12 @@ Unless required by applicable law or agreed to in writing, software distributed
                              }
                            end %>
 
-  <% @videojs_options = {"aspectRatio": section_info[:is_video] ? '16:9' : '1:0',
+  <% @videojs_options = {
                          "autoplay": false,
                          "width": @player_width || 480,
                          "height": @player_height || 270,
                          "bigPlayButton": section_info[:is_video] ? true : false,
                          "poster": section_info[:is_video] ?  section_info[:poster_image] : false,
-                         "fluid": true,
-                         "responsive": true,
                          "preload": "auto",
                          "controlBar": control_bar_options,
                          "userActions": {


### PR DESCRIPTION
VideoJS fluid mode forces the player to a specific aspect ratio. When the container that the player is embedded in does not match that aspect ratio it generates scroll bars for the content. Turning off fluid mode keeps the video within the container, letter/pillarboxing as necessary. 

This PR also turns off responsive mode, as in testing it did not seem to have any affect on the rendering.