### PR TITLE
Use JSON string array of ids instead of ordered_aggregation linked list

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -141,7 +141,7 @@ class BookmarksController < CatalogController
     playlist = Playlist.find(params[:target_playlist_id])
     Array(documents.map(&:id)).each do |id|
       media_object = SpeedyAF::Proxy::MediaObject.find(id)
-      media_object.ordered_master_files.to_a.each do |mf|
+      media_object.sections.each do |mf|
         clip = AvalonClip.create(master_file: mf)
         PlaylistItem.create(clip: clip, playlist: playlist)
       end

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -202,13 +202,10 @@ class MasterFilesController < ApplicationController
     authorize! :destroy, @master_file, message: "You do not have sufficient privileges to delete files"
     filename = File.basename(@master_file.file_location) if @master_file.file_location.present?
     filename ||= @master_file.id
-    media_object = MediaObject.find(@master_file.media_object_id)
-    media_object.ordered_master_files.delete(@master_file)
-    media_object.master_files.delete(@master_file)
-    media_object.save
+    media_object_id = @master_file.media_object_id
     @master_file.destroy
     flash[:notice] = "#{filename} has been deleted from the system"
-    redirect_to edit_media_object_path(media_object, step: "file-upload")
+    redirect_to edit_media_object_path(media_object_id, step: "file-upload")
   end
 
   def set_frame

--- a/app/helpers/media_objects_helper.rb
+++ b/app/helpers/media_objects_helper.rb
@@ -195,10 +195,10 @@ module MediaObjectsHelper
         milliseconds_to_formatted_time((stop.to_i - start.to_i) * 1000, false)
       end
 
-      # This method mirrors the one in the MediaObject model but makes use of the master files passed in which can be SpeedyAF Objects
+      # This method mirrors the one in the MediaObject model but makes use of the sections passed in which can be SpeedyAF Objects
       # This would be good to refactor in the future but speeds things up considerably for now
-      def gather_all_comments(media_object, master_files)
-        media_object.comment.sort + master_files.collect do |mf|
+      def gather_all_comments(media_object, sections)
+        media_object.comment.sort + sections.collect do |mf|
           mf.comment.reject(&:blank?).collect do |c|
             mf.display_title.present? ? "[#{mf.display_title}] #{c}" : c
           end.sort

--- a/app/helpers/security_helper.rb
+++ b/app/helpers/security_helper.rb
@@ -30,20 +30,20 @@ module SecurityHelper
   # media_object CDL check only happens once
   # session tokens retrieved in batch then passed into add_stream_url
   # Returns Hash[MasterFile.id, stream_info]
-  def secure_stream_infos(master_files, media_objects)
+  def secure_stream_infos(sections, media_objects)
     stream_info_hash = {}
 
     not_checked_out_hash = {}
-    mo_ids = master_files.collect(&:media_object_id)
+    mo_ids = sections.collect(&:media_object_id)
     mo_ids.each { |mo_id| not_checked_out_hash[mo_id] ||= not_checked_out?(mo_id, media_object: media_objects.find {|mo| mo.id == mo_id}) }
-    not_checked_out_master_files = master_files.select { |mf| not_checked_out_hash[mf.media_object_id] }
-    checked_out_master_files = master_files - not_checked_out_master_files
+    not_checked_out_sections = sections.select { |mf| not_checked_out_hash[mf.media_object_id] }
+    checked_out_sections = sections - not_checked_out_sections
 
-    not_checked_out_master_files.each { |mf| stream_info_hash[mf.id] = mf.stream_details }
+    not_checked_out_sections.each { |mf| stream_info_hash[mf.id] = mf.stream_details }
 
-    stream_tokens = StreamToken.get_session_tokens_for(session: session, targets: checked_out_master_files.map(&:id))
+    stream_tokens = StreamToken.get_session_tokens_for(session: session, targets: checked_out_sections.map(&:id))
     stream_token_hash = stream_tokens.pluck(:target, :token).to_h
-    checked_out_master_files.each { |mf| stream_info_hash[mf.id] = secure_stream_info(mf.stream_details, stream_token_hash[mf.id]) }
+    checked_out_sections.each { |mf| stream_info_hash[mf.id] = secure_stream_info(mf.stream_details, stream_token_hash[mf.id]) }
 
     stream_info_hash
   end

