### PR TITLE
Fix skip transcoding with minio/s3 file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git"
 gem "omniauth-saml", "~> 2.0"
 
 # Media Access & Transcoding
-gem 'active_encode', '~> 1.2'
+gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git"
 gem 'audio_waveform-ruby', '~> 1.0.7', require: 'audio_waveform'
 gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'v1.2-avalon'
 gem 'fastimage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,14 @@ GIT
       omniauth
 
 GIT
+  remote: https://github.com/samvera-labs/active_encode.git
+  revision: cad5ced9ca18f11c4003e839ae836e815eeec6df
+  specs:
+    active_encode (1.2.1)
+      addressable (~> 2.8)
+      rails
+
+GIT
   remote: https://github.com/samvera-labs/iiif_manifest.git
   revision: 6a027ff84d2b1ca65765dea0c83c820643cebe01
   branch: main
@@ -143,9 +151,6 @@ GEM
     active_elastic_job (3.2.0)
       aws-sdk-sqs (~> 1)
       rails (>= 5.2.6, < 7.1)
-    active_encode (1.2.1)
-      addressable (~> 2.8)
-      rails
     active_fedora-datastreams (0.5.0)
       active-fedora (>= 11.0.0.pre)
       activemodel (>= 5.2)
@@ -980,7 +985,7 @@ DEPENDENCIES
   active-fedora (~> 14.0, >= 14.0.1)
   active_annotations (~> 0.4)
   active_elastic_job
-  active_encode (~> 1.2)
+  active_encode!
   active_fedora-datastreams (~> 0.5)
   activejob-traffic_control
   activejob-uniqueness

--- a/app/models/pass_through_encode.rb
+++ b/app/models/pass_through_encode.rb
@@ -14,19 +14,4 @@
 
 class PassThroughEncode < WatchedEncode
   self.engine_adapter = :pass_through
-
-  before_create prepend: true do |encode|
-    localize_input encode
-  end
-
-  private
-
-    # Download s3 object to extract technical metadata locally
-    def localize_input(encode)
-      return unless Addressable::URI.parse(encode.input.url).scheme == 's3'
-      encode.input.url = localize_s3_file encode.input.url
-      encode.options[:outputs].each do |output|
-        output[:url] = localize_s3_file output[:url]
-      end
-    end
 end

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -33,7 +33,7 @@ class FileLocator
 
     def local_file
       @local_file ||= Tempfile.new(File.basename(key))
-      object.download_file(@local_file.path) if File.zero?(@local_file)
+      object.download_file(@local_file.path, mode: 'single_request') if File.zero?(@local_file)
       @local_file
     ensure
       @local_file.close

--- a/spec/models/pass_through_encode_spec.rb
+++ b/spec/models/pass_through_encode_spec.rb
@@ -17,44 +17,7 @@ require 'rails_helper'
 require 'fakefs/safe'
 
 describe PassThroughEncode do
-  let(:master_file) { FactoryBot.create(:master_file) }
-  let(:encode) do
-    described_class.new("s3://bucket/sample.mp4",
-      master_file_id: master_file.id,
-      outputs: [{ label: "high", url: "s3://bucket/sample.high.mp4" }],
-      preset: "pass_through"
-    )
-  end
-
-  before do
-    allow(MasterFile).to receive(:find).with(master_file.id).and_return(master_file)
-  end
-
-  describe 'create' do  
-    context 'with S3 inputs' do
-      let!(:altered_input) { Tempfile.new("sample.mp4") }
-      let!(:altered_output) { Tempfile.new("sample.high.mp4") }
-      let(:running_encode) do
-        described_class.new(altered_input.path, outputs: [{ label: "high", url: altered_output.path }]).tap do |e|
-          e.id = SecureRandom.uuid
-          e.state = :running
-          e.created_at = Time.zone.now
-          e.updated_at = Time.zone.now
-        end
-      end
-
-      before do
-        allow(Tempfile).to receive(:new).with("sample.mp4").and_return(altered_input)
-        allow(Tempfile).to receive(:new).with("sample.high.mp4").and_return(altered_output)
-        allow(Settings).to receive(:encoding).and_return(double(engine_adapter: "pass_through"))
-      end
-
-      it 'download the input first' do
-        expect(described_class.engine_adapter).to receive(:create).with(altered_input.path, hash_including(outputs: [{ label: "high", url: altered_output.path }])).and_return(running_encode)
-        encode.create!
-        expect(File.exist?(altered_input.path)).to eq true
-        expect(File.exist?(altered_output.path)).to eq true
-      end
-    end
+  it 'uses pass through adapter' do
+    expect(described_class.engine_adapter.class).to eq ActiveEncode::EngineAdapters::PassThroughAdapter 
   end
 end


### PR DESCRIPTION
The pass through encode model previously copied the s3 content into a local tempfile and passed that to active_encode to workaround the issue of mediainfo not being able to read s3 urls.  That may have worked at one point but now the tempfiles get deleted/garbage collected after one read so mediainfo always returns an empty xml file leading to failed encodes.  This PR resolves this by making changes to the PassThroughAdapter in active_encode and then relying on that instead of having a workaround locally.
https://github.com/samvera-labs/active_encode/pull/132

This PR also resolves an issue with FileLocator::S3File that I discovered while debugging this issue locally.  The `single_request` mode is not as efficient as a multi-part download but was the only way I could get it to work with minio.

Related to #5594 