### PR TITLE
Extend playlist items container height fully on mobile devices

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -50,6 +50,9 @@ const Ramp = ({
 
   let interval;
 
+  const USER_AGENT = window.navigator.userAgent;
+  const IS_MOBILE = (/Mobi/i).test(USER_AGENT);
+
   React.useEffect(() => {
     let url = `${base_url}/playlists/${playlist_id}/manifest.json`;
     setManifestUrl(url);
@@ -86,7 +89,7 @@ const Ramp = ({
           <Card className="ramp--playlist-accordion">
             <Card.Header>
               <h4>{activeItemTitle}</h4>
-              { activeItemSummary && <div>{activeItemSummary}</div> }
+              {activeItemSummary && <div>{activeItemSummary}</div>}
             </Card.Header>
             <Card.Body>
               <Accordion>
@@ -114,7 +117,7 @@ const Ramp = ({
             </Card.Body>
           </Card>
         </Col>
-        <Col sm={4} className="ramp--playlist-items-column">
+        <Col sm={4} className={`ramp--playlist-items-column ${IS_MOBILE ? 'mobile-view' : ''}`}>
           <Row>
             <Col sm={6}>
               <AutoAdvanceToggle />

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -356,4 +356,11 @@
       max-height: inherit;
     }
   }
+
+  /* CSS for playlist items column height in landscape mode for mobile devices */
+  @media(orientation: landscape) {
+    .ramp--playlist-items-column.mobile-view {
+      height: 109vh !important;
+    }
+  }
 }


### PR DESCRIPTION
Related issue: https://github.com/avalonmediasystem/avalon/issues/5589