### PR TITLE
Remove margin and padding from embed body element

### DIFF
--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -30,7 +30,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render "modules/google_analytics" %>
   </head>
 
-  <body>
+  <body style='margin: 0; padding: 0;'>
     <%= yield %>
     <%= yield :page_scripts %>
   </body>


### PR DESCRIPTION
Related issue: #5908

Certain html elements have built in margins or padding not reflected in the CSS readouts of inspect element. `<body>` is one of these elements. This built in margin was causing the embedded audio player to overflow the iframe it was embedded in, resulting in unintended scrolling behavior. Setting the embed layout's body to have no margin and no padding allows the embedded media to properly fill the iframe and avoid scrolling.