### PR TITLE
Add option to rescue Solr/Fedora connection errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -252,7 +252,7 @@ class ApplicationController < ActionController::Base
     end
 
     def handle_solr_connection_error(exception)
-      raise if Settings.solr_and_fedora.raise_on_connection_error
+      raise if Settings.app_controller.solr_and_fedora.raise_on_connection_error
       Rails.logger.error(exception.class.to_s + ': ' + exception.message + '\n' + exception.backtrace.join('\n'))
 
       if request.format == :json
@@ -263,7 +263,7 @@ class ApplicationController < ActionController::Base
     end
 
     def handle_fedora_connection_error(exception)
-      raise if Settings.solr_and_fedora.raise_on_connection_error
+      raise if Settings.app_controller.solr_and_fedora.raise_on_connection_error
       Rails.logger.error(exception.class.to_s + ': ' + exception.message + '\n' + exception.backtrace.join('\n'))
 
       if request.format == :json

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -24,7 +24,7 @@ class ApplicationJob < ActiveJob::Base
 
   private
     def handle_connection_error(exception)
-      raise if Settings.solr_and_fedora.raise_on_connection_error
+      raise if Settings.app_job.solr_and_fedora.raise_on_connection_error
       Rails.logger.error(exception.class.to_s + ': ' + exception.message + '\n' + exception.backtrace.join('\n'))
     end
 end

--- a/app/views/errors/fedora_connection.html.erb
+++ b/app/views/errors/fedora_connection.html.erb
@@ -1,0 +1,22 @@
+<%#
+Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+<div id="main_content_container" class="container-fluid">
+  <div class="content" class="col-md-8">
+    <h2>Fedora Connection Error</h2>
+    <p>The application was unable to connect to the Fedora database. Please try again in a few minutes.</p>
+    <p>If the problem persists contact your support staff.</p>
+  </div>
+</div>

--- a/app/views/errors/solr_connection.html.erb
+++ b/app/views/errors/solr_connection.html.erb
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Solr Connection Error (503)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <div class="dialog">
+    <div>
+      <h1>Solr Connection Error</h1>
+    </div>
+    <p>
+      The application was unable to connect to the Solr database. 
+      </br>Please try again in a few minutes.
+      </br>
+      </br>If the problem persists contact your support staff.
+    </p>
+  </div>
+</body>
+</html>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,8 @@ solr:
     rule:
     shards:
     snitch:
+solr_and_fedora:
+  raise_on_connection_error: true
 zookeeper:
   connection_str: "localhost:9983/configs"
 streaming:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,7 @@ solr:
     snitch:
 app_controller:
   solr_and_fedora:
-    raise_on_connection_error: true
+    raise_on_connection_error: false
 app_job:
   solr_and_fedora:
     raise_on_connection_error: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,8 +44,12 @@ solr:
     rule:
     shards:
     snitch:
-solr_and_fedora:
-  raise_on_connection_error: true
+app_controller:
+  solr_and_fedora:
+    raise_on_connection_error: true
+app_job:
+  solr_and_fedora:
+    raise_on_connection_error: true
 zookeeper:
   connection_str: "localhost:9983/configs"
 streaming:

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -80,6 +80,48 @@ describe ApplicationController do
       get :show, params: { id: 'deleted-id' }
       expect(response).to render_template("errors/deleted_pid")
     end
