### PR TITLE
Don't titlize for matching since resource type isn't titlized in the index anymore

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,12 +58,11 @@ module ApplicationHelper
     user_omniauth_callback_lti_url(target_id: target)
   end
 
-  # TODO: Fix me with latest changes from 5.1.4
   def image_for(document)
     master_file_id = document["section_id_ssim"].try :first
 
-    video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image'.titleize) } rescue 0
-    audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording'.titleize) } rescue 0
+    video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image') } rescue 0
+    audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording') } rescue 0
 
     if master_file_id
       if video_count > 0

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -137,15 +137,15 @@ describe ApplicationHelper do
       expect(helper.image_for(doc)).to eq(nil)
     end
     it "should return audio icon" do
-      doc = {"avalon_resource_type_ssim" => ['Sound Recording', 'Sound Recording'] }
+      doc = {"avalon_resource_type_ssim" => ['sound recording', 'sound recording'] }
       expect(helper.image_for(doc).start_with?("#{root_url}assets/audio_icon")).to be_truthy
     end
     it "should return video icon" do
-      doc = {"avalon_resource_type_ssim" => ['Moving Image'] }
+      doc = {"avalon_resource_type_ssim" => ['moving image'] }
       expect(helper.image_for(doc).start_with?("#{root_url}assets/video_icon")).to be_truthy
     end
     it "should return hybrid icon" do
-      doc = {"avalon_resource_type_ssim" => ['Moving Image', 'Sound Recording'] }
+      doc = {"avalon_resource_type_ssim" => ['moving image', 'sound recording'] }
       expect(helper.image_for(doc).start_with?("#{root_url}assets/hybrid_icon")).to be_truthy
     end
     it "should return nil when only unprocessed video" do
@@ -153,7 +153,7 @@ describe ApplicationHelper do
       expect(helper.image_for(doc)).to eq(nil)
     end
     it "should return thumbnail" do
-      doc = {"section_id_ssim" => ['1'], "avalon_resource_type_ssim" => ['Moving Image'] }
+      doc = {"section_id_ssim" => ['1'], "avalon_resource_type_ssim" => ['moving image'] }
       expect(helper.image_for(doc)).to eq('/master_files/1/thumbnail')
     end
   end


### PR DESCRIPTION
Fixes broken thumbnails in search results on avalon-dev after merging #5846 and reindexing