### PR TITLE
Delay localize_times until Ramp has loaded

### DIFF
--- a/app/assets/javascripts/localize_times.js
+++ b/app/assets/javascripts/localize_times.js
@@ -23,3 +23,17 @@ function localize_times() {
 
 $(document).ready(localize_times);
 $(document).on('draw.dt', localize_times);
+// This interval is necessary to make sure CDL return time is calculated
+// and displayed on pages that have a Ramp player. The message renders in Ramp so 
+// we need to wait until it is initialized to run localize_times.
+$(document).ready(function () {
+  let timeCheck = setInterval(initLocalizeTimes, 500);
+  function initLocalizeTimes() {
+    console.log(document.readyState);
+    // Check readyState to avoid constant interval polling on non-Ramp pages.
+    if (document.readyState === 'complete') {
+      clearInterval(timeCheck);
+      localize_times();
+    }
+  }
+});

--- a/app/assets/javascripts/localize_times.js
+++ b/app/assets/javascripts/localize_times.js
@@ -29,7 +29,6 @@ $(document).on('draw.dt', localize_times);
 $(document).ready(function () {
   let timeCheck = setInterval(initLocalizeTimes, 500);
   function initLocalizeTimes() {
-    console.log(document.readyState);
     // Check readyState to avoid constant interval polling on non-Ramp pages.
     if (document.readyState === 'complete') {
       clearInterval(timeCheck);

--- a/app/views/media_objects/_embed_checkout.html.erb
+++ b/app/views/media_objects/_embed_checkout.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if !@masterFiles.blank? %>
-  <% master_file=@media_object.master_files.first %>
+  <% master_file = @media_object.master_files.first %>
   <div class="checkout <%= master_file.is_video? ? 'video' : 'audio' %> mb-3" style="height: <%= master_file.is_video? ? 400 : 120 %>px">
     <div class="centered <%= 'video' if master_file.is_video? %>">
       <% if !current_user %>


### PR DESCRIPTION
The function to generate the return time was running on `$(document).ready`, which triggers before Ramp has fully loaded. Since the message is displayed within Ramp this timing issue caused no time to be displayed. 