### PR TITLE
Serialize captions to IIIF manifest with text/vtt as the format

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -209,7 +209,11 @@ class IiifCanvasPresenter
     def supplemental_attributes(file)
       if file.is_a?(SupplementalFile)
         label = file.tags.include?('machine_generated') ? file.label + ' (machine generated)' : file.label
-        format = file.file.content_type
+        format = if file.file.content_type == 'text/srt' && file.tags.include?('caption')
+                   'text/vtt'
+                 else
+                   file.file.content_type
+                 end
         language = file.language || 'en'
         filename = file.file.filename.to_s
       else

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -269,6 +269,16 @@ describe IiifCanvasPresenter do
         expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq false
       end
 
+      context 'srt captions' do
+        let(:srt_caption_file) { FactoryBot.create(:supplemental_file, :with_caption_srt_file, :with_caption_tag) }
+        let(:supplemental_files) { [supplemental_file, transcript_file, caption_file, srt_caption_file] }
+        it 'sets format to "text/vtt"' do
+          captions = subject.select { |s| s.body_id.include?('captions') }
+          expect(captions.none? { |content| content.format == 'text/srt' }).to eq true
+          expect(captions.all? { |content| content.format == 'text/vtt' }).to eq true
+        end
+      end
+
       context 'legacy master file captions' do
         let(:master_file) { FactoryBot.create(:master_file, :with_waveform, :with_captions, supplemental_files_json: supplemental_files_json, media_object: media_object, derivatives: [derivative]) }
 


### PR DESCRIPTION
SRT formatted captions are converted to VTT format when the content is requested by Ramp. However, the iiif manifest still had the format for these files listed as 'text/srt'. This caused Ramp to not process the file correctly and the caption file would not show up in the subs/captions list in the player. Setting the format to 'text/vtt' allows Ramp to correctly process the caption track.

Related Issue: #5765 