### PR TITLE
Use playlist token for manifest requests

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -24,7 +24,7 @@ class PlaylistsController < ApplicationController
   authorize_resource only: [:index]
   before_action :get_user_playlists, only: [:index, :paged_index]
   before_action :get_all_other_playlists, only: [:edit]
-  before_action :load_playlist_token, only: [:show, :duplicate]
+  before_action :load_playlist_token, only: [:show, :duplicate, :manifest]
 
   helper_method :access_token_url
 

--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -41,6 +41,7 @@ const ExpandCollapseArrow = () => {
 const Ramp = ({
   base_url,
   playlist_id,
+  token,
   share,
   comment_tag
 }) => {
@@ -55,6 +56,7 @@ const Ramp = ({
 
   React.useEffect(() => {
     let url = `${base_url}/playlists/${playlist_id}/manifest.json`;
+    if (token) url += `?token=${token}`;
     setManifestUrl(url);
 
     interval = setInterval(addPlayerEventListeners, 500);

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -32,6 +32,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       {
         base_url: request.protocol+request.host_with_port,
         playlist_id: @playlist.id,
+        token: @playlist_token,
         share: { canShare: (will_partial_list_render? :share), content: render('share') },
         comment_tag: { content: render('comments_and_tags') }
       }

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe PlaylistsController, type: :controller do
       end
       context 'with a private playlist and token' do
         let(:playlist) { FactoryBot.create(:playlist, :with_access_token, items: [playlist_item]) }
-        it "should return the playlist view page" do
+        it "should return the playlist view page and manifest" do
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).to be_successful
           expect(get :manifest, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -91,9 +91,11 @@ RSpec.describe PlaylistsController, type: :controller do
       end
       context 'with a private playlist and token' do
         let(:playlist) { FactoryBot.create(:playlist, :with_access_token, items: [playlist_item]) }
-        it "should return the playlist view page" do
+        it "should return the playlist view page and manifest" do
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).to be_successful
+          expect(get :manifest, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)
+          expect(get :manifest, params: { id: playlist.id, token: playlist.access_token }).to be_successful
         end
       end
     end
@@ -124,6 +126,8 @@ RSpec.describe PlaylistsController, type: :controller do
         it "should return the playlist view page" do
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)
           expect(get :show, params: { id: playlist.id, token: playlist.access_token }).to be_successful
+          expect(get :manifest, params: { id: playlist.id, token: playlist.access_token }).not_to redirect_to(root_path)
+          expect(get :manifest, params: { id: playlist.id, token: playlist.access_token }).to be_successful
         end
       end
     end


### PR DESCRIPTION
Pass token into PlaylistRamp component and use it to make manifest requests.  On the Avalon side use playlist token for authentication on manifest requests.