### PR TITLE
Use safe navigator on activeElement[0] methods

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -76,8 +76,8 @@ const Ramp = ({
       playerInst.ready(() => {
         let activeElement = document.getElementsByClassName('ramp--structured-nav__list-item active');
         if (activeElement != undefined && activeElement?.length > 0) {
-          setActiveItemTitle(activeElement[0].dataset.label);
-          setActiveItemSummary(activeElement[0].dataset.summary);
+          setActiveItemTitle(activeElement[0]?.dataset.label);
+          setActiveItemSummary(activeElement[0]?.dataset.summary);
         }
       });
     }


### PR DESCRIPTION
The console error seen with playlists was related to the activeElement variable briefly becoming undefined after a state update, breaking the second state update.