### PR TITLE
Avalon::TranscriptSearch does phrase searching by default

### DIFF
--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -855,5 +855,14 @@ describe MasterFilesController do
       result = JSON.parse(response.body)
       expect(result['items'].any? { |item| item["id"].include?(other_master_file.id) }).to eq false
     end
+
+    it 'does phrase searches' do
+      get('search', params: { id: parent_master_file.id, q: 'before lunch' } )
+      result = JSON.parse(response.body)
+      items = result["items"]
+      expect(items.count).to eq 1
+      expect(items[0]["body"]["value"]).to eq "Just <em>before</em> <em>lunch</em> one day, a puppet show was put on at school."
+      expect(items[0]["target"]).to eq "#{Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(parent_master_file.id, transcript_1.id)}#t=00:00:22.200,00:00:26.600"
+    end
   end
 end

--- a/spec/lib/avalon/transcript_search.rb
+++ b/spec/lib/avalon/transcript_search.rb
@@ -18,34 +18,50 @@ require 'avalon/transcript_search'
 describe Avalon::TranscriptSearch do
   subject { described_class.new(query: 'before', master_file: parent_master_file) }
 
-  let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_tag, parent_id: parent_master_file.id, file: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'chunk_test.txt'), 'text/plain')) }
+  let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_tag, parent_id: parent_master_file.id, file: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'chunk_test.vtt'), transcript_mime_type)) }
+  let(:transcript_global_id) { transcript.to_global_id.to_s }
+  let(:transcript_mime_type) { 'text/vtt' }
+  let(:transcript2) { FactoryBot.create(:supplemental_file, :with_transcript_tag, parent_id: parent_master_file.id, file: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'chunk_test.txt'), transcript2_mime_type)) }
+  let(:transcript2_global_id) { transcript2.to_global_id.to_s }
+  let(:transcript2_mime_type) { 'text/plain' }
   let(:parent_master_file) { FactoryBot.create(:master_file, :with_media_object) }
 
   before :each do
-    parent_master_file.supplemental_files += [transcript]
+    parent_master_file.supplemental_files += [transcript, transcript2]
     parent_master_file.save
   end
 
   describe '#perform_search' do
     it 'returns a solr document of transcript chunks with the matching term' do
       search = subject.perform_search
-      global_id = transcript.to_global_id.to_s
-      expect(search['response']['docs'].first['id']).to eq global_id
-      expect(search['response']['docs'].first['mime_type_ssi']).to eq transcript.file.content_type
-      expect(search['highlighting'][global_id]['transcript_tsim']).to be_a Array
-      expect(search['highlighting'][global_id]['transcript_tsim'].count).to eq 1
-      expect(search['highlighting'][global_id]['transcript_tsim'].first).to include '<em>before</em>'
+      expect(search['response']['docs'].count).to eq 2
+      expect(search['response']['docs']).to include({"id"=>transcript_global_id, "mime_type_ssi"=>transcript_mime_type})
+      expect(search['response']['docs']).to include({"id"=>transcript2_global_id, "mime_type_ssi"=>transcript2_mime_type})
+      expect(search['highlighting'][transcript_global_id]['transcript_tsim']).to be_a Array
+      expect(search['highlighting'][transcript_global_id]['transcript_tsim'].count).to eq 1
+      expect(search['highlighting'][transcript_global_id]['transcript_tsim'].first).to include '<em>before</em>'
+      expect(search['highlighting'][transcript2_global_id]['transcript_tsim']).to be_a Array
+      expect(search['highlighting'][transcript2_global_id]['transcript_tsim'].count).to eq 1
+      expect(search['highlighting'][transcript2_global_id]['transcript_tsim'].first).to include '<em>before</em>'
     end
 
     context 'with multiple terms in the query' do
       subject { described_class.new(query: 'before lunch', master_file: parent_master_file) }
-      let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_tag, parent_id: parent_master_file.id, file: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'chunk_test.vtt'), 'text/vtt')) }
-      
-      it 'returns a solr document of transcript chunks with any of the matching terms' do
+
+      it 'returns a solr document of transcript chunks' do
         search = subject.perform_search
-        global_id = transcript.to_global_id.to_s
         # solr search is case insensitive, so we convert results to lower case for simpler testing
