### PR TITLE
Fix a11y color contrast for SCSS variable  in branding

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -18,11 +18,13 @@
 
 @import 'blacklight/blacklight';
 
-.result-thumbnail img, img.result-thumbnail {
+.result-thumbnail img,
+img.result-thumbnail {
   max-width: 160px;
 }
 
-.no-icon img, img.no-icon {
+.no-icon img,
+img.no-icon {
   max-height: 90px;
 }
 
@@ -31,7 +33,8 @@
   @extend .btn-outline;
 }
 
-#sort-dropdown, #per_page-dropdown {
+#sort-dropdown,
+#per_page-dropdown {
   .dropdown-item.active {
     color: $dark;
     background-color: $white;
@@ -44,7 +47,9 @@
 
 // Access control update modal form in Bookmarks
 #update_access_control_form {
-  .item-discovery, .item-access, .special-access {
+  .item-discovery,
+  .item-access,
+  .special-access {
     legend {
       border-bottom: 1px solid #e5e5e5;
     }
@@ -55,7 +60,7 @@
 // Needed to override btn-secondary-outline
 .applied-filter .remove:hover {
   color: white !important;
-  background-color: #f44336 !important;
+  background-color: #d14242 !important;
 }
 
 .page-item span.page-link {

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -53,7 +53,7 @@ $lightblue: #31708f;
 $info: #fbb040;
 $success: #429453;
 $warning: #bf841b;
-$danger: #f44336;
+$danger: #d14242;
 
 /**
   * Bootstrap variable overrides
@@ -118,8 +118,7 @@ $navbar-light-toggle-border-color: $white;
 // Inverted navbar toggle
 $navbar-inverse-toggle-hover-bg: #e6e6e6;
 $navbar-inverse-toggle-icon-bar-bg: $lightgray;
-$navbar-inverse-toggle-border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1)
-  rgba(0, 0, 0, 0.25);
+$navbar-inverse-toggle-border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 
 $grid-gutter-width: 16px;
 


### PR DESCRIPTION
Related issue: #5628 

In this PR, the value for `$danger` is changed from `#F44336` to `#D14242`.

The value `#D14242` was derived by using https://webaim.org/resources/contrastchecker/, with values for foreground color set to `#FFFFFF` and background color set to `#F44336` (old color) and adjusting the luminance till contrast ratio reached 4.59:1 (in compliance with WCAG 2.0 level AA).

Before:
<img width="1267" alt="Screenshot 2024-04-12 at 4 26 07 PM" src="https://github.com/avalonmediasystem/avalon/assets/1331659/725c66f2-9a95-4f7c-9996-360edd5be955">

After:
<img width="1267" alt="Screenshot 2024-04-12 at 4 29 27 PM" src="https://github.com/avalonmediasystem/avalon/assets/1331659/f78fce02-0287-4fc3-a838-987e581f051e">
