### PR TITLE
Allow setting default headers in fedora.yml config

### DIFF
--- a/config/initializers/active_fedora_reindexing.rb
+++ b/config/initializers/active_fedora_reindexing.rb
@@ -1,4 +1,24 @@
 ActiveFedora::Fedora.class_eval do
+    def header_options
+      @config[:headers]
+    end
+
+    def authorized_connection
+      options = {}
+      options[:ssl] = ssl_options if ssl_options
+      options[:request] = request_options if request_options
+      options[:headers] = header_options if header_options
+      Faraday.new(host, options) do |conn|
+        conn.response :encoding # use Faraday::Encoding middleware
+        conn.adapter Faraday.default_adapter # net/http
+        if Gem::Version.new(Faraday::VERSION) < Gem::Version.new('2')
+          conn.request :basic_auth, user, password
+        else
+          conn.request :authorization, :basic, user, password
+        end
+      end
+    end
+
     def ntriples_connection
       authorized_connection.tap { |conn| conn.headers['Accept'] = 'application/n-triples' }
     end


### PR DESCRIPTION
This facilitates a workaround we needed in production to set the `User-Agent` header on all faraday requests to a known good value `curl/7.76.1`  instead of `Faraday v2.7.4`.  With this PR it ensures that the header is set on all faraday requests when configured in fedora.yml.  This approach is also flexible and gives us a space to set other headers in the future if needed.

Example fedora.yml config:
```
production:
  user: fedoraAdmin
  password: fedoraAdmin
  url: http://127.0.0.1:8983/fedora4/rest
  base_path: /prod
  request: { timeout: 600, open_timeout: 60} # Increase if Fedora connection times out for large operations
  headers: { User-Agent: 'curl/7.76.1' }
```