--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -40,7 +40,7 @@ const ExpandCollapseArrow = () => {
 
 const Ramp = ({
   urls,
-  master_files_count,
+  sections_count,
   has_structure,
   title,
   share,
@@ -153,7 +153,7 @@ const Ramp = ({
               </React.Fragment>
               )
             : (<React.Fragment>
-              {master_files_count > 0 &&
+              {sections_count > 0 &&
                 <React.Fragment>
                   <MediaPlayer enableFileDownload={false} />
                   <div className="ramp--rails-title">
@@ -217,7 +217,7 @@ const Ramp = ({
                           ref={expandCollapseBtnRef}
                         >
                           <ExpandCollapseArrow />
-                          {isClosed ? ' Expand' : ' Close'} {master_files_count > 1 ? `${master_files_count} Sections` : 'Section'}
+                          {isClosed ? ' Expand' : ' Close'} {sections_count > 1 ? `${sections_count} Sections` : 'Section'}
                         </button>
                       </Col>
                     }
@@ -244,13 +244,13 @@ const Ramp = ({
             )
           }
         </Col>
-        <Col sm={(master_files_count == 0) ? 12 : 4} className="ramp--tabs-panel">
+        <Col sm={(sections_count == 0) ? 12 : 4} className="ramp--tabs-panel">
           {cdl.enabled && <div dangerouslySetInnerHTML={{ __html: cdl.destroy }} />}
           <Tabs>
             <Tab eventKey="details" title="Details">
               <MetadataDisplay showHeading={false} displayTitle={false} />
             </Tab>
-            {(cdl.can_stream && master_files_count != 0 && has_transcripts) &&
+            {(cdl.can_stream && sections_count != 0 && has_transcripts) &&
               <Tab eventKey="transcripts" title="Transcripts" className="ramp--transcripts_tab">
                 <Transcript
                   playerID="iiif-media-player"

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -55,6 +55,7 @@ module Avalon
       property :avalon_publisher,     "rdfs:isDefinedBy" => %(avr-media_object:).freeze, type: "rdfs:Class".freeze
       property :supplementalFiles,    "rdfs:isDefinedBy" => %(avr-media_object:).freeze, type: "rdfs:Class".freeze
       property :avalon_uploader,      "rdfs:isDefinedBy" => %(avr-media_object:).freeze, type: "rdfs:Class".freeze
+      property :section_list,         "rdfs:isDefinedBy" => %(avr-media_object:).freeze, type: "rdfs:Class".freeze
     end
 
     class Collection < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/collection#")

--- a/app/models/batch_entries.rb
+++ b/app/models/batch_entries.rb
@@ -73,13 +73,13 @@ class BatchEntries < ActiveRecord::Base
     return (@encoding_status = :error) unless media_object
 
     # TODO: match file_locations strings with those in MasterFiles?
-    if media_object.master_files.to_a.count != files.count
+    if media_object.sections.count != files.count
       return (@encoding_status = :error)
     end
 
     # Only return success if all MasterFiles have status 'COMPLETED'
     status = :success
-    media_object.master_files.each do |master_file|
+    media_object.sections.each do |master_file|
       next if master_file.status_code == 'COMPLETED'
       # TODO: explore border cases
       if master_file.status_code == 'FAILED' || master_file.status_code == 'CANCELLED'

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -108,8 +108,7 @@ module MasterFileBehavior
                  structuralMetadata.section_title
                elsif title.present?
                  title
-               # FIXME: The test for media_object.master_file_ids.size is expensive and takes ~0.25 seconds
-               elsif file_location.present? && (media_object.master_file_ids.size > 1)
+               elsif file_location.present? && (media_object.section_ids.size > 1)
                  file_location.split("/").last
                end
     mf_title.blank? ? nil : mf_title

--- a/app/models/concerns/media_object_behavior.rb
+++ b/app/models/concerns/media_object_behavior.rb
@@ -15,20 +15,6 @@
 # This module contains methods which transform stored values for use either on the MediaObject or the SpeedyAF presenter
 module MediaObjectBehavior
 
-  def section_ids
-    return @section_ids if @section_ids
-
-    # Do migration
-    self.section_ids = self.ordered_master_file_ids if self.section_list.nil?
-
-    return [] if self.section_list.nil?
-    @section_ids = JSON.parse(self.section_list)
-  end
-
-  def sections
-    @sections ||= self.master_files.sort { |mf1, mf2| section_ids.index(mf1.id) <=> section_ids.index(mf2.id) }
-  end
-
   def as_json(options={})
     {
       id: id,

--- a/app/models/concerns/media_object_behavior.rb
+++ b/app/models/concerns/media_object_behavior.rb
@@ -14,6 +14,21 @@
 
 # This module contains methods which transform stored values for use either on the MediaObject or the SpeedyAF presenter
 module MediaObjectBehavior
+
+  def section_ids
+    return @section_ids if @section_ids
+
+    # Do migration
+    self.section_ids = self.ordered_master_file_ids if self.section_list.nil?
+
+    return [] if self.section_list.nil?
+    @section_ids = JSON.parse(self.section_list)
+  end
+
+  def sections
+    @sections ||= self.master_files.sort { |mf1, mf2| section_ids.index(mf1.id) <=> section_ids.index(mf2.id) }
+  end
+
   def as_json(options={})
     {
       id: id,

--- a/app/models/concerns/media_object_behavior.rb
+++ b/app/models/concerns/media_object_behavior.rb
@@ -59,11 +59,11 @@ module MediaObjectBehavior
   end
 
   def has_captions
-    master_files.any? { |mf| mf.has_captions? }
+    sections.any? { |mf| mf.has_captions? }
   end
 
   def has_transcripts
-    master_files.any? { |mf| mf.has_transcripts? }
+    sections.any? { |mf| mf.has_transcripts? }
   end
 
   # CDL methods

--- a/app/models/concerns/media_object_intercom.rb
+++ b/app/models/concerns/media_object_intercom.rb
@@ -15,7 +15,7 @@
 module MediaObjectIntercom
   def to_ingest_api_hash(include_structure = true, remove_identifiers: false, publish: false)
     {
-      files: ordered_master_files.to_a.collect { |mf| mf.to_ingest_api_hash(include_structure, remove_identifiers: remove_identifiers) },
+      files: sections.collect { |mf| mf.to_ingest_api_hash(include_structure, remove_identifiers: remove_identifiers) },
       fields:
         {
           duration: duration,

--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -39,12 +39,8 @@ class FileUploadStep < Avalon::Workflow::BasicStep
     deleted_master_files = update_master_files context
     context[:notice] = "Several clean up jobs have been sent out. Their statuses can be viewed by your sysadmin at #{ Settings.matterhorn.cleanup_log }" unless deleted_master_files.empty?
 
-    # Reloads media_object.master_files, should use .reload when we update hydra-head
     media = MediaObject.find(context[:media_object].id)
-    unless media.master_files.empty?
-      media.save
-      context[:media_object] = media
-    end
+    context[:media_object] = media
 
     context
   end
@@ -56,7 +52,6 @@ class FileUploadStep < Avalon::Workflow::BasicStep
   # label - Display label in the interface
   # id - Identifier for the masterFile to help with mapping
   def update_master_files(context)
-    media_object = context[:media_object]
     files = context[:master_files] || {}
     deleted_master_files = []
     if not files.blank?

--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -36,8 +36,8 @@ class FileUploadStep < Avalon::Workflow::BasicStep
   end
 
   def execute context
-    deleted_master_files = update_master_files context
-    context[:notice] = "Several clean up jobs have been sent out. Their statuses can be viewed by your sysadmin at #{ Settings.matterhorn.cleanup_log }" unless deleted_master_files.empty?
+    deleted_sections = update_master_files context
+    context[:notice] = "Several clean up jobs have been sent out. Their statuses can be viewed by your sysadmin at #{ Settings.matterhorn.cleanup_log }" unless deleted_sections.empty?
 
     media = MediaObject.find(context[:media_object].id)
     context[:media_object] = media
@@ -53,14 +53,14 @@ class FileUploadStep < Avalon::Workflow::BasicStep
   # id - Identifier for the masterFile to help with mapping
   def update_master_files(context)
     files = context[:master_files] || {}
-    deleted_master_files = []
+    deleted_sections = []
     if not files.blank?
       files.each_pair do |id,master_file|
         selected_master_file = MasterFile.find(id)
 
         if selected_master_file
           if master_file[:remove]
-            deleted_master_files << selected_master_file
+            deleted_sections << selected_master_file
             selected_master_file.destroy
           else
             selected_master_file.title = master_file[:title] unless master_file[:title].nil?
@@ -75,6 +75,6 @@ class FileUploadStep < Avalon::Workflow::BasicStep
         end
       end
     end
-    deleted_master_files
+    deleted_sections
   end
 end

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -202,7 +202,7 @@ class IiifManifestPresenter
   end
 
   def thumbnail_url
-    master_file_id = media_object.ordered_master_file_ids.try :first
+    master_file_id = media_object.section_ids.try :first
 
     video_count = media_object.avalon_resource_type.map(&:titleize)&.count { |m| m.start_with?('moving image'.titleize) } || 0
     audio_count = media_object.avalon_resource_type.map(&:titleize)&.count { |m| m.start_with?('sound recording'.titleize) } || 0

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -20,16 +20,16 @@ class IiifManifestPresenter
   IIIF_ALLOWED_TAGS = ['a', 'b', 'br', 'i', 'img', 'p', 'small', 'span', 'sub', 'sup'].freeze
   IIIF_ALLOWED_ATTRIBUTES = ['href', 'src', 'alt'].freeze
 
-  attr_reader :media_object, :master_files, :lending_enabled
+  attr_reader :media_object, :sections, :lending_enabled
 
   def initialize(media_object:, master_files:, lending_enabled: false)
     @media_object = media_object
-    @master_files = master_files
+    @sections = master_files
     @lending_enabled = lending_enabled
   end
 
   def file_set_presenters
-    master_files
+    sections
   end
 
   def work_presenters

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -551,6 +551,11 @@ class MasterFile < ActiveFedora::Base
     end
   end
 
+  def stop_processing!
+    # Stops all processing
+    ActiveEncodeJobs::CancelEncodeJob.perform_later(workflow_id, id) if workflow_id.present? && !finished_processing?
+  end
+
   protected
 
   def mediainfo
@@ -769,11 +774,6 @@ class MasterFile < ActiveFedora::Base
   def find_encoder_class(klass_name)
     klass = klass_name&.safe_constantize
     klass if klass&.ancestors&.include?(ActiveEncode::Base)
-  end
-
-  def stop_processing!
-    # Stops all processing
-    ActiveEncodeJobs::CancelEncodeJob.perform_later(workflow_id, id) if workflow_id.present? && finished_processing?
   end
 
   def update_parent!

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -244,7 +244,7 @@ class MasterFile < ActiveFedora::Base
     # Removes existing association
     if self.media_object.present?
       self.media_object.master_files = self.media_object.master_files.to_a.reject { |mf| mf.id == self.id }
-      self.media_object.ordered_master_files = self.media_object.ordered_master_files.to_a.reject { |mf| mf.id == self.id }
+      self.media_object.section_ids -= [self.id]
       self.media_object.save
     end
 
@@ -252,7 +252,8 @@ class MasterFile < ActiveFedora::Base
     self.save!(validate: false)
 
     unless self.media_object.nil?
-      self.media_object.ordered_master_files += [self]
+      self.media_object.master_files += [self]
+      self.media_object.section_ids += [self.id]
       self.media_object.save
     end
   end
@@ -777,7 +778,8 @@ class MasterFile < ActiveFedora::Base
 
   def update_parent!
     return unless media_object.present?
-    media_object.master_file_ids -= [self.id]
+    media_object.master_files.delete(self)
+    media_object.section_ids.delete(self.id)
     media_object.set_media_types!
     media_object.set_duration!
     if !media_object.save

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -239,6 +239,8 @@ class MasterFile < ActiveFedora::Base
 
   # This requires the MasterFile having an actual id
   def media_object=(mo)
+    self.save!(validate: false) unless self.persisted?
+
     # Removes existing association
     if self.media_object.present?
       self.media_object.master_files = self.media_object.master_files.to_a.reject { |mf| mf.id == self.id }
@@ -247,6 +249,8 @@ class MasterFile < ActiveFedora::Base
     end
 
     self._media_object=(mo)
+    self.save!(validate: false)
+
     unless self.media_object.nil?
       self.media_object.ordered_master_files += [self]
       self.media_object.save
@@ -773,8 +777,7 @@ class MasterFile < ActiveFedora::Base
 
   def update_parent!
     return unless media_object.present?
-    media_object.master_files.delete(self)
-    media_object.ordered_master_files.delete(self)
+    media_object.master_file_ids -= [self.id]
     media_object.set_media_types!
     media_object.set_duration!
     if !media_object.save

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -230,21 +230,21 @@ class MediaObject < ActiveFedora::Base
   end
 
   def set_media_types!
-    mime_types = section_solr_docs.reject { |mf| mf["file_location_ssi"].blank? }.collect do |mf|
-      Rack::Mime.mime_type(File.extname(mf["file_location_ssi"]))
+    mime_types = section_solr_docs.reject { |section| section["file_location_ssi"].blank? }.collect do |section|
+      Rack::Mime.mime_type(File.extname(section["file_location_ssi"]))
     end.uniq
     self.format = mime_types.empty? ? nil : mime_types
   end
 
   def set_resource_types!
-    self.avalon_resource_type = section_solr_docs.reject { |mf| mf["file_format_ssi"].blank? }.collect do |mf|
-      case mf["file_format_ssi"]
+    self.avalon_resource_type = section_solr_docs.reject { |section| section["file_format_ssi"].blank? }.collect do |section|
+      case section["file_format_ssi"]
       when 'Moving image'
         'moving image'
       when 'Sound'
         'sound recording'
       else
-        mf.file_format.downcase
+        section.file_format.downcase
       end
     end.uniq
   end
@@ -257,9 +257,9 @@ class MediaObject < ActiveFedora::Base
   end
 
   def all_comments
-    comment.sort + sections.compact.collect do |mf|
-      mf.comment.reject(&:blank?).collect do |c|
-        mf.display_title.present? ? "[#{mf.display_title}] #{c}" : c
+    comment.sort + sections.compact.collect do |section|
+      section.comment.reject(&:blank?).collect do |c|
+        section.display_title.present? ? "[#{section.display_title}] #{c}" : c
       end.sort
     end.flatten.uniq
   end
@@ -400,7 +400,7 @@ class MediaObject < ActiveFedora::Base
     media_objects.dup.each do |mo|
       begin
         # TODO: mass assignment may speed things up
-        mo.sections.each { |mf| mf.media_object = self }
+        mo.sections.each { |section| section.media_object = self }
         mo.reload.destroy!
 
         mergeds << mo

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -48,8 +48,8 @@ class MediaObject < ActiveFedora::Base
   # Have to handle create specially otherwise will attempt to associate prior to having an id
   around_create do |_, block|
     block.call
-    self.master_files = self.sections unless self.master_file_ids.sort == self.section_ids.sort
-    self.save!(validate: false)
+    # Saving again will force running through the before_save callback that should do the actual work
+    self.save!(validate: false) unless self.master_file_ids.sort == self.section_ids.sort
   end
   before_save do
     self.master_files = self.sections unless self.new_record? || self.master_file_ids.sort == self.section_ids.sort

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -117,13 +117,21 @@ class MediaObject < ActiveFedora::Base
     index.as :stored_sortable
   end
 
-  property :master_file_list, predicate: Avalon::RDFVocab::MediaObject.section_list, multiple: false do |index|
+  property :section_list, predicate: Avalon::RDFVocab::MediaObject.section_list, multiple: false do |index|
     index.as :symbol
   end
 
+  def section_ids
+    return [] if self.section_list.nil?
+    JSON.parse(self.section_list)
+  end
+
+  def section_ids= ids
+    self.section_list = ids.to_json
+  end
+
   def master_file_ids
-    return [] if self.master_file_list.nil?
-    JSON.parse(self.master_file_list)
+    self.section_ids
   end
 
   def ordered_master_file_ids
@@ -131,7 +139,7 @@ class MediaObject < ActiveFedora::Base
   end
 
   def master_file_ids= ids
-    self.master_file_list = ids.to_json
+    self.section_ids = ids
   end
 
   def ordered_master_file_ids= ids

--- a/app/models/structure_step.rb
+++ b/app/models/structure_step.rb
@@ -20,12 +20,7 @@
     def execute context
       media_object = context[:media_object]
       if ! context[:master_file_ids].nil?
-        # gather the parts in the right order
-        # in this situation we cannot use MatterFile.find([]) because
-        # it will not return the results in the correct order
-        master_files = context[:master_file_ids].map{ |master_file_id| MasterFile.find(master_file_id) }
-        # re-add the parts that are now in the right order
-        media_object.ordered_master_files = master_files
+        media_object.section_ids = context[:master_file_ids]
         media_object.save
       end
       context

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -40,8 +40,7 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
                  structuralMetadata.section_title
                elsif title.present?
                  title
-               # FIXME: The test for media_object.master_file_ids.size is expensive and takes ~0.25 seconds
-               elsif file_location.present? && (media_object.master_file_ids.size > 1)
+               elsif file_location.present? && (media_object.section_ids.size > 1)
                  file_location.split("/").last
                end
     mf_title.blank? ? nil : mf_title

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -27,6 +27,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     end
     # Handle this case here until a better fix can be found for multiple solr fields which don't have a model property
     @attrs[:section_id] = solr_document["section_id_ssim"]
+    @attrs[:section_ids] = solr_document["section_id_ssim"]
     @attrs[:hidden?] = solr_document["hidden_bsi"]
     @attrs[:read_groups] = solr_document["read_access_group_ssim"] || []
     @attrs[:edit_groups] = solr_document["edit_access_group_ssim"] || []
@@ -81,15 +82,14 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
 
   def master_file_ids
     if real?
-      real_object.master_file_ids
-    elsif section_id.nil? # No master files or not indexed yet
+      real_object.section_ids
+    elsif section_ids.nil? # No master files or not indexed yet
       ActiveFedora::Base.logger.warn("Reifying MediaObject because master_files not indexed")
-      real_object.master_file_ids
+      real_object.section_ids
     else
-      section_id
+      section_ids
     end
   end
-  alias_method :ordered_master_file_ids, :master_file_ids
 
   def master_files
     # NOTE: Defaults are set on returned SpeedyAF::Base objects if field isn't present in the solr doc.
@@ -100,7 +100,6 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
                                                         order: -> { master_file_ids },
                                                         load_reflections: true)
   end
-  alias_method :ordered_master_files, :master_files
 
   def collection
     @collection ||= SpeedyAF::Proxy::Admin::Collection.find(collection_id)

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -80,27 +80,6 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     end
   end
 
-  def master_file_ids
-    if real?
-      real_object.section_ids
-    elsif section_ids.nil? # No master files or not indexed yet
-      ActiveFedora::Base.logger.warn("Reifying MediaObject because sections not indexed")
-      real_object.section_ids
-    else
-      section_ids
-    end
-  end
-
-  def master_files
-    # NOTE: Defaults are set on returned SpeedyAF::Base objects if field isn't present in the solr doc.
-    # This is important otherwise speedy_af will reify from fedora when trying to access this field.
-    # When adding a new property to the master file model that will be used in the interface,
-    # add it to the default below to avoid reifying for master files lacking a value for the property.
-    @master_files ||= SpeedyAF::Proxy::MasterFile.where("isPartOf_ssim:#{id}",
-                                                        order: -> { master_file_ids },
-                                                        load_reflections: true)
-  end
-
   def sections
     return [] unless section_ids.present?
     query = "id:" + section_ids.join(" id:")

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -81,15 +81,14 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
 
   def master_file_ids
     if real?
-      real_object.indexed_master_file_ids
+      real_object.master_file_ids
     elsif section_id.nil? # No master files or not indexed yet
       ActiveFedora::Base.logger.warn("Reifying MediaObject because master_files not indexed")
-      real_object.indexed_master_file_ids
+      real_object.master_file_ids
     else
       section_id
     end
   end
-  alias_method :indexed_master_file_ids, :master_file_ids
   alias_method :ordered_master_file_ids, :master_file_ids
 
   def master_files
@@ -101,7 +100,6 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
                                                         order: -> { master_file_ids },
                                                         load_reflections: true)
   end
-  alias_method :indexed_master_files, :master_files
   alias_method :ordered_master_files, :master_files
 
   def collection

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -84,7 +84,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     if real?
       real_object.section_ids
     elsif section_ids.nil? # No master files or not indexed yet
-      ActiveFedora::Base.logger.warn("Reifying MediaObject because master_files not indexed")
+      ActiveFedora::Base.logger.warn("Reifying MediaObject because sections not indexed")
       real_object.section_ids
     else
       section_ids
@@ -104,9 +104,9 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
   def sections
     return [] unless section_ids.present?
     query = "id:" + section_ids.join(" id:")
-    @master_files ||= SpeedyAF::Proxy::MasterFile.where(query,
-                                                        order: -> { section_ids },
-                                                        load_reflections: true)
+    @sections ||= SpeedyAF::Proxy::MasterFile.where(query,
+                                                    order: -> { section_ids },
+                                                    load_reflections: true)
   end
 
   def collection
@@ -119,7 +119,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
 
   def format
     # TODO figure out how to memoize this
-    mime_types = master_files.reject { |mf| mf.file_location.blank? }.collect do |mf|
+    mime_types = sections.reject { |mf| mf.file_location.blank? }.collect do |mf|
       Rack::Mime.mime_type(File.extname(mf.file_location))
     end.uniq
     mime_types.empty? ? nil : mime_types
@@ -154,7 +154,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
   end
 
   def sections_with_files(tag: '*')
-    master_files.select { |master_file| master_file.supplemental_files(tag: tag).present? }.map(&:id)
+    sections.select { |master_file| master_file.supplemental_files(tag: tag).present? }.map(&:id)
   end
 
   def permalink_with_query(query_vars = {})

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -101,6 +101,14 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
                                                         load_reflections: true)
   end
 
+  def sections
+    return [] unless section_ids.present?
+    query = "id:" + section_ids.join(" id:")
+    @master_files ||= SpeedyAF::Proxy::MasterFile.where(query,
+                                                        order: -> { section_ids },
+                                                        load_reflections: true)
+  end
+
   def collection
     @collection ||= SpeedyAF::Proxy::Admin::Collection.find(collection_id)
   end

--- a/app/views/ingest_batch_mailer/status_email.html.erb
+++ b/app/views/ingest_batch_mailer/status_email.html.erb
@@ -20,8 +20,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <h4>
       <%= media_object.title %>
     </h4>
-    <% master_files = media_object.master_files.to_a %>
-    <% if master_files.count > 0 %>
+    <% sections = media_object.sections %>
+    <% if sections.count > 0 %>
       <table class="master-files table table-striped">
         <thead>
           <th>Name</th>
@@ -29,7 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <th>Status</th>
         </thead>
         <tbody>
-          <% master_files.each do |master_file| %>
+          <% sections.each do |master_file| %>
             <% status_code = master_file.status_code.downcase %>
             <tr>
               <td class="master-file">

--- a/app/views/media_objects/_embed_checkout.html.erb
+++ b/app/views/media_objects/_embed_checkout.html.erb
@@ -14,7 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if !@masterFiles.blank? %>
-  <% master_file = @media_object.master_files.first %>
+  <% master_file = @media_object.sections.first %>
   <div class="checkout <%= master_file.is_video? ? 'video' : 'audio' %> mb-3" style="height: <%= master_file.is_video? ? 400 : 120 %>px">
     <div class="centered <%= 'video' if master_file.is_video? %>">
       <% if !current_user %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -62,7 +62,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     // display the video player
     $(document).ready(function () {
       const mediaObjectId = <%= @media_object.id.to_json.html_safe %>;
-      const sectionIds = <%= @media_object.ordered_master_file_ids.to_json.html_safe %>;
+      const sectionIds = <%= @media_object.section_ids.to_json.html_safe %>;
       const transcriptSections = <%= @media_object.sections_with_files(tag: 'transcript').to_json.html_safe %>;
 
       // Enable action buttons after derivative is loaded

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -42,8 +42,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= react_component("MediaObjectRamp",
       {
         urls: { base_url: request.protocol + request.host_with_port, fullpath_url: request.fullpath },
-        master_files_count: @media_object.master_files.size,
-        has_structure: @media_object.master_files.any?{ |mf| mf.has_structuralMetadata? },
+        sections_count: @media_object.sections.size,
+        has_structure: @media_object.sections.any?{ |mf| mf.has_structuralMetadata? },
         title: { content: render('title') },
         share: { canShare: (will_partial_list_render? :share), content: lending_enabled?(@media_object) ? (render('share') if can_stream) : render('share') },
         timeline: { canCreate: (current_ability.can? :create, Timeline), content: lending_enabled?(@media_object) ? (render('timeline') if can_stream) : render('timeline') },

--- a/app/views/media_objects/tree.html.erb
+++ b/app/views/media_objects/tree.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <ul>
   <li><%=@media_object.title%> (<%=@media_object.id%>)
     <ul>
-      <% @media_object.ordered_master_files.to_a.each do |mf| %>
+      <% @media_object.sections.each do |mf| %>
         <li><%=stream_label_for(mf)%> (<%=mf.id%>)
           <ul>
             <% mf.derivatives.each do |d| %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -190,7 +190,7 @@ describe CatalogController do
       before(:each) do
         @media_object = FactoryBot.create(:fully_searchable_media_object)
         @master_file = FactoryBot.create(:master_file, :with_structure, media_object: @media_object, title: 'Test Label')
-        @media_object.ordered_master_files += [@master_file]
+        @media_object.sections += [@master_file]
         @media_object.save!
         # Explicitly run indexing job to ensure fields are indexed for structure searching
         MediaObjectIndexingJob.perform_now(@media_object.id)

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -685,17 +685,15 @@ describe MasterFilesController do
         login_as :administrator
       end
       it 'moves the master file' do
-        expect(current_media_object.master_file_ids).to include master_file.id
         expect(current_media_object.section_ids).to include master_file.id
-        expect(target_media_object.master_file_ids).not_to include master_file.id
         expect(target_media_object.section_ids).not_to include master_file.id
         post('move', params: { id: master_file.id, target: target_media_object.id })
+        current_media_object.reload
+        target_media_object.reload
         expect(response).to redirect_to(edit_media_object_path(current_media_object))
         expect(flash[:success]).not_to be_blank
         expect(master_file.reload.media_object_id).to eq target_media_object.id
-        expect(current_media_object.reload.master_file_ids).not_to include master_file.id
         expect(current_media_object.section_ids).not_to include master_file.id
-        expect(target_media_object.reload.master_file_ids).to include master_file.id
         expect(target_media_object.section_ids).to include master_file.id
       end
     end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -100,7 +100,7 @@ describe MasterFilesController do
         file = fixture_file_upload('/videoshort.mp4', 'video/mp4')
         post :create, params: { Filedata: [file], original: 'any', container_id: media_object.id }
 
-        master_file = media_object.reload.ordered_master_files.to_a.first
+        master_file = media_object.reload.sections.first
         expect(master_file.file_format).to eq "Moving image"
 
         expect(flash[:error]).to be_nil
@@ -110,7 +110,7 @@ describe MasterFilesController do
         file = fixture_file_upload('/jazz-performance.mp3', 'audio/mp3')
         post :create, params: { Filedata: [file], original: 'any', container_id: media_object.id }
 
-        master_file = media_object.reload.ordered_master_files.to_a.first
+        master_file = media_object.reload.sections.first
         expect(master_file.file_format).to eq "Sound"
       end
 
@@ -147,7 +147,7 @@ describe MasterFilesController do
         post :create, params: { Filedata: [file], original: 'any', container_id: media_object.id }
 
         master_file = MasterFile.all.last
-        expect(media_object.reload.ordered_master_files.to_a).to include master_file
+        expect(media_object.reload.sections).to include master_file
         expect(master_file.media_object.id).to eq(media_object.id)
 
         expect(flash[:error]).to be_nil
@@ -159,7 +159,7 @@ describe MasterFilesController do
 
         master_file = MasterFile.all.last
         media_object.reload
-        expect(media_object.ordered_master_files.to_a).to include master_file
+        expect(media_object.sections).to include master_file
         expect(master_file.media_object.id).to eq(media_object.id)
 
         expect(flash[:error]).to be_nil
@@ -171,7 +171,7 @@ describe MasterFilesController do
 
         master_file = MasterFile.all.last
         media_object.reload
-        expect(media_object.ordered_master_files.to_a).to include master_file
+        expect(media_object.sections).to include master_file
         expect(master_file.media_object.id).to eq(media_object.id)
 
         expect(flash[:error]).to be_nil
@@ -189,7 +189,7 @@ describe MasterFilesController do
         post :create, params: { Filedata: [file], original: 'any', container_id: media_object.id }
 
         master_file = MasterFile.all.last
-        expect(media_object.reload.ordered_master_files.to_a).to include master_file
+        expect(media_object.reload.sections).to include master_file
         expect(master_file.media_object.id).to eq(media_object.id)
 
         expect(flash[:error]).to be_nil
@@ -206,14 +206,14 @@ describe MasterFilesController do
       login_as :administrator
       expect(controller.current_ability.can?(:destroy, master_file)).to be_truthy
       expect { post :destroy, params: { id: master_file.id } }.to change { MasterFile.count }.by(-1)
-      expect(master_file.media_object.reload.ordered_master_files.to_a).not_to include master_file
+      expect(master_file.media_object.reload.sections).not_to include master_file
     end
 
     it "deletes a master file as manager of owning collection" do
       login_user master_file.media_object.collection.managers.first
       expect(controller.current_ability.can?(:destroy, master_file)).to be_truthy
       expect { post(:destroy, params: { id: master_file.id }) }.to change { MasterFile.count }.by(-1)
-      expect(master_file.media_object.reload.ordered_master_files.to_a).not_to include master_file
+      expect(master_file.media_object.reload.sections).not_to include master_file
     end
 
     it "redirect to restricted content page for end users" do
@@ -686,17 +686,17 @@ describe MasterFilesController do
       end
       it 'moves the master file' do
         expect(current_media_object.master_file_ids).to include master_file.id
-        expect(current_media_object.ordered_master_file_ids).to include master_file.id
+        expect(current_media_object.section_ids).to include master_file.id
         expect(target_media_object.master_file_ids).not_to include master_file.id
-        expect(target_media_object.ordered_master_file_ids).not_to include master_file.id
+        expect(target_media_object.section_ids).not_to include master_file.id
         post('move', params: { id: master_file.id, target: target_media_object.id })
         expect(response).to redirect_to(edit_media_object_path(current_media_object))
         expect(flash[:success]).not_to be_blank
         expect(master_file.reload.media_object_id).to eq target_media_object.id
         expect(current_media_object.reload.master_file_ids).not_to include master_file.id
-        expect(current_media_object.ordered_master_file_ids).not_to include master_file.id
+        expect(current_media_object.section_ids).not_to include master_file.id
         expect(target_media_object.reload.master_file_ids).to include master_file.id
-        expect(target_media_object.ordered_master_file_ids).to include master_file.id
+        expect(target_media_object.section_ids).to include master_file.id
       end
     end
   end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1199,7 +1199,19 @@ describe MediaObjectsController, type: :controller do
         expect(json['published_by']).to eq(media_object.avalon_publisher)
         expect(json['published']).to eq(media_object.published?)
         expect(json['summary']).to eq(media_object.abstract)
-        expect(json['fields'].symbolize_keys).to eq(media_object.to_ingest_api_hash(false)[:fields])
+
+        # FIXME: https://github.com/avalonmediasystem/avalon/issues/5834
+        ingest_api_hash = media_object.to_ingest_api_hash(false)
+        json['fields'].each do |k,v|
+          if k == "avalon_resource_type"
+            expect(v.map(&:downcase)).to eq(ingest_api_hash[:fields][k.to_sym])
+          elsif k == "record_identifier"
+            # no-op since not indexed
+          else
+            expect(v).to eq(ingest_api_hash[:fields][k.to_sym])
+          end
+        end
+
         # Symbolize keys for master files and derivatives
         json['files'].each do |mf|
           mf.symbolize_keys!

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
         rights_statement { ['http://rightsstatements.org/vocab/InC-EDU/1.0/'] }
         terms_of_use { [ 'Terms of Use: Be kind. Rewind.' ] }
         series { [Faker::Lorem.word] }
-        master_files { [] }
+        sections { [] }
         # after(:create) do |mo|
         #   mo.update_datastream(:descMetadata, {
         #     note: {note[Faker::Lorem.paragraph],

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -66,9 +66,7 @@ FactoryBot.define do
       after(:create) do |mo|
         mf = FactoryBot.create(:master_file)
         mf.media_object = mo
-        mf.save
-        # mo.sections += [mf]
-        mo.save
+        # Above line will cause a save of both the master file and parent media object
       end
     end
     trait :with_completed_workflow do

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -49,6 +49,7 @@ FactoryBot.define do
         rights_statement { ['http://rightsstatements.org/vocab/InC-EDU/1.0/'] }
         terms_of_use { [ 'Terms of Use: Be kind. Rewind.' ] }
         series { [Faker::Lorem.word] }
+        master_files { [] }
         # after(:create) do |mo|
         #   mo.update_datastream(:descMetadata, {
         #     note: {note[Faker::Lorem.paragraph],

--- a/spec/factories/media_objects.rb
+++ b/spec/factories/media_objects.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
         mf = FactoryBot.create(:master_file)
         mf.media_object = mo
         mf.save
-        # mo.ordered_master_files += [mf]
+        # mo.sections += [mf]
         mo.save
       end
     end

--- a/spec/features/login_redirect_spec.rb
+++ b/spec/features/login_redirect_spec.rb
@@ -18,8 +18,8 @@ describe 'Login Redirects' do
   let(:user) { FactoryBot.create(:user, :with_identity) }
 
   describe '/media_objects/:id' do
-    let(:media_object) { FactoryBot.create(:fully_searchable_media_object, master_files: [master_file]) }
-    let(:master_file) { FactoryBot.create(:master_file, :with_derivative) }
+    let(:media_object) { FactoryBot.create(:fully_searchable_media_object) }
+    let!(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
 
     it 'redirects to item page' do
       visit media_object_path(media_object)

--- a/spec/features/login_redirect_spec.rb
+++ b/spec/features/login_redirect_spec.rb
@@ -23,7 +23,7 @@ describe 'Login Redirects' do
 
     it 'redirects to item page' do
       visit media_object_path(media_object)
-      visit hls_manifest_master_file_path(media_object.master_files.first, "high")
+      visit hls_manifest_master_file_path(media_object.sections.first, "high")
       sign_in user
       expect(page.current_path).to eq media_object_path(media_object)
     end

--- a/spec/helpers/media_objects_helper_spec.rb
+++ b/spec/helpers/media_objects_helper_spec.rb
@@ -62,17 +62,17 @@ describe MediaObjectsHelper do
 
   describe '#gather_all_comments' do
     let(:media_object) { instance_double("MediaObject", comment: ['MO Comment']) }
-    let(:master_files) { [instance_double("MasterFile", comment: [])] }
+    let(:sections) { [instance_double("MasterFile", comment: [])] }
 
     it 'returns a list of unique comment strings' do
-      expect(helper.gather_all_comments(media_object, master_files)).to eq ["MO Comment"]
+      expect(helper.gather_all_comments(media_object, sections)).to eq ["MO Comment"]
     end
 
     context 'with a master file comment' do
-      let(:master_files) { [instance_double("MasterFile", comment: ["MF Comment"], display_title: "MF1")] }
+      let(:sections) { [instance_double("MasterFile", comment: ["MF Comment"], display_title: "MF1")] }
 
       it 'returns a list of unique comment strings' do
-        expect(helper.gather_all_comments(media_object, master_files)).to eq ["MO Comment", "[MF1] MF Comment"]
+        expect(helper.gather_all_comments(media_object, sections)).to eq ["MO Comment", "[MF1] MF Comment"]
       end
     end
   end

--- a/spec/jobs/media_object_indexing_job_spec.rb
+++ b/spec/jobs/media_object_indexing_job_spec.rb
@@ -18,15 +18,16 @@ describe MediaObjectIndexingJob do
   let(:job) { MediaObjectIndexingJob.new }
 
   describe "perform" do
+    let(:comment) { "A comment" }
     let!(:media_object) { FactoryBot.create(:media_object) }
-    let!(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
+    let!(:master_file) { FactoryBot.create(:master_file, media_object: media_object, comment: [comment]) }
 
     it 'indexes the media object including master_file fields' do
       before_doc = ActiveFedora::SolrService.query("id:#{media_object.id}").first
-      expect(before_doc["section_id_ssim"]).to be_blank
+      expect(before_doc["all_comments_ssim"]).to be_blank
       job.perform(media_object.id)
       after_doc = ActiveFedora::SolrService.query("id:#{media_object.id}").first
-      expect(after_doc["section_id_ssim"]).to eq [master_file.id]
+      expect(after_doc["all_comments_ssim"]).to eq [comment]
     end
   end
 end

--- a/spec/lib/avalon/batch/entry_spec.rb
+++ b/spec/lib/avalon/batch/entry_spec.rb
@@ -164,7 +164,7 @@ describe Avalon::Batch::Entry do
 
   describe '#process!' do
     let(:entry_files) { [{ file: File.join(testdir, filename), offset: '00:00:00.500', label: 'Quis quo', date_digitized: '2015-10-30', skip_transcoding: false }] }
-    let(:master_file) { entry.media_object.master_files.first }
+    let(:master_file) { entry.media_object.sections.first }
     before do
       entry.process!
     end

--- a/spec/lib/avalon/intercom_spec.rb
+++ b/spec/lib/avalon/intercom_spec.rb
@@ -86,7 +86,7 @@ describe Avalon::Intercom do
       expect(response).to eq({ message: 'StandardError', status: 500 })
     end
     it "should respond with a link to the pushed object on target" do
-      media_object.ordered_master_files=[master_file_with_structure]
+      media_object.sections=[master_file_with_structure]
       media_object_hash = media_object.to_ingest_api_hash(false)
       media_object_hash.merge!(
         { 'collection_id' => 'cupcake_collection', 'import_bib_record' => true, 'publish' => false }

--- a/spec/models/batch_entries_spec.rb
+++ b/spec/models/batch_entries_spec.rb
@@ -106,7 +106,7 @@ describe BatchEntries do
       media_object = FactoryBot.create(:media_object)
       batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
-      expect(media_object.master_files.to_a.count).to eq(0)
+      expect(media_object.sections.count).to eq(0)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
 
       expect(batch_entry.encoding_finished?).to be_truthy
@@ -119,7 +119,7 @@ describe BatchEntries do
       media_object = master_file.media_object
       batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
-      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(media_object.sections.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
 
       expect(batch_entry.encoding_finished?).to be_truthy
@@ -132,7 +132,7 @@ describe BatchEntries do
       media_object = master_file.media_object
       batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
-      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(media_object.sections.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
 
       expect(batch_entry.encoding_finished?).to be_truthy
@@ -145,7 +145,7 @@ describe BatchEntries do
       media_object = master_file.media_object
       batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
-      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(media_object.sections.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
 
       expect(batch_entry.encoding_finished?).to be_truthy
@@ -158,7 +158,7 @@ describe BatchEntries do
       media_object = master_file.media_object
       batch_entry = FactoryBot.build(:batch_entries, media_object_pid: media_object.id)
 
-      expect(media_object.master_files.to_a.count).to eq(1)
+      expect(media_object.sections.count).to eq(1)
       expect(JSON.parse(batch_entry.payload)['files'].count).to eq(1)
 
       expect(batch_entry.encoding_finished?).to be_falsey

--- a/spec/models/file_upload_step_spec.rb
+++ b/spec/models/file_upload_step_spec.rb
@@ -16,8 +16,8 @@ require 'rails_helper'
 
 describe FileUploadStep do
   describe '#update_master_files' do
-    let!(:master_file) {FactoryBot.create(:master_file, title: 'foo')}
-    let!(:media_object) {FactoryBot.create(:media_object, master_files: [master_file])}
+    let(:master_file) {FactoryBot.create(:master_file, title: 'foo')}
+    let(:media_object) {FactoryBot.create(:media_object, sections: [master_file])}
     it 'should not regenerate a section permalink when the title is changed' do
       step_context = {media_object: media_object, master_files: {master_file.id => {title: 'new title'}}}
       expect{FileUploadStep.new.update_master_files(step_context)}.to_not change{master_file.permalink}

--- a/spec/models/ingest_batch_spec.rb
+++ b/spec/models/ingest_batch_spec.rb
@@ -23,7 +23,7 @@ describe IngestBatch do
   end
   describe '#finished?' do
     it 'returns true when all the master files are finished' do
-      media_object = FactoryBot.create(:media_object, master_files: [FactoryBot.create(:master_file, :cancelled_processing), FactoryBot.create(:master_file, :completed_processing)])
+      media_object = FactoryBot.create(:media_object, sections: [FactoryBot.create(:master_file, :cancelled_processing), FactoryBot.create(:master_file, :completed_processing)])
       ingest_batch = IngestBatch.new(media_object_ids: [media_object.id], email: 'email@something.com')
       expect(ingest_batch.finished?).to be true
     end

--- a/spec/models/ingest_batch_spec.rb
+++ b/spec/models/ingest_batch_spec.rb
@@ -22,22 +22,16 @@ describe IngestBatch do
     expect(ingest_batch.media_object_ids).to eq(media_object_ids)
   end
   describe '#finished?' do
-    it 'returns true when all the master files are finished' do
+    it 'returns true when all the sections are finished' do
       media_object = FactoryBot.create(:media_object, sections: [FactoryBot.create(:master_file, :cancelled_processing), FactoryBot.create(:master_file, :completed_processing)])
       ingest_batch = IngestBatch.new(media_object_ids: [media_object.id], email: 'email@something.com')
       expect(ingest_batch.finished?).to be true
     end
 
-    # fix: adding master_files to media object parts is broken
-    it 'returns false when one or more master files are not finished' do
-       skip "Fix problems with this test"
-
-       media_object = MediaObject.new(id:'avalon:ingest-batch-test')
-       media_object.add_relationship(:has_part, FactoryBot.build(:master_file, :completed_processing))
-       media_object.parts << FactoryBot.build(:master_file)
-       media_object.save
-       ingest_batch = IngestBatch.new(media_object_ids: ['avalon:ingest-batch-test'], email: 'email@something.com')
-       expect(ingest_batch.finished?).to be true
+    it 'returns false when one or more sections are not finished' do
+       media_object = FactoryBot.create(:media_object, sections: [FactoryBot.create(:master_file), FactoryBot.create(:master_file)])
+       ingest_batch = IngestBatch.new(media_object_ids: [media_object.id], email: 'email@something.com')
+       expect(ingest_batch.finished?).to be false
     end
   end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -513,7 +513,7 @@ describe MasterFile do
 
       it 'should have an appropriate title for the embed code with no label (more than 1 section)' do
         allow(subject.media_object).to receive(:sections).and_return([subject,subject])
-        allow(subject.media_object).to receive(:master_file_ids).and_return([subject.id,subject.id])
+        allow(subject.media_object).to receive(:section_ids).and_return([subject.id,subject.id])
         expect( subject.embed_title ).to eq( 'test - video.mp4' )
       end
 
@@ -801,10 +801,12 @@ describe MasterFile do
 
     it 'sets a new media object as its parent' do
       master_file.media_object = media_object2
-      expect(media_object1.reload.master_file_ids).not_to include master_file.id
-      expect(media_object1.reload.section_ids).not_to include master_file.id
-      expect(media_object2.reload.master_file_ids).to include master_file.id
-      expect(media_object2.reload.section_ids).to include master_file.id
+      media_object1.reload
+      media_object2.reload
+      expect(media_object1.master_file_ids).not_to include master_file.id
+      expect(media_object1.section_ids).not_to include master_file.id
+      expect(media_object2.master_file_ids).to include master_file.id
+      expect(media_object2.section_ids).to include master_file.id
     end
   end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -759,9 +759,13 @@ describe MasterFile do
     let(:master_file) { FactoryBot.build(:master_file) }
     before do
       allow(ActiveEncode::Base).to receive(:find).and_return(nil)
+      allow(master_file).to receive(:finished_processing?).and_return(false)
     end
     it 'does not error if the master file has no encode' do
-      expect { master_file.send(:stop_processing!) }.not_to raise_error
+      expect { master_file.stop_processing! }.not_to raise_error
+    end
+    it 'enqueues cancel job if currently processing' do
+      expect { master_file.stop_processing! }.to have_enqueued_job(ActiveEncodeJobs::CancelEncodeJob)
     end
   end
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -84,7 +84,7 @@ describe MasterFile do
     end
   end
 
-  describe "master_files=" do
+  describe "derivatives=" do
     let(:derivative) {Derivative.create}
     let(:master_file) {FactoryBot.create(:master_file)}
     it "should set hasDerivation relationships on self" do

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -329,14 +329,9 @@ describe MasterFile do
       let(:media_path) { File.expand_path("../../master_files-#{SecureRandom.uuid}",__FILE__)}
       let(:dropbox_path) { File.expand_path("../../collection-#{SecureRandom.uuid}",__FILE__)}
       let(:upload)     { ActionDispatch::Http::UploadedFile.new :tempfile => tempfile, :filename => original, :type => 'video/mp4' }
-      let(:media_object) { MediaObject.new }
+      let!(:media_object) { FactoryBot.create(:media_object, sections: [subject]) }
       let(:collection) { Admin::Collection.new }
-      subject {
-        mf = MasterFile.new
-        mf.media_object = media_object
-        mf.setContent(upload, dropbox_dir: collection.dropbox_absolute_path)
-        mf
-      }
+      subject { FactoryBot.create(:master_file) }
 
       before(:each) do
         @old_media_path = Settings.encoding.working_file_path
@@ -356,11 +351,13 @@ describe MasterFile do
 
       it "should move an uploaded file into the root of the collection's dropbox" do
         Settings.encoding.working_file_path = nil
+        subject.setContent(upload, dropbox_dir: collection.dropbox_absolute_path)
         expect(subject.file_location).to eq(File.realpath(File.join(collection.dropbox_absolute_path,original)))
       end
 
       it "should copy an uploaded file to the media path" do
         Settings.encoding.working_file_path = media_path
+        subject.setContent(upload, dropbox_dir: collection.dropbox_absolute_path)
         expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
       end
 
@@ -373,6 +370,7 @@ describe MasterFile do
 
         it "appends a numerical suffix" do
           Settings.encoding.working_file_path = nil
+          subject.setContent(upload, dropbox_dir: collection.dropbox_absolute_path)
           expect(subject.file_location).to eq(File.realpath(File.join(collection.dropbox_absolute_path,duplicate)))
         end
       end
@@ -384,14 +382,9 @@ describe MasterFile do
       let(:dropbox_file_path) { File.join(dropbox_path, 'nested-dir', original)}
       let(:media_path) { File.expand_path("../../master_files-#{SecureRandom.uuid}",__FILE__)}
       let(:dropbox_path) { File.expand_path("../../collection-#{SecureRandom.uuid}",__FILE__)}
-      let(:media_object) { MediaObject.new }
+      let!(:media_object) { FactoryBot.create(:media_object, sections: [subject]) }
       let(:collection) { Admin::Collection.new }
-      subject {
-        mf = MasterFile.new
-        mf.media_object = media_object
-        mf.setContent(File.new(dropbox_file_path), dropbox_dir: collection.dropbox_absolute_path)
-        mf
-      }
+      subject { FactoryBot.create(:master_file) }
 
       before(:each) do
         @old_media_path = Settings.encoding.working_file_path
@@ -412,6 +405,7 @@ describe MasterFile do
 
       it "should not move a file in a subdirectory of the collection's dropbox" do
         Settings.encoding.working_file_path = nil
+        subject.setContent(File.new(dropbox_file_path), dropbox_dir: collection.dropbox_absolute_path)
         expect(subject.file_location).to eq dropbox_file_path
         expect(File.exist?(dropbox_file_path)).to eq true
         expect(File.exist?(File.join(collection.dropbox_absolute_path,original))).to eq false
@@ -419,6 +413,7 @@ describe MasterFile do
 
       it "should copy an uploaded file to the media path" do
         Settings.encoding.working_file_path = media_path
+        subject.setContent(File.new(dropbox_file_path), dropbox_dir: collection.dropbox_absolute_path)
         expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
       end
     end
@@ -429,7 +424,7 @@ describe MasterFile do
       let(:file_size) { 12345 }
       let(:auth_header) { {"Authorization"=>"Bearer ya29.a0AfH6SMC6vSj4D6po1aDxAr6JmY92azh3lxevSuPKxf9QPPSKmMzqbZvI7B3oIACqqMVono1P0XD2F1Jl_rkayoI6JGz-P2cpg44-55oJFcWychAvUliWeRKf1cifMo9JF10YmXxhIfrG5mu7Ahy9FZpudN92p2JhvTI"} }
 
-      subject { MasterFile.new }
+      subject { FactoryBot.create(:master_file) }
 
       it "should set the right properties" do
         allow(subject).to receive(:reloadTechnicalMetadata!).and_return(nil)

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -517,7 +517,7 @@ describe MasterFile do
       end
 
       it 'should have an appropriate title for the embed code with no label (more than 1 section)' do
-        allow(subject.media_object).to receive(:ordered_master_files).and_return([subject,subject])
+        allow(subject.media_object).to receive(:sections).and_return([subject,subject])
         allow(subject.media_object).to receive(:master_file_ids).and_return([subject.id,subject.id])
         expect( subject.embed_title ).to eq( 'test - video.mp4' )
       end
@@ -803,9 +803,9 @@ describe MasterFile do
     it 'sets a new media object as its parent' do
       master_file.media_object = media_object2
       expect(media_object1.reload.master_file_ids).not_to include master_file.id
-      expect(media_object1.reload.ordered_master_file_ids).not_to include master_file.id
+      expect(media_object1.reload.section_ids).not_to include master_file.id
       expect(media_object2.reload.master_file_ids).to include master_file.id
-      expect(media_object2.reload.ordered_master_file_ids).to include master_file.id
+      expect(media_object2.reload.section_ids).to include master_file.id
     end
   end
 

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -475,6 +475,7 @@ describe MediaObject do
 
     before do
       master_files
+      media_object.reload
       # Explicitly run indexing job to ensure fields are indexed for structure searching
       MediaObjectIndexingJob.perform_now(media_object.id)
     end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1252,23 +1252,25 @@ describe MediaObject do
       end
 
       it 'reads from ordered_aggregation' do
+        expect(media_object.ordered_master_files.to_a).to eq [section, section2]
         expect(media_object.section_list).to eq nil
         mo = MediaObject.find(media_object.id)
         expect(mo.section_list).not_to eq nil
         expect(mo.ordered_master_files.to_a).to eq [section, section2]
-        expect(mo.ordered_master_file_ids).to eq [section.id, section2.id]
-        expect(mo.sections).to eq [section, section2]
-        expect(mo.section_ids).to eq [section.id, section2.id]
+        expect(mo.sections).to eq mo.ordered_master_files.to_a
+        expect(mo.section_ids).to eq mo.ordered_master_file_ids
       end
 
-      it 'migrates to section_list without interaction' do
+      it 'prefers reading from section_list when set' do
         expect(media_object.section_list).to eq nil
         mo = MediaObject.find(media_object.id)
+        new_section = FactoryBot.create(:master_file)
+        mo.sections += [new_section]
         mo.save
         mo = MediaObject.find(media_object.id)
         expect(mo.section_list).not_to eq nil
-        expect(mo.sections).to eq [section, section2]
-        expect(mo.section_ids).to eq [section.id, section2.id]
+        expect(mo.sections).not_to eq mo.ordered_master_files.to_a
+        expect(mo.section_ids).to eq [section.id, section2.id, new_section.id]
       end
     end
   end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -456,13 +456,13 @@ describe MediaObject do
 
   describe '#finished_processing?' do
     it 'returns true if the statuses indicate processing is finished' do
-      media_object.ordered_master_files += [FactoryBot.create(:master_file, :cancelled_processing)]
-      media_object.ordered_master_files += [FactoryBot.create(:master_file, :completed_processing)]
+      media_object.sections += [FactoryBot.create(:master_file, :cancelled_processing)]
+      media_object.sections += [FactoryBot.create(:master_file, :completed_processing)]
       expect(media_object.finished_processing?).to be true
     end
     it 'returns true if the statuses indicate processing is not finished' do
-      media_object.ordered_master_files += [FactoryBot.create(:master_file, :cancelled_processing)]
-      media_object.ordered_master_files += [FactoryBot.create(:master_file)]
+      media_object.sections += [FactoryBot.create(:master_file, :cancelled_processing)]
+      media_object.sections += [FactoryBot.create(:master_file)]
       expect(media_object.finished_processing?).to be false
     end
   end
@@ -819,7 +819,7 @@ describe MediaObject do
       mf2 = FactoryBot.create(:master_file, title: 'Test Label2', physical_description: 'cave paintings', media_object: media_object)
       media_object.reload
 
-      #expect(media_object.ordered_master_files.size).to eq(2)
+      #expect(media_object.sections.size).to eq(2)
       expect(media_object.section_physical_descriptions).to match(['cave paintings'])
     end
   end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -855,10 +855,10 @@ describe MediaObject do
 
   describe 'descMetadata' do
     it 'sets original_name to default value' do
-      expect(media_object.descMetadata.original_name).to eq 'descMetadata.xml'
+      # requires a reload now?
+      expect(media_object.reload.descMetadata.original_name).to eq 'descMetadata.xml'
     end
     it 'is a valid MODS document' do
-      media_object = FactoryBot.create(:media_object, :with_master_file)
       xsd_path = File.join(Rails.root, 'spec', 'fixtures', 'mods-3-6.xsd')
       # Note: we instantiate Schema with a file handle so that relative paths
       # to included schema definitions can be resolved
@@ -1166,7 +1166,7 @@ describe MediaObject do
 
   describe "#has_captions" do
     let(:captionless_media_object) { FactoryBot.create(:media_object, :with_master_file) }
-    let(:captioned_media_object) { FactoryBot.create(:media_object, master_files: [master_file1, master_file2]) }
+    let(:captioned_media_object) { FactoryBot.create(:media_object, sections: [master_file1, master_file2]) }
     let(:master_file1) { FactoryBot.create(:master_file) }
     let(:master_file2) { FactoryBot.create(:master_file, :with_captions) }
     it "returns false when child master files contain no captions" do
@@ -1180,7 +1180,7 @@ describe MediaObject do
 
   describe "#has_transcripts" do
     let(:transcriptless_media_object) { FactoryBot.create(:media_object, :with_master_file) }
-    let(:transcript_media_object) { FactoryBot.create(:media_object, master_files: [master_file1, master_file2]) }
+    let(:transcript_media_object) { FactoryBot.create(:media_object, sections: [master_file1, master_file2]) }
     let(:master_file1) { FactoryBot.create(:master_file) }
     let(:master_file2) { FactoryBot.create(:master_file, supplemental_files: [transcript]) }
     let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_tag) }

--- a/spec/models/working_file_path_spec.rb
+++ b/spec/models/working_file_path_spec.rb
@@ -93,7 +93,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the working_file_path to active_encode' do
         MasterFileBuilder.build(media_object, params)
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         expect(File.exist? master_file.working_file_path.first).to be true
         input = FileLocator.new(master_file.working_file_path.first).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
@@ -104,7 +104,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the working_file_path to active_encode' do
           MasterFileBuilder.build(media_object, params)
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           expect(File.exist? master_file.working_file_path.first).to be true
           input_path = FileLocator.new(master_file.working_file_path.first).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through")
@@ -119,7 +119,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the working_file_path to active_encode' do
         MasterFileBuilder.build(media_object, params)
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         expect(File.exist? master_file.working_file_path.first).to be true
         input = FileLocator.new(master_file.working_file_path.first).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
@@ -130,7 +130,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the working_file_path to active_encode' do
           MasterFileBuilder.build(media_object, params)
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           expect(File.exist? master_file.working_file_path.first).to be true
           input_path = FileLocator.new(master_file.working_file_path.first).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through")
@@ -152,7 +152,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the working_file_path to active_encode' do
         entry.process!
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         expect(File.exist? master_file.working_file_path.first).to be true
         input = FileLocator.new(master_file.working_file_path.first).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
@@ -163,7 +163,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the working_file_path to active_encode' do
           entry.process!
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           expect(File.exist? master_file.working_file_path.first).to be true
           input_path = FileLocator.new(master_file.working_file_path.first).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through" )
@@ -191,7 +191,7 @@ describe "MasterFile#working_file_path" do
         # TODO: Ensure all working file copies are cleaned up by the background job
         it 'sends the working_file_path to active_encode' do
           entry.process!
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           working_file_path_high = master_file.working_file_path.find { |file| file.include? "high" }
           working_file_path_medium = master_file.working_file_path.find { |file| file.include? "medium" }
           working_file_path_low = master_file.working_file_path.find { |file| file.include? "low" }
@@ -224,7 +224,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the file_location to active_encode' do
         MasterFileBuilder.build(media_object, params)
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         input = FileLocator.new(master_file.file_location).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
       end
@@ -234,7 +234,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the file_location to active_encode' do
           MasterFileBuilder.build(media_object, params)
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           input_path = FileLocator.new(master_file.file_location).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through")
         end
@@ -248,7 +248,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the file_location to active_encode' do
         MasterFileBuilder.build(media_object, params)
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         input = FileLocator.new(master_file.file_location).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
       end
@@ -258,7 +258,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the file_location to active_encode' do
           MasterFileBuilder.build(media_object, params)
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           input_path = FileLocator.new(master_file.file_location).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through")
         end
@@ -279,7 +279,7 @@ describe "MasterFile#working_file_path" do
 
       it 'sends the file_location to active_encode' do
         entry.process!
-        master_file = media_object.reload.master_files.first
+        master_file = media_object.reload.sections.first
         input = FileLocator.new(master_file.file_location).uri.to_s
         expect(encoder_class).to have_received(:create).with(input, { headers: nil, master_file_id: master_file.id, preset: workflow })
       end
@@ -289,7 +289,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the file_location to active_encode' do
           entry.process!
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
           input_path = FileLocator.new(master_file.file_location).uri.to_s
           expect(encoder_class).to have_received(:create).with(input_path, master_file_id: master_file.id, outputs: [{ label: "high", url: input_path }], preset: "pass_through")
         end
@@ -314,7 +314,7 @@ describe "MasterFile#working_file_path" do
 
         it 'sends the derivative locations to active_encode' do
           entry.process!
-          master_file = media_object.reload.master_files.first
+          master_file = media_object.reload.sections.first
 
           input_path = Addressable::URI.convert_path(File.absolute_path(filename_high)).to_s
           expect(encoder_class).to have_received(:create).with(

--- a/spec/presenters/speedy_af/proxy/media_object_spec.rb
+++ b/spec/presenters/speedy_af/proxy/media_object_spec.rb
@@ -85,6 +85,7 @@ describe SpeedyAF::Proxy::MediaObject do
   end
 
   describe '#master_files' do
+
   end
 
   describe '#master_file_ids' do

--- a/spec/presenters/speedy_af/proxy/media_object_spec.rb
+++ b/spec/presenters/speedy_af/proxy/media_object_spec.rb
@@ -65,6 +65,8 @@ describe SpeedyAF::Proxy::MediaObject do
       expect(presenter.other_identifier).to eq media_object.other_identifier
       expect(presenter.comment).to eq media_object.comment.to_a
       expect(presenter.visibility).to eq media_object.visibility
+      expect(presenter.section_list).to eq media_object.section_list
+      expect(presenter.section_ids).to eq media_object.section_ids
     end
   end
 
@@ -84,16 +86,23 @@ describe SpeedyAF::Proxy::MediaObject do
     end
   end
 
-  describe '#master_files' do
-
-  end
-
-  describe '#master_file_ids' do
-  end
-
   describe '#sections' do
-  end
+    let(:section1) { FactoryBot.create(:master_file, media_object: media_object) }
+    let(:section2) { FactoryBot.create(:master_file, media_object: media_object) }
+    let(:media_object) { FactoryBot.create(:media_object) }
 
-  describe '#section_ids' do
+    context 'when no sections present' do
+      it 'returns empty array without reifying' do
+        expect(presenter.sections).to eq []
+        expect(presenter.real?).to eq false
+      end
+    end
+
+    it 'returns array of master file proxy objects in proper order' do
+      section1
+      section2
+      expect(presenter.sections.map(&:id)).to eq media_object.section_ids
+      expect(presenter.sections.map(&:class)).to eq [SpeedyAF::Proxy::MasterFile, SpeedyAF::Proxy::MasterFile]
+    end
   end
 end

--- a/spec/presenters/speedy_af/proxy/media_object_spec.rb
+++ b/spec/presenters/speedy_af/proxy/media_object_spec.rb
@@ -83,4 +83,16 @@ describe SpeedyAF::Proxy::MediaObject do
       expect(presenter.lending_period).to be_present
     end
   end
+
+  describe '#master_files' do
+  end
+
+  describe '#master_file_ids' do
+  end
+
+  describe '#sections' do
+  end
+
+  describe '#section_ids' do
+  end
 end


### PR DESCRIPTION
Create a new property on media objects which store a JSON serialized array of ids: `section_list`.  This property and related methods, `sections` and `section_ids`, replace nearly all calls to `master_files`, `ordered_master_files`, and `indexed_master_files` methods along with their `*_ids` counterparts.  The only calls left to these methods are in the migration to the new property and one instance in MediaObjectsController that I wasn't able to figure out how to remove.

In order to migrate a media object it needs to be saved thus a full migration of all media objects might take too long to be done during a maintenance window.  For this reason migrating is done in-place and lazily.  When a media object is loaded from fedora it is migrated in-memory and made final on save.  Subsequent loads from fedora use the already migrated `section_list` and should not attempt to read from `list_source`.  After some time a portion of the repository should have been migrated naturally and a follow-up background job can be setup to force migration of the remainder of media objects.  A future version of Avalon that requires the migration is complete might remove the `ordered_aggregation` and `master_files` association entirely.

While implementing this change I wanted to ensure that edits to `section_list`/`sections`/`section_ids` are in-memory only until saving.  Previously changes to `master_files` and `ordered_master_files` were persisted immediately.  In order to avoid that I put the synchronization of `section_list` and `master_files` into a `before_save` callback.  This did cause some complications because that synchronization can lead to saves when objects were in odd states in the test suite.  This was a reason for doing the switch of all references to `master_files` to `sections` throughout the code base.  The only place I wasn't able to resolve this was in `MediaObjectsController#update_media_object`.  One thing to be aware of is that because of this synchronization you may need to reload the media object after saving in order to get the updated `master_files` loaded.  (See `MasterFile#media_object=` for an example of this.)

Review notes:
- The main changes occur in `app/models/media_object.rb` and `app/models/master_file.rb`
- I tried to leave in-line comments in important places to explain why certain things were necessary.  Please add questions or suggestions if anything is unclear or could be improved.

It probably makes sense to squash this PR when merging.

Resolves #5749 

Future work:
- Test performance on avalon-dev on loading/editing many-sectioned items
- Test migration on existing data