### PR TITLE
Set event listeners once for playlist modal

### DIFF
--- a/app/views/media_objects/_add_to_playlist.html.erb
+++ b/app/views/media_objects/_add_to_playlist.html.erb
@@ -205,6 +205,9 @@ Unless required by applicable law or agreed to in writing, software distributed
           addToPlaylistBtn.disabled = false;
         }
         if(!listenersAdded) {
+          // Add 'Add new playlist' option to dropdown
+          window.add_new_playlist_option();
+
           addListeners();
         }
       }
@@ -228,8 +231,6 @@ Unless required by applicable law or agreed to in writing, software distributed
             currentTime = currentPlayer.player.currentTime();
             duration = currentPlayer.player.duration();
           }
-          // Add 'Add new playlist' option to dropdown
-          window.add_new_playlist_option();
 
           let canvasIndex = parseInt(currentPlayer.dataset.canvasindex);
           mediaObjectTitle = playlistForm.dataset.title;


### PR DESCRIPTION
We were encountering an issue where adding a new playlist from the dropdown menu would insert the new playlist's name into the list multiple times. This was caused by the `.add_new_playlist_option()` function being triggered every time the Add to Playlist menu was opened. This caused the event listener that updates the dropdown list to be added every time the menu opened, resulting in the duplication we were seeing. Moving the function call out of the parent event listener so it only runs once fixes the issue.