### PR TITLE
Turn off feeding caption tracks into embedded player

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -60,7 +60,7 @@ module MasterFileBehavior
       caption_paths = []
       supplemental_file_captions.each { |c| caption_paths.append(build_caption_hash(c)) }
 
-      caption_paths.append(build_caption_hash(captions)) if captions
+      caption_paths.append(build_caption_hash(captions)) if captions.present?
 
       caption_paths
     end

--- a/app/views/modules/player/_video_js_element.html.erb
+++ b/app/views/modules/player/_video_js_element.html.erb
@@ -53,7 +53,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                          "userActions": {
                            hotkeys: true
                          }
-                       }.compact.to_json %>
+                        }.compact.to_json %>
 
   <div class='video-container' style="width:100%; height:100%;">
     <video-js id="video-js-embed-<%= @master_file.id %>"
@@ -64,9 +64,12 @@ Unless required by applicable law or agreed to in writing, software distributed
       <% section_info[:stream_hls].each do |hls| %>
         <source src="<%= hls[:url] %>" type="application/x-mpegURL" data-quality="<%= hls[:quality] %>" label="<%= hls[:quality] %>"/>
       <% end %>
-      <% if section_info[:caption_paths].present? %>
+      <%# Captions are contained in the HLS manifest and so we do not need to manually provide them to VideoJS here %>
+      <%# TODO: Reenable if/when we remove captions from HLS %>
+      <% skip_captions = true %>
+      <% if section_info[:caption_paths].present? && !skip_captions %>
         <% section_info[:caption_paths].each do |c| %>
-          <track <% if c[:label] %>label="<%= c[:label] %>" <% end %> srclang="<%= c[:language] %>" kind="subtitles" type="<%= c[:mime_type] %>" src="<%= c[:path] %>"></track>
+         <track <% if c[:label] %>label="<%= c[:label] %>" <% end %> srclang="<%= c[:language] %>" kind="subtitles" type="<%= c[:mime_type] %>" src="<%= c[:path] %>"></track>
         <% end %>
       <% end %>
     </video-js>

--- a/app/views/modules/player/_video_js_element.html.erb
+++ b/app/views/modules/player/_video_js_element.html.erb
@@ -43,16 +43,16 @@ Unless required by applicable law or agreed to in writing, software distributed
                            end %>
 
   <% @videojs_options = {
-                         "autoplay": false,
-                         "width": @player_width || 480,
-                         "height": @player_height || 270,
-                         "bigPlayButton": section_info[:is_video] ? true : false,
-                         "poster": section_info[:is_video] ?  section_info[:poster_image] : false,
-                         "preload": "auto",
-                         "controlBar": control_bar_options,
-                         "userActions": {
-                           hotkeys: true
-                         }
+                          "autoplay": false,
+                          "width": @player_width || 480,
+                          "height": @player_height || 270,
+                          "bigPlayButton": section_info[:is_video] ? true : false,
+                          "poster": section_info[:is_video] ?  section_info[:poster_image] : false,
+                          "preload": "auto",
+                          "controlBar": control_bar_options,
+                          "userActions": {
+                            hotkeys: true
+                          }
                         }.compact.to_json %>
 
   <div class='video-container' style="width:100%; height:100%;">
@@ -69,7 +69,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <% skip_captions = true %>
       <% if section_info[:caption_paths].present? && !skip_captions %>
         <% section_info[:caption_paths].each do |c| %>
-         <track <% if c[:label] %>label="<%= c[:label] %>" <% end %> srclang="<%= c[:language] %>" kind="subtitles" type="<%= c[:mime_type] %>" src="<%= c[:path] %>"></track>
+          <track <% if c[:label] %>label="<%= c[:label] %>" <% end %> srclang="<%= c[:language] %>" kind="subtitles" type="<%= c[:mime_type] %>" src="<%= c[:path] %>"></track>
         <% end %>
       <% end %>
     </video-js>


### PR DESCRIPTION
Captions are currently contained in the HLS manifest and these are parsed by VideoJS. We do not need to manually provide text tracks to the embedded player because of this. This commit also includes a change to the filtering of captions for the embedded player for if/when we reenable manually providing them so that issues will not arise for implementers who run the caption file migration.