### PR TITLE
Set footer to negative z-index so paging works

### DIFF
--- a/app/assets/stylesheets/avalon/_footer.scss
+++ b/app/assets/stylesheets/avalon/_footer.scss
@@ -21,6 +21,7 @@
   width: 100%;
   min-height: 2.5rem;
   color: #999999;
+  z-index: -1000;
 }
 
 footer {


### PR DESCRIPTION
If controls such as the playlist paging ended up on the same level as the footer they were not clickable because the padding around the footer was covering them up. Setting the footer with a large negative z-index ensures that it will always be below the paging controls.

Related Issue: #5869 