### PR TITLE
Enable action buttons on item page only when player is fully loaded

### DIFF
--- a/app/views/media_objects/_add_to_playlist.html.erb
+++ b/app/views/media_objects/_add_to_playlist.html.erb
@@ -177,7 +177,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           // This timeout enables the add to playlist button, when this happens. It checks the button's state and enables it as needed.
           setTimeout(() => {
             enableAddToPlaylist();
-          }, 500);
+          }, 100);
           player.on('seeked', () => {
             if(getActiveItem() != undefined) {
               activeTrack = getActiveItem(false);
@@ -200,8 +200,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       }
 
       function enableAddToPlaylist() {
+        let player = document.getElementById('iiif-media-player');
         let addToPlaylistBtn = document.getElementById('addToPlaylistBtn');
-        if(addToPlaylistBtn && addToPlaylistBtn.disabled) {
+        if(addToPlaylistBtn && addToPlaylistBtn.disabled && player?.player.readyState() === 4) {
           addToPlaylistBtn.disabled = false;
         }
         if(!listenersAdded) {

--- a/app/views/media_objects/_thumbnail.html.erb
+++ b/app/views/media_objects/_thumbnail.html.erb
@@ -59,19 +59,29 @@ Unless required by applicable law or agreed to in writing, software distributed
           if (thumbnailBtn) {
             thumbnailBtn.disabled = false;
           }
-          clearInterval(timeCheck);
         });
         /*
           Browsers on MacOS sometimes miss the 'loadedmetadata' event resulting in a disabled add to playlist button indefinitely.
           This timeout enables the add to playlist button, when this happens. It checks the button's state and enables it as needed.
+          Additional check for player's readyState ensures the button is enabled only when player is ready after the timeout.
         */
         setTimeout(() => {
           let thumbnailBtn = document.getElementById('create-thumbnail-btn');
-          if (thumbnailBtn && thumbnailBtn.disabled) {
-            thumbnailBtn.disabled = false;
+          if (thumbnailBtn && thumbnailBtn.disabled && player.player?.readyState() === 4) {
+              thumbnailBtn.disabled = false;
           }
-          clearInterval(timeCheck);
-        }, 500);
+        }, 100);
+
+        /* 
+          Disable 'Create Thumbnail' button on player dispose, so that it can be enabled again or keep disabled on the next section load
+          based on the player status.      
+        */
+        player.player.on('dispose', () => {
+          let thumbnailBtn = document.getElementById('create-thumbnail-btn');
+          if (thumbnailBtn) {
+            thumbnailBtn.disabled = true;
+          }
+        });
       }
 
       $('#thumbnailModal').on('show.bs.modal', function(e) {

--- a/app/views/media_objects/_timeline.html.erb
+++ b/app/views/media_objects/_timeline.html.erb
@@ -54,19 +54,29 @@ $(document).ready(function() {
         if (timelineBtn) {
           timelineBtn.disabled = false;
         }
-        clearInterval(timeCheck);
       });
       /*
         Browsers on MacOS sometimes miss the 'loadedmetadata' event resulting in a disabled add to playlist button indefinitely.
         This timeout enables the add to playlist button, when this happens. It checks the button's state and enables it as needed.
+        Additional check for player's readyState ensures the button is enabled only when player is ready after the timeout.
       */
       setTimeout(() => {
         let timelineBtn = document.getElementById('timelineBtn');
-        if (timelineBtn && timelineBtn.disabled) {
+        if (timelineBtn && timelineBtn.disabled && player.player?.readyState() === 4) {
           timelineBtn.disabled = false;
         }
-        clearInterval(timeCheck);
-      }, 500);
+      }, 100);
+
+      /* 
+        Disable 'Create Timeline' button on player dispose, so that it can be enabled again or keep disabled on the next section load
+        based on the player status.      
+      */
+      player.player.on('dispose', () => {
+        let timelineBtn = document.getElementById('timelineBtn');
+        if (timelineBtn) {
+          timelineBtn.disabled = true;
+        }
+      });
     }
 
     $('#timelineModal').on('shown.bs.modal', function (e) {


### PR DESCRIPTION
> Part of the work done in https://github.com/avalonmediasystem/avalon/pull/5687. This was not added in the previous PR, as this will need thorough testing.
> The code needs to be cleaned up as needed and handle all possible use-cases.

Tested in different browsers on desktop and Android. I couldn't test this on iOS devices as streaming doesn't work in iOS in my dev environment.

Action buttons are enabled with playable media on page:

![item with media](https://github.com/avalonmediasystem/avalon/assets/1331659/5660977b-3d73-4bb1-912c-91251fe96562)

Action buttons are disabled without playable media on page:

![item w:o media](https://github.com/avalonmediasystem/avalon/assets/1331659/c23133df-0591-482c-ba8b-c1031490de1c)

Related issue: https://github.com/avalonmediasystem/avalon/issues/5691