-        expect(search['highlighting'][global_id]['transcript_tsim'].all? { |h| h.downcase.include?('<em>before</em>') || h.downcase.include?('<em>lunch</em>') }).to eq true
+        expect(search['highlighting'][transcript_global_id]['transcript_tsim'].all? { |h| h.downcase.include?('<em>before</em> <em>lunch</em>') }).to eq true
+        expect(search['highlighting'][transcript_global_id]['transcript_tsim'].count).to eq 1
+      end
+
+      context 'with phrase searching disabled' do
+        it 'returns a solr document of transcript chunks with any of the matching terms' do
+          search = subject.perform_search(phrase_searching: false)
+          # solr search is case insensitive, so we convert results to lower case for simpler testing
+          expect(search['highlighting'][transcript_global_id]['transcript_tsim'].all? { |h| h.downcase.include?('<em>before</em>') || h.downcase.include?('<em>lunch</em>') }).to eq true
+          expect(search['highlighting'][transcript_global_id]['transcript_tsim'].count).to eq 4
+        end
       end
     end
   end
@@ -60,21 +76,28 @@ describe Avalon::TranscriptSearch do
       expect(search[:items]).to be_present
       items = search[:items]
       expect(items).to be_a Array
-      item = items.first
-      expect(item[:id]).to eq "#{Rails.application.routes.url_helpers.media_object_url(parent_master_file.media_object_id)}/manifest/canvas/#{parent_master_file.id}/search/abc1234"
-      expect(item[:type]).to eq 'Annotation'
-      expect(item[:motivation]).to eq 'supplementing'
-      expect(item[:body]).to be_present
-      expect(item[:body][:type]).to eq 'TextualBody'
-      expect(item[:body][:value]).to be_a String
-      expect(item[:body][:value]).to include '<em>before</em>'
-      expect(item[:body][:format]).to eq 'text/plain'
-      expect(item[:target]).to eq Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(parent_master_file.id, transcript.id)
+      expect(items.first[:id]).to eq "#{Rails.application.routes.url_helpers.media_object_url(parent_master_file.media_object_id)}/manifest/canvas/#{parent_master_file.id}/search/abc1234"
+      expect(items.first[:type]).to eq 'Annotation'
+      expect(items.first[:motivation]).to eq 'supplementing'
+      expect(items.first[:body]).to be_present
+      expect(items.first[:body][:type]).to eq 'TextualBody'
+      expect(items.first[:body][:value]).to be_a String
+      expect(items.first[:body][:value]).to include '<em>before</em>'
+      expect(items.first[:body][:format]).to eq 'text/plain'
+      expect(items.first[:target]).to eq Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(parent_master_file.id, transcript.id, anchor: "t=00:00:22.200,00:00:26.600")
+      expect(items.second[:id]).to eq "#{Rails.application.routes.url_helpers.media_object_url(parent_master_file.media_object_id)}/manifest/canvas/#{parent_master_file.id}/search/abc1234"
+      expect(items.second[:type]).to eq 'Annotation'
+      expect(items.second[:motivation]).to eq 'supplementing'
+      expect(items.second[:body]).to be_present
+      expect(items.second[:body][:type]).to eq 'TextualBody'
+      expect(items.second[:body][:value]).to be_a String
+      expect(items.second[:body][:value]).to include '<em>before</em>'
+      expect(items.second[:body][:format]).to eq 'text/plain'
+      expect(items.second[:target]).to eq Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(parent_master_file.id, transcript2.id)
+
     end
 
     context 'transcript with timed text' do
-      let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_tag, parent_id: parent_master_file.id, file: fixture_file_upload(Rails.root.join('spec', 'fixtures', 'chunk_test.vtt'), 'text/vtt')) }
-
       it 'returns result value without time cues' do
         item = subject.iiif_content_search[:items].first
         expect(item[:body][:value]).to_not match(/\d{2}:\d{2}:\d{2}/)


### PR DESCRIPTION
With this PR phrase searching is the default for IIIF content search and a keyword argument (`phrase_searching`) provides a way to turn it off for multi-term searching instead.

Note that this will change the behavior of IIIF content search and searching within ramp may break or have inconsistencies until changes are made to handle this change.

Resolves #5861 