### PR TITLE
Index avalon_resource_type the same as it is stored in fedora

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -80,7 +80,7 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    config.add_facet_field 'avalon_resource_type_ssim', label: 'Format', limit: 5, collapse: false
+    config.add_facet_field 'avalon_resource_type_ssim', label: 'Format', limit: 5, collapse: false, helper_method: :titleize
     config.add_facet_field 'creator_ssim', label: 'Main contributor', limit: 5
     config.add_facet_field 'date_sim', label: 'Date', limit: 5
     config.add_facet_field 'genre_ssim', label: 'Genres', limit: 5

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -226,6 +226,10 @@ module ApplicationHelper
       omission: "...#{label.last(end_length)}")
   end
 
+  def titleize value
+    value.is_a?(Array) ? value.map(&:titleize) : value.titleize
+  end
+
   def master_file_meta_properties( m )
     formatted_duration = m.duration ? Time.new(m.duration.to_i / 1000).iso8601 : ''
     item_type = m.is_video? ? 'http://schema.org/VideoObject' : 'http://schema.org/AudioObject'

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -260,7 +260,7 @@ class MediaObject < ActiveFedora::Base
       solr_doc["title_ssort"] = self.title
       solr_doc["creator_ssort"] = Array(self.creator).join(', ')
       solr_doc["date_ingested_ssim"] = self.create_date.strftime "%F" if self.create_date.present?
-      solr_doc['avalon_resource_type_ssim'] = self.avalon_resource_type.map(&:titleize)
+      solr_doc['avalon_resource_type_ssim'] = self.avalon_resource_type
       solr_doc['identifier_ssim'] = self.identifier.map(&:downcase)
       solr_doc['note_ssm'] = self.note.collect { |n| n.to_json }
       solr_doc['other_identifier_ssm'] = self.other_identifier.collect { |oi| oi.to_json }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -87,6 +87,15 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#titleize" do
+    it "titleizes a string" do
+      expect(helper.titleize("lower case phrase")).to eq "Lower Case Phrase"
+    end
+    it "titleizes an array of strings" do
+      expect(helper.titleize(["ant", "adam ant", "tic tac toe"])).to eq ["Ant", "Adam Ant", "Tic Tac Toe"]
+    end
+  end
+
   describe "#truncate_center" do
     it "should return empty string if empty string received" do
       expect(helper.truncate_center("", 5)).to eq ""


### PR DESCRIPTION
Shift titleization into front end through a helper method utilized by the Blacklight facet.

Resolves #5836