### PR TITLE
Playlist description fixes

### DIFF
--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -24,7 +24,6 @@ class Playlist < ActiveRecord::Base
 
   validates :user, presence: true
   validates :title, presence: true
-  validates :comment, length: { maximum: 255 }
   validates :visibility, presence: true
   validates :visibility, inclusion: { in: proc { [PUBLIC, PRIVATE, PRIVATE_WITH_TOKEN] } }
 

--- a/app/views/playlists/_description_and_tags.html.erb
+++ b/app/views/playlists/_description_and_tags.html.erb
@@ -14,8 +14,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if @playlist.comment.present? %>
-<h4>Comments</h4>
-<%= @playlist.comment %>
+<h4><%= t("activerecord.attributes.playlist.comment") %></h4>
+<%= simple_format @playlist.comment %>
 <% end %>
 
 <% if @playlist.tags.present? %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -36,7 +36,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <% if @playlist.comment.blank? %>
         <span class="info-text-gray">No description</span>
         <% else %>
-        <%= @playlist.comment %>
+        <%= simple_format @playlist.comment %>
         <% end %>
       </dd>
       <dt class="col-sm-2"><%= t("playlist.visibility") %>:</dt>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -35,7 +35,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         playlist_item_ids: @playlist.item_ids,
         token: @playlist_token,
         share: { canShare: (will_partial_list_render? :share), content: render('share') },
-        comment_tag: { content: render('comments_and_tags') }
+        comment_tag: { content: render('description_and_tags') }
       }
     ) %>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_24_200346) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_31_201828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -196,7 +196,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_200346) do
   create_table "playlists", force: :cascade do |t|
     t.string "title"
     t.bigint "user_id", null: false
-    t.string "comment"
+    t.text "comment"
     t.string "visibility"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false


### PR DESCRIPTION
- Consistently label playlist description by using i18n translation
- Display new lines in playlist description by using `simple_format` helper
- Remove length restrictions on playlist description

Resolves #5839 and https://github.com/samvera-labs/ramp/issues/498