### PR TITLE
Reduce Video.js icon size for mobile devices to 90%

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -31,6 +31,12 @@
       .video-js .vjs-control-bar {
         font-size: 90% !important;
       }
+
+      // reduce player height to match with adjusted font-size
+      // for smaller screens
+      .video-js.vjs-audio {
+        min-height: 2.9em;
+      }
     }
   }
 

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -27,10 +27,10 @@
       .video-js .vjs-big-play-button {
         scale: 1.5;
       }
-    }
 
-    .video-js .vjs-control-bar {
-      font-size: 100% !important;
+      .video-js .vjs-control-bar {
+        font-size: 90% !important;
+      }
     }
   }
 


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/402