### PR TITLE
Use latest 3.x zookeeper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
       - image: ualbertalib/docker-fcrepo4:4.7
         environment:
           CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
-      - image: zookeeper:3.4
+      - image: zookeeper:3.9
+        environment:
+          ZOO_ADMINSERVER_ENABLED: false
       - image: solr:9
         environment:
           VERBOSE: yes


### PR DESCRIPTION
Solr 9.6 was released earlier this week and appears to cause a compatibility issue with the version of zookeeper we were pinning to.