### PR TITLE
Correctly convert count result array into hash

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -41,11 +41,11 @@ class Admin::CollectionsController < ApplicationController
     count_query = "has_model_ssim:MediaObject"
     count_response = ActiveFedora::SolrService.get(count_query, { rows: 0, facet: true, 'facet.field': "isMemberOfCollection_ssim", 'facet.limit': -1 })
     counts_array = count_response["facet_counts"]["facet_fields"]["isMemberOfCollection_ssim"] rescue []
-    counts = counts_array.blank? ? {} : [counts_array].to_h
+    counts = counts_array.each_slice(2).to_h
     unpublished_query = count_query + " AND workflow_published_sim:Unpublished"
     unpublished_count_response = ActiveFedora::SolrService.get(unpublished_query, { rows: 0, facet: true, 'facet.field': "isMemberOfCollection_ssim", 'facet.limit': -1 })
     unpublished_counts_array = unpublished_count_response["facet_counts"]["facet_fields"]["isMemberOfCollection_ssim"] rescue []
-    unpublished_counts = unpublished_counts_array.blank? ? {} : [unpublished_counts_array].to_h
+    unpublished_counts = unpublished_counts_array.each_slice(2).to_h
 
     @collections = response.documents.collect { |doc| ::Admin::CollectionPresenter.new(doc, media_object_count: counts[doc.id], unpublished_media_object_count: unpublished_counts[doc.id]) }.sort_by { |c| c.name.downcase }
   end

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -47,7 +47,11 @@ class Admin::CollectionsController < ApplicationController
     unpublished_counts_array = unpublished_count_response["facet_counts"]["facet_fields"]["isMemberOfCollection_ssim"] rescue []
     unpublished_counts = unpublished_counts_array.each_slice(2).to_h
 
-    @collections = response.documents.collect { |doc| ::Admin::CollectionPresenter.new(doc, media_object_count: counts[doc.id], unpublished_media_object_count: unpublished_counts[doc.id]) }.sort_by { |c| c.name.downcase }
+    @collections = response.documents.collect do |doc| 
+                     ::Admin::CollectionPresenter.new(doc, 
+                                                      media_object_count: (counts[doc.id] || 0),
+                                                      unpublished_media_object_count: (unpublished_counts[doc.id] || 0))
+                   end.sort_by { |c| c.name.downcase }
   end
 
   # GET /collections

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -154,7 +154,8 @@ describe Admin::CollectionsController, type: :controller do
   end
 
   describe "#index" do
-    let!(:collection) { FactoryBot.create(:collection) }
+    let!(:collection) { FactoryBot.create(:collection, items: 1) }
+    let!(:collection2) { FactoryBot.create(:collection, items: 1) }
     subject(:json) { JSON.parse(response.body) }
 
     let(:administrator) { FactoryBot.create(:administrator) }
@@ -165,7 +166,7 @@ describe Admin::CollectionsController, type: :controller do
     end
     it "should return list of collections" do
       get 'index', params: { format:'json' }
-      expect(json.count).to eq(1)
+      expect(json.count).to eq(2)
       expect(json.first['id']).to eq(collection.id)
       expect(json.first['name']).to eq(collection.name)
       expect(json.first['unit']).to eq(collection.unit)


### PR DESCRIPTION
Fix bug in #5713 