### PR TITLE
Fix embedded player after Ramp rework

### DIFF
--- a/app/javascript/components/embeds/EmbeddedRamp.jsx
+++ b/app/javascript/components/embeds/EmbeddedRamp.jsx
@@ -25,7 +25,8 @@ import './Ramp.scss';
 
 const Ramp = ({
 	urls,
-	media_object_id
+	media_object_id,
+  is_video
 }) => {
 	const [manifestUrl, setManifestUrl] = React.useState('');
 	const [startCanvasId, setStartCanvasId] = React.useState();
@@ -79,16 +80,18 @@ const Ramp = ({
         else if (command=='get_offset') event.source.postMessage({'command': 'currentTime','currentTime': embeddedPlayer.currentTime()}, event.origin);
       });
 
-      /* 
-        Quality selector extends outside iframe for audio items, so we need to disable that control
-        and rely on the quality automatically selected by the user's system.
-       */
-      if (embeddedPlayer.isAudio()) { embeddedPlayer.controlBar.removeChild('qualitySelector'); }
+      if (embeddedPlayer.audioOnlyMode()) { 
+        /* 
+          Quality selector extends outside iframe for audio items, so we need to disable that control
+          and rely on the quality automatically selected by the user's system.
+         */
+        embeddedPlayer.controlBar.qualitySelector.dispose();
+      }
 
       // Create button component for "View in Repository" and add to control bar
       let repositoryUrl = Object.values(urls).join('/').replace('/embed', '');
-      let position = embeddedPlayer.isAudio() ? embeddedPlayer.controlBar.children_.length : embeddedPlayer.controlBar.children_.length - 1;
-      var viewInRepoButton = embeddedPlayer.getChild('ControlBar').addChild('button', {
+      let position = embeddedPlayer.audioOnlyMode() ? embeddedPlayer.controlBar.children_.length : embeddedPlayer.controlBar.children_.length - 1;
+      var viewInRepoButton = embeddedPlayer.controlBar.addChild('button', {
         clickHandler: function(event) {
           window.open(repositoryUrl, '_blank').focus();
         }
@@ -99,7 +102,7 @@ const Ramp = ({
       viewInRepoButton.controlText('View in Repository');
 
       // Add button icon
-      document.querySelector('.vjs-custom-external-link .vjs-icon-placeholder').innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/></svg>'
+      document.querySelector('.vjs-custom-external-link').innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/></svg>'
 
       // This function only needs to run once, so we clear the interval here
       clearInterval(interval);
@@ -111,7 +114,7 @@ const Ramp = ({
       customErrorMessage='This embed encountered an error. Please refresh or contact an administrator.'
       startCanvasId={startCanvasId}
       startCanvasTime={startCanvasTime}>
-      <MediaPlayer enableFileDownload={false} enablePlaybackRate={true} />
+      <MediaPlayer enableFileDownload={false} enablePlaybackRate={is_video} />
     </IIIFPlayer>
   );
 };

--- a/app/javascript/components/embeds/Ramp.scss
+++ b/app/javascript/components/embeds/Ramp.scss
@@ -22,6 +22,14 @@
   .video-js .vjs-big-play-button {
     left: 55% !important;
   }
+  .video-js.vjs-audio-only-mode {
+    // Disable tooltips for volume and progress in embedded
+    // audio. Viewport is too small to display them.
+    .vjs-volume-panel:hover .vjs-mouse-display,
+    .vjs-custom-progress-bar .tooltiptext {
+      display: none !important;
+    }
+  }
   @media (max-width: 585px) {
     .video-js .vjs-big-play-button {
       scale: 1.5;

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -17,6 +17,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= react_component("EmbeddedRamp",
   {
     urls: { base_url: request.protocol+request.host_with_port, fullpath_url: request.fullpath },
-    media_object_id: @master_file.media_object_id
+    media_object_id: @master_file.media_object_id,
+    is_video: @master_file.is_video?
   }
 ) %>


### PR DESCRIPTION
Either the Video.js upgrade or other reworking of Ramp broke certain features of the embedded player. This work:

1. Fixes the "View in Repository" button so that the icon renders and button instances are not continuously added.
2. Fixes behavior so the quality selector is not present on audio items.
3. Removes the playback rate option from embedded audio player.

Related issues: #5899, #5732