### PR TITLE
Improve handling of improperly formatted time cues in Transcript Parser

### DIFF
--- a/lib/avalon/transcript_parser.rb
+++ b/lib/avalon/transcript_parser.rb
@@ -48,7 +48,8 @@ module Avalon
 
     # Separate time cue and text content from a single line of timed text to facilitate result formatting of transcript searches.
     def self.extract_single_time_cue(timed_text)
-      split_text = timed_text.match(/(\d{2,}*:?\d{2}:\d{2}\.?,?\d{3} --> \d{2,}*:?\d{2}:\d{2}\.?,?\d{3})(.*)/)
+      split_text = timed_text.match(/(\d{0,}:?\d{2}:\d{2}\.?,?\d{3} --> \d{0,}:?\d{2}:\d{2}\.?,?\d{3})(.*)/)
+      return [nil, nil] if split_text.blank?
       time_cue = split_text[1].sub(',', '.').gsub(/\s-->\s/, ',')
       text = split_text[2].strip
       [time_cue, text]


### PR DESCRIPTION
Related issue: #5886 

Malformed time cues would cause the transcript search to bomb because the regex to separate timed text cues would fail to find a match. We are loosening the regex to match time cues of the form `h:mm:ss.ttt` and also providing a failure path so that if the timed text cannot be separated properly, the search will still return matches. It will just be the entire cue instead of the text with a time fragment anchored target.