### PR TITLE
Fix iiif validator errors for media object manifest generation

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -217,8 +217,8 @@ class IiifCanvasPresenter
     def manifest_attributes(quality, media_type)
       media_hash = {
         label: quality,
-        width: master_file.width.to_i,
-        height: master_file.height.to_i,
+        width: (master_file.width || '1280').to_i,
+        height: (master_file.height || MasterFile::AUDIO_HEIGHT).to_i,
         duration: stream_info[:duration],
         type: media_type,
         format: 'application/x-mpegURL'

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -70,12 +70,16 @@ class IiifCanvasPresenter
     elsif section_processing?(@master_file)
       IIIFManifest::V3::DisplayContent.new(nil,
                                            label: I18n.t('media_object.conversion_msg'),
+                                           width: 1280,
+                                           height: 720,
                                            type: 'Text',
                                            format: 'text/plain')
     else
       support_email = Settings.email.support
       IIIFManifest::V3::DisplayContent.new(nil,
                                            label: I18n.t('errors.missing_derivatives_error') % [support_email, support_email],
+                                           width: 1280,
+                                           height: 720,
                                            type: 'Text',
                                            format: 'text/plain')
     end

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -211,7 +211,7 @@ class IiifManifestPresenter
       if video_count > 0
         Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
       elsif audio_count > 0
-        Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
+        ActionController::Base.helpers.asset_url('audio_icon.png')
       end
     elsif video_count > 0 && audio_count > 0
       ActionController::Base.helpers.asset_url('hybrid_icon.png')

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -211,7 +211,7 @@ class IiifManifestPresenter
       if video_count > 0
         Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
       elsif audio_count > 0
-        ActionController::Base.helpers.asset_url('audio_icon.png')
+        Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file_id)
       end
     elsif video_count > 0 && audio_count > 0
       ActionController::Base.helpers.asset_url('hybrid_icon.png')

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -59,7 +59,7 @@ class IiifManifestPresenter
   def ranges
     [
       IiifManifestRange.new(
-        label: { '@none'.to_sym => media_object.title },
+        label: { 'none' => [media_object.title] },
         items: file_set_presenters.collect(&:range)
       )
     ]

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -17,6 +17,7 @@ if server_options
     Rails.application.routes.default_url_options.merge!( server_options )
     ActionMailer::Base.default_url_options.merge!( server_options )
     ApplicationController.default_url_options = server_options
+    ActionController::Base.asset_host = URI("#{Settings.domain.protocol}://#{Settings.domain.host}:#{Settings.domain.port}").to_s
   end
 
   # Required for rails 6+

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -129,15 +129,15 @@ describe ApplicationHelper do
     end
     it "should return audio icon" do
       doc = {"avalon_resource_type_ssim" => ['Sound Recording', 'Sound Recording'] }
-      expect(helper.image_for(doc).start_with?('/assets/audio_icon')).to be_truthy
+      expect(helper.image_for(doc).start_with?("#{root_url}assets/audio_icon")).to be_truthy
     end
     it "should return video icon" do
       doc = {"avalon_resource_type_ssim" => ['Moving Image'] }
-      expect(helper.image_for(doc).start_with?('/assets/video_icon')).to be_truthy
+      expect(helper.image_for(doc).start_with?("#{root_url}assets/video_icon")).to be_truthy
     end
     it "should return hybrid icon" do
       doc = {"avalon_resource_type_ssim" => ['Moving Image', 'Sound Recording'] }
-      expect(helper.image_for(doc).start_with?('/assets/hybrid_icon')).to be_truthy
+      expect(helper.image_for(doc).start_with?("#{root_url}assets/hybrid_icon")).to be_truthy
     end
     it "should return nil when only unprocessed video" do
       doc = {"section_id_ssim" => ['1'], "avalon_resource_type_ssim" => [] }

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -56,11 +56,21 @@ describe IiifCanvasPresenter do
       it 'has format' do
         expect(subject.format).to eq "application/x-mpegURL"
       end
+
+      it 'has height and width' do
+        expect(subject.width).to eq 1280
+        expect(subject.height).to eq 40
+      end
     end
 
     context 'when video file' do
       it 'has format' do
         expect(subject.format).to eq "application/x-mpegURL"
+      end
+
+      it 'has height and width' do
+        expect(subject.width).to eq 1280
+        expect(subject.height).to eq 720
       end
     end
   end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -185,6 +185,11 @@ describe IiifCanvasPresenter do
       it 'has label' do
         expect(subject.label).to eq I18n.t('errors.missing_derivatives_error') % [Settings.email.support, Settings.email.support]
       end
+
+      it 'has height and width' do
+        expect(subject.width).to eq 1280
+        expect(subject.height).to eq 720
+      end
     end
 
     context 'when master file is processing' do
@@ -200,6 +205,11 @@ describe IiifCanvasPresenter do
 
       it 'has label' do
         expect(subject.label).to eq I18n.t('media_object.conversion_msg')
+      end
+
+      it 'has height and width' do
+        expect(subject.width).to eq 1280
+        expect(subject.height).to eq 720
       end
     end
   end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -69,8 +69,8 @@ describe IiifCanvasPresenter do
       end
 
       it 'has height and width' do
-        expect(subject.width).to eq 1280
-        expect(subject.height).to eq 720
+        expect(subject.width).to eq 1024
+        expect(subject.height).to eq 768
       end
     end
   end


### PR DESCRIPTION
Related issue: #5798 