### PR TITLE
Add rake task to migrate IndexedFile captions to ActiveStorage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,6 @@ GEM
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
     hashie (5.0.0)
-    highline (3.0.1)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -542,8 +541,6 @@ GEM
       rdf-turtle
       rdf-vocab (>= 0.8)
       slop
-    license_header (0.0.4)
-      highline
     link_header (0.0.8)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -1040,7 +1037,6 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   ldp (~> 1.1.0)
-  license_header
   listen
   lograge
   mail (> 2.8.0.1)

--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -31,7 +31,7 @@ namespace :avalon do
         # Retrieve parent master file
         master_file_id = caption_file.id.split('/').first
         master_file = MasterFile.find(master_file_id) rescue nil
-        next unless master_file
+        next unless master_file && caption_file.present?
         # Grab original file metadata from IndexedFile
         filename = caption_file.original_name
         content_type = caption_file.mime_type
@@ -49,7 +49,7 @@ namespace :avalon do
         count += 1
       end
 
-      puts "Successfully updated #{count} records"
+      count > 0 ? puts("Successfully updated #{count} records") : puts("All files are already up to date. No records updated.")
     end
   end
 end


### PR DESCRIPTION
The original implementation for captions was a single IndexedFile attached to the master file. When we changed to ActiveStorage to support upload of multiple captions, we removed the controller routes and frontend code related to displaying, creating, and deleting the legacy captions. This migration moves the legacy captions to the new caption format so that users will be able to maintain access to, and control of, these captions.