### PR TITLE
Display comments, tags for an empty playlist

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -61,12 +61,12 @@ const Ramp = ({
     let url = `${base_url}/playlists/${playlist_id}/manifest.json`;
     if (token) url += `?token=${token}`;
 
-    let [fullpath, position] = fullpath_url.split('?position=');
-    let start_canvas = playlist_item_ids[position - 1]
+    let [_, position] = fullpath_url.split('?position=');
+    let start_canvas = playlist_item_ids[position - 1];
     setStartCanvasId(
       start_canvas && start_canvas != undefined
-      ? `${base_url}/playlists/${playlist_id}/manifest/canvas/${start_canvas}`
-      : undefined
+        ? `${base_url}/playlists/${playlist_id}/manifest/canvas/${start_canvas}`
+        : undefined
     );
     setManifestUrl(url);
 
@@ -97,40 +97,43 @@ const Ramp = ({
   return (
     <IIIFPlayer manifestUrl={manifestUrl}
       customErrorMessage='This playlist is empty.'
+      emptyManifestMessage='This playlist currently has no playable items.'
       startCanvasId={startCanvasId}>
       <Row className="ramp--all-components ramp--playlist">
         <Col sm={8}>
           <MediaPlayer enableFileDownload={false} />
-          <Card className="ramp--playlist-accordion">
-            <Card.Header>
-              <h4>{activeItemTitle}</h4>
-              {activeItemSummary && <div>{activeItemSummary}</div>}
-            </Card.Header>
-            <Card.Body>
-              <Accordion>
-                <Card>
-                  <Accordion.Collapse eventKey="0" id="markers">
-                    <Card.Body>
-                      <MarkersDisplay showHeading={false} />
-                    </Card.Body>
-                  </Accordion.Collapse>
-                  <Accordion.Toggle as={Card.Header} variant="link" eventKey="0" className="ramp--playlist-accordion-header">
-                    <ExpandCollapseArrow /> Markers
-                  </Accordion.Toggle>
-                </Card>
-                <Card>
-                  <Accordion.Collapse eventKey="1">
-                    <Card.Body className="p-3">
-                      <MetadataDisplay displayOnlyCanvasMetadata={true} showHeading={false} />
-                    </Card.Body>
-                  </Accordion.Collapse>
-                  <Accordion.Toggle as={Card.Header} variant="link" eventKey="1" className="ramp--playlist-accordion-header">
-                    <ExpandCollapseArrow /> Source Item Details
-                  </Accordion.Toggle>
-                </Card>
-              </Accordion>
-            </Card.Body>
-          </Card>
+          {playlist_item_ids?.lenght > 0 && (
+            <Card className="ramp--playlist-accordion">
+              <Card.Header>
+                <h4>{activeItemTitle}</h4>
+                {activeItemSummary && <div>{activeItemSummary}</div>}
+              </Card.Header>
+              <Card.Body>
+                <Accordion>
+                  <Card>
+                    <Accordion.Collapse eventKey="0" id="markers">
+                      <Card.Body>
+                        <MarkersDisplay showHeading={false} />
+                      </Card.Body>
+                    </Accordion.Collapse>
+                    <Accordion.Toggle as={Card.Header} variant="link" eventKey="0" className="ramp--playlist-accordion-header">
+                      <ExpandCollapseArrow /> Markers
+                    </Accordion.Toggle>
+                  </Card>
+                  <Card>
+                    <Accordion.Collapse eventKey="1">
+                      <Card.Body className="p-3">
+                        <MetadataDisplay displayOnlyCanvasMetadata={true} showHeading={false} />
+                      </Card.Body>
+                    </Accordion.Collapse>
+                    <Accordion.Toggle as={Card.Header} variant="link" eventKey="1" className="ramp--playlist-accordion-header">
+                      <ExpandCollapseArrow /> Source Item Details
+                    </Accordion.Toggle>
+                  </Card>
+                </Accordion>
+              </Card.Body>
+            </Card>
+          )}
         </Col>
         <Col sm={4} className={`ramp--playlist-items-column ${IS_MOBILE ? 'mobile-view' : ''}`}>
           <Row>
@@ -154,7 +157,7 @@ const Ramp = ({
               }
             </Col>
           </Row>
-          <Row className="mx-0">
+          <Row className="mx-0 mb-2">
             <Col md={12} lg={12} sm={12} className="px-0">
               <div className="collapse" id="shareList">
                 <div dangerouslySetInnerHTML={{ __html: share.content }} />
@@ -162,8 +165,12 @@ const Ramp = ({
             </Col>
           </Row>
           <div dangerouslySetInnerHTML={{ __html: comment_tag.content }} />
-          <h4 className="mt-3">Playlist Items</h4>
-          <StructuredNavigation />
+          {playlist_item_ids?.length > 0 && (
+            <React.Fragment>
+              <h4 className="mt-3">Playlist Items</h4>
+              <StructuredNavigation />
+            </React.Fragment>
+          )}
         </Col>
       </Row>
     </IIIFPlayer>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "7",
-    "@samvera/ramp": "^3.1.0",
+    "@samvera/ramp": "https://github.com/samvera-labs/ramp.git",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,10 +1440,9 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@samvera/ramp@^3.1.0":
+"@samvera/ramp@https://github.com/samvera-labs/ramp.git":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@samvera/ramp/-/ramp-3.1.0.tgz#6254646f34b9a434ff6e6046f1e013130d036e28"
-  integrity sha512-B5UiU0DDxi7Ub+DfbKC7j80zjMCmkuLnmDJNUqnftjO1L2gocdMOuUfYZ30pAh9SO9HbMCEtAFtLUHPlizPz3A==
+  resolved "https://github.com/samvera-labs/ramp.git#e3b34b978f8f8448317b3717db2ae52b359481da"
   dependencies:
     "@rollup/plugin-json" "^6.0.1"
     "@silvermine/videojs-quality-selector" "^1.2.4"


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/457

The changes in this PR are associated with https://github.com/samvera-labs/ramp/pull/475. To finish this work a new Ramp build with these changes should be brought into Avalon.

An empty playlist with be displayed as follows with `emptyManifestMessage='This playlist currently has no playable items.'`;

![Screenshot 2024-04-05 at 1 31 56 PM](https://github.com/samvera-labs/ramp/assets/1331659/02afe550-a559-4a72-ac71-a3a96112a2ce)