### PR TITLE
Overrides of ActiveFedora to avoid doing costly loads of list_source and master_files when saving

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -249,10 +249,6 @@ class MediaObjectsController < ApplicationController
         if api_params[:replace_masterfiles]
           old_ordered_sections.each do |mf|
             p = MasterFile.find(mf)
-            # FIXME: Figure out why this next line is necessary
-            # without it the save below will fail with Ldp::Gone when attempting to set master_files in the MediaObject before_save callback
-            # This could be avoided by doing a reload after all of the destroys but I'm afraid that would mess up other changes already staged in-memory.
-            @media_object.master_files.delete(p)
             # Need to manually remove from section_ids in memory to match changes that will persist when the master file is destroyed
             @media_object.section_ids -= [p.id]
             p.destroy

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1271,6 +1271,8 @@ describe MediaObject do
         expect(mo.section_list).not_to eq nil
         expect(mo.sections).not_to eq mo.ordered_master_files.to_a
         expect(mo.section_ids).to eq [section.id, section2.id, new_section.id]
+        expect(mo.master_file_ids).to eq mo.section_ids
+        expect(mo.master_files).to eq mo.sections
       end
     end
   end


### PR DESCRIPTION
Two overrides needed to realize the gains hoped for with  #5778 
- Skip attempting to update first/last properties of list_source on save
- Allow setting hasPart triples directly on media object to avoid `master_files=` which causes load of all master files and associated files (I was able to reuse overrides I had written as part of the Fedora 6 work. :slightly_smiling_face: )

The second change will skip writing to the proxy ActiveFedora::IndirectContainer object (`id/master_files`) which will become a snapshot of pre-migration state just like `list_source`.

Resolves #5849 