### PR TITLE
Set duration of MasterFile from ActiveEncode instead of relying on the imprecise mediainfo duration

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -294,9 +294,13 @@ class MasterFile < ActiveFedora::Base
     #TODO pull this from the encode
     self.date_digitized ||= Time.now.utc.iso8601
 
-    # Set duration after transcode if mediainfo fails to find.
-    # e.x. WebM files missing technical metadata
-    self.duration ||= encode.input.duration
+    # Update the duration detected by ActiveEncode
+    # because it has higher precision than mediainfo
+    # Set for the first time for files without duration
+    # e.g. WebM files missing technical metadata
+    # ActiveEncode returns duration in milliseconds which
+    # is stored as an integer string
+    self.duration = encode.input.duration.to_i.to_s if encode.input.duration.present?
 
     outputs = Array(encode.output).collect do |output|
       {

--- a/spec/factories/encode.rb
+++ b/spec/factories/encode.rb
@@ -26,12 +26,14 @@ FactoryBot.define do
       state { :running }
       percent_complete { 50.5 }
       current_operations { ['encoding'] }
+      input { FactoryBot.build(:encode_output) }
     end
       
     trait :succeeded do
       state { :completed }
       percent_complete { 100 }
       current_operations { ['DONE'] }
+      input { FactoryBot.build(:encode_output) }
       output { [ FactoryBot.build(:encode_output) ] }
     end
 
@@ -39,15 +41,29 @@ FactoryBot.define do
       state { :failed }
       percent_complete { 50.5 }
       current_operations { ['FAILED'] }
+      input { FactoryBot.build(:encode_output) }
       errors { ['Out of disk space.'] }
     end
+  end
+
+  factory :encode_input, class: ActiveEncode::Input do
+    id { SecureRandom.uuid }
+    label { 'quality-high' }
+    url { 'file://path/to/output.mp4' }
+    duration { '21575.0' }
+    audio_bitrate { '163842.0' }
+    audio_codec { 'AAC' }
+    video_bitrate { '4000000.0' }
+    video_codec { 'AVC' }
+    width { '1024' }
+    height { '768' }
   end
 
   factory :encode_output, class: ActiveEncode::Output do
     id { SecureRandom.uuid }
     label { 'quality-high' }
     url { 'file://path/to/output.mp4' }
-    duration { '21575' }
+    duration { '21575.0' }
     audio_bitrate { '163842.0' }
     audio_codec { 'AAC' }
     video_bitrate { '4000000.0' }


### PR DESCRIPTION
Resolves #5748 