### PR TITLE
Limit the number of stream tokens in a user session to avoid SessionOverflow errors

### DIFF
--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -17,6 +17,8 @@ class StreamToken < ActiveRecord::Base
   class Unauthorized < Exception; end
 
   #  attr_accessible :token, :target, :expires
+  class_attribute :max_tokens_per_user
+  self.max_tokens_per_user = 1000
 
   def self.media_token(session)
     session[:hash_tokens] ||= []
@@ -75,7 +77,7 @@ class StreamToken < ActiveRecord::Base
 
   def self.purge_expired!(session)
     purged = expired.delete_all
-    session[:hash_tokens] = StreamToken.where(token: Array(session[:hash_tokens])).pluck(:token)
+    session[:hash_tokens] = StreamToken.where(token: Array(session[:hash_tokens])).order(expires: :desc).limit(max_tokens_per_user).pluck(:token)
     purged
   end
 

--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -18,7 +18,7 @@ class StreamToken < ActiveRecord::Base
 
   #  attr_accessible :token, :target, :expires
   class_attribute :max_tokens_per_user
-  self.max_tokens_per_user = 1000
+  self.max_tokens_per_user = 2000
 
   def self.media_token(session)
     session[:hash_tokens] ||= []

--- a/db/migrate/20240624204921_change_sessions_data_to_medium_text.rb
+++ b/db/migrate/20240624204921_change_sessions_data_to_medium_text.rb
@@ -1,0 +1,5 @@
+class ChangeSessionsDataToMediumText < ActiveRecord::Migration[7.0]
+  def change
+    change_column :sessions, :data, :text, limit: 16777215
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_31_201828) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_24_204921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/stream_token_spec.rb
+++ b/spec/models/stream_token_spec.rb
@@ -133,11 +133,8 @@ describe StreamToken do
     end
 
     context 'with custom max_tokens_per_user' do
-      around do |example|
-        @previous_max_tokens_per_user = StreamToken.max_tokens_per_user
-        StreamToken.max_tokens_per_user = 10
-        example.run
-        StreamToken.max_tokens_per_user = @previous_max_tokens_per_user
+      before do
+        allow(StreamToken).to receive(:max_tokens_per_user).and_return(10)
       end
 
       it 'limits the number of tokens in the session' do


### PR DESCRIPTION
Resolves #5377 

This PR limits the number of stream tokens in a session to avoid overflowing the session's `data` column in the database.  The `data` column is type `text` which means that for MySql it is up to 65,535 bytes.  Given that each stream token is 40 characters I think the session could only hold 1,638 tokens (65,535 / 40 = 1638.375) even if it wasn't storing any other information.  In testing though, my session on MCO-staging could only store 910 tokens before it overflowed.  Given this I added a migration to increase the limit of the text column to medium text which can store up to 16MB instead of 64KB.  This larger size will accomodate the requested limit of 2,000 tokens and should avoid SessionOverflow errors for the foreseeable future.