### PR TITLE
Split query into terms, search each individually, and return intersecion

### DIFF
--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -16,8 +16,16 @@ class Timeline < ActiveRecord::Base
   belongs_to :user
   scope :by_user, ->(user) { where(user_id: user.id) }
   # Explicitly cast everything to lowercase for DB agnostic case-insentive search.
-  scope :title_like, ->(title_filter) { where("LOWER(title) LIKE ?", "%#{title_filter.downcase}%") }
-  scope :desc_like, ->(desc_filter) { where("LOWER(description) LIKE ?", "%#{desc_filter.downcase}%") }
+  scope :title_like, ->(title_filter) do
+    term_array = title_filter.split.map { |term| "%#{sanitize_sql_like(term).downcase}%" }
+    query = Array.new(term_array.size, "LOWER(title) LIKE ?").join(" AND ")
+    where(query, *term_array)
+  end
+  scope :desc_like, ->(desc_filter) do
+    term_array = desc_filter.split.map { |term| "%#{sanitize_sql_like(term).downcase}%" }
+    query = Array.new(term_array.size, "LOWER(description) LIKE ?").join(" AND ")
+    where(query, *term_array)
+  end
   scope :with_tag, ->(tag_filter) { where("LOWER(tags) LIKE ?", "%\n- #{tag_filter.downcase}\n%") }
 
   validates :user, presence: true

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe Timeline, type: :model do
       it 'does not return timelines without matching titles' do
         expect(Timeline.title_like(title_filter)).not_to include(timeline3)
       end
+      it 'searches on multiple terms' do
+        expect(Timeline.title_like('Fav Moose')).to include(timeline2)
+        expect(Timeline.title_like('Fav Moose')).not_to include(timeline1)
+        expect(Timeline.title_like('Fav Moose')).not_to include(timeline3)
+        expect(Timeline.title_like('Moose Fav')).to include(timeline2)
+        expect(Timeline.title_like('Moose Fav')).not_to include(timeline1)
+        expect(Timeline.title_like('Moose Fav')).not_to include(timeline3)
+      end
     end
     describe 'desc_like' do
       let(:timeline1) { FactoryBot.create(:timeline, description: 'Moose tunes') }
@@ -175,6 +183,14 @@ RSpec.describe Timeline, type: :model do
       end
       it 'does not return timelines without matching descriptions' do
         expect(Timeline.desc_like(desc_filter)).not_to include(timeline3)
+      end
+      it 'searches on multiple terms' do
+        expect(Timeline.desc_like('Fav Moose')).to include(timeline2)
+        expect(Timeline.desc_like('Fav Moose')).not_to include(timeline1)
+        expect(Timeline.desc_like('Fav Moose')).not_to include(timeline3)
+        expect(Timeline.desc_like('Moose Fav')).to include(timeline2)
+        expect(Timeline.desc_like('Moose Fav')).not_to include(timeline1)
+        expect(Timeline.desc_like('Moose Fav')).not_to include(timeline3)
       end
     end
     describe 'with_tag' do


### PR DESCRIPTION
Follow on to #5606
Possible solution to #5586

This approach makes a query like:
`WHERE LOWER(title) LIKE %op% AND LOWER(title) LIKE %35%`