+
+    context 'raise_on_connection_error disabled' do
+      let(:request_context) { { body: "request_context" } }
+      let(:e) { { body: "error_response" } }
+
+      [RSolr::Error::ConnectionRefused, RSolr::Error::Timeout, Blacklight::Exceptions::ECONNREFUSED, Faraday::ConnectionFailed].each do |error_code|
+        it "rescues #{error_code} errors" do
+          raised_error = error_code == RSolr::Error::Timeout ? error_code.new(request_context, e) : error_code 
+          allow(Settings.solr_and_fedora).to receive(:raise_on_connection_error).and_return(false)
+          allow(controller).to receive(:show).and_raise(raised_error)
+          allow_any_instance_of(Exception).to receive(:backtrace).and_return(["Test trace"])
+          allow_any_instance_of(Exception).to receive(:message).and_return('Connection reset by peer')
+          expect(Rails.logger).to receive(:error).with(error_code.to_s + ': Connection reset by peer\nTest trace')
+          expect { get :show, params: { id: 'abc1234' } }.to_not raise_error
+        end
+
+        it "renders error template for #{error_code} errors" do
+          error_template = error_code == Faraday::ConnectionFailed ? 'errors/fedora_connection' : 'errors/solr_connection'
+          raised_error = error_code == RSolr::Error::Timeout ? error_code.new(request_context, e) : error_code
+          allow(Settings.solr_and_fedora).to receive(:raise_on_connection_error).and_return(false)
+          allow(controller).to receive(:show).and_raise(raised_error)
+          get :show, params: { id: 'abc1234' }
+          expect(response).to render_template(error_template)
+        end
+      end
+    end
+
+    context 'raise_on_connection_error enabled' do
+      let(:request_context) { { body: "request_context" } }
+      let(:e) { { body: "error_response" } }
+
+      [RSolr::Error::ConnectionRefused, RSolr::Error::Timeout, Blacklight::Exceptions::ECONNREFUSED, Faraday::ConnectionFailed].each do |error_code|
+        it "raises #{error_code} errors" do
+          raised_error = error_code == RSolr::Error::Timeout ? error_code.new(request_context, e) : error_code 
+          allow(Settings.solr_and_fedora).to receive(:raise_on_connection_error).and_return(true)
+          allow(controller).to receive(:show).and_raise(raised_error)
+          allow_any_instance_of(Exception).to receive(:backtrace).and_return(["Test trace"])
+          allow_any_instance_of(Exception).to receive(:message).and_return('Connection reset by peer')
+          expect { get :show, params: { id: 'abc1234' } }.to raise_error(error_code, 'Connection reset by peer')
+        end
+      end
+    end
   end
 
   describe "rewrite_v4_ids" do

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -30,7 +30,7 @@ describe ApplicationJob do
       [RSolr::Error::ConnectionRefused, RSolr::Error::Timeout, Blacklight::Exceptions::ECONNREFUSED, Faraday::ConnectionFailed].each do |error_code|
         it "rescues #{error_code} errors" do
           raised_error = error_code == RSolr::Error::Timeout ? error_code.new(request_context, e) : error_code 
-          allow(Settings.solr_and_fedora).to receive(:raise_on_connection_error).and_return(false)
+          allow(Settings.app_job.solr_and_fedora).to receive(:raise_on_connection_error).and_return(false)
           allow_any_instance_of(described_class).to receive(:perform).and_raise(raised_error)
           allow_any_instance_of(Exception).to receive(:backtrace).and_return(["Test trace"])
           allow_any_instance_of(Exception).to receive(:message).and_return('Connection reset by peer')
@@ -47,7 +47,7 @@ describe ApplicationJob do
       [RSolr::Error::ConnectionRefused, RSolr::Error::Timeout, Blacklight::Exceptions::ECONNREFUSED, Faraday::ConnectionFailed].each do |error_code|
         it "raises #{error_code} errors" do
           raised_error = error_code == RSolr::Error::Timeout ? error_code.new(request_context, e) : error_code 
-          allow(Settings.solr_and_fedora).to receive(:raise_on_connection_error).and_return(true)
+          allow(Settings.app_job.solr_and_fedora).to receive(:raise_on_connection_error).and_return(true)
           allow_any_instance_of(described_class).to receive(:perform).and_raise(raised_error)
           allow_any_instance_of(Exception).to receive(:backtrace).and_return(["Test trace"])
           allow_any_instance_of(Exception).to receive(:message).and_return('Connection reset by peer')


### PR DESCRIPTION
This implementation uses a static error page for the Solr connection errors. The nav bar header rendered as part of the regular Avalon layout checks user permissions, which directly calls out to Solr. This triggers an error that is not caught by rescue methods in application_controller. Because the nav bar is rendered on almost every page of the application, this results in most of the application being inaccessible. As such, serving a static error page/message should be sufficient.

Using the Rails `config.action_dispatch.rescue_response` handling pathway was not logging the proper error in testing and did not prevent other partials from attempting to render which resulted in extra errors and noise being present in the logs. Serving this file without the Avalon layout and logging the Solr error as part of a standard `rescue_from` in the application_controller feels more in line with our needs.

The issue with the nav bar does not occur when Fedora is inaccessible, so that uses a non-static error page similar to the `deleted_pid.html.erb` style views. This keeps the user in the standard Avalon context and allows them to continue using the application outside of pages that need the fedora connection (which should be most non-edit pages).