### PR TITLE
Use terser instead of uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'react-rails'
 gem 'sass', '3.4.22'
 gem 'sprockets-es6'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
-gem 'uglifier', '>= 1.3.0'
+gem 'terser'
 gem 'shakapacker'
 
 # Core Samvera

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,7 @@ GEM
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
     hashie (5.0.0)
+    highline (3.0.1)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -541,6 +542,8 @@ GEM
       rdf-turtle
       rdf-vocab (>= 0.8)
       slop
+    license_header (0.0.4)
+      highline
     link_header (0.0.8)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -910,6 +913,8 @@ GEM
     sxp (1.2.3)
       matrix (~> 0.4)
       rdf (~> 3.2)
+    terser (1.2.0)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.2)
     tilt (2.0.11)
     timeout (0.3.2)
@@ -923,8 +928,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.0.15)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -1037,6 +1040,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   ldp (~> 1.1.0)
+  license_header
   listen
   lograge
   mail (> 2.8.0.1)
@@ -1088,8 +1092,8 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3
+  terser
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
-  uglifier (>= 1.3.0)
   wavefile (~> 1.0.1)
   web-console
   webdrivers (~> 3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(:harmony => true)
+  config.assets.js_compressor = :terser
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Use terser instead of uglifier for JS processing during asset precompilation due to uglifier not supporting newer versions of ECMAScript