### PR TITLE
Index MODS recordChangeDate on parent media object

### DIFF
--- a/app/models/mods_behaviors.rb
+++ b/app/models/mods_behaviors.rb
@@ -89,6 +89,8 @@ module ModsBehaviors
     # For full text, we stuff it into the mods_tesim field which is already configured for Mods doucments
     solr_doc['mods_tesim'] = self.ng_xml.xpath('//text()').collect { |t| t.text }
 
+    solr_doc['descMetadata_modified_dtsi'] = ActiveFedora::Indexing::DefaultDescriptors.iso8601_date(self.record_change_date.first)
+
     # TODO: Find a better way to handle super long fields other than simply dropping them from the solr doc.
     solr_doc.delete_if do |field,value|
       case value

--- a/app/views/catalog/_document_media_object.atom.builder
+++ b/app/views/catalog/_document_media_object.atom.builder
@@ -4,7 +4,7 @@ xml.entry do
   xml.title index_presenter(document).label(document_show_link_field(document))
 
   # updated is required, for now we'll just set it to now, sorry
-  xml.updated document[:timestamp]
+  xml.updated document[:descMetadata_modified_dtsi] || document[:timestamp]
 
   xml.link    "rel" => "alternate", "type" => "application/json", "href" => media_object_url(document.id, format: :json)
   # add other doc-specific formats, atom only lets us have one per

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -636,6 +636,9 @@ describe MediaObject do
       media_object.save!
       expect(media_object.to_solr['read_access_ip_group_ssim']).to include(ip_addr)
     end
+    it 'indexes modified time for descMetadata subresource' do
+      expect(DateTime.parse(media_object.to_solr['descMetadata_modified_dtsi'])).to eq DateTime.parse(media_object.descMetadata.record_change_date.first)
+    end
   end
 
   describe 'permalink' do

--- a/spec/requests/atom_feed_spec.rb
+++ b/spec/requests/atom_feed_spec.rb
@@ -25,7 +25,7 @@ describe 'atom feed', type: :request do
     let(:updated_date) do
       query = ActiveFedora::SolrQueryBuilder.construct_query(ActiveFedora.id_field => media_object.id)
       doc = ActiveFedora::SolrService.get(query)['response']['docs'].first
-      doc["timestamp"]
+      doc["descMetadata_modified_dtsi"]
     end
 
     it 'returns information about a media object' do
@@ -45,12 +45,12 @@ describe 'atom feed', type: :request do
     let(:updated_date1) do
       query = ActiveFedora::SolrQueryBuilder.construct_query(ActiveFedora.id_field => media_object1.id)
       doc = ActiveFedora::SolrService.get(query)['response']['docs'].first
-      doc["timestamp"]
+      doc["descMetadata_modified_dtsi"]
     end
     let(:updated_date2) do
       query = ActiveFedora::SolrQueryBuilder.construct_query(ActiveFedora.id_field => media_object2.id)
       doc = ActiveFedora::SolrService.get(query)['response']['docs'].first
-      doc["timestamp"]
+      doc["descMetadata_modified_dtsi"]
     end
 
     it 'sorts based upon solr timestamp' do


### PR DESCRIPTION
This field will act as a better indicator of when the object's metadata has changed instead of relying on media object's solr timestamp which gets updated any time the object gets reindexed. This new value is used in the ATOM feed and is available for use in OAI-PMH. 

Resolves #5580