### PR TITLE
Context search solr query should return results across entire indexed value when extremely long

### DIFF
--- a/lib/avalon/transcript_search.rb
+++ b/lib/avalon/transcript_search.rb
@@ -37,7 +37,8 @@ module Avalon
                                     "hl.fl": "transcript_tsim",
                                     "hl.snippets": 1000000,
                                     "hl.fragsize": 0,
-                                    "hl.method": "original")
+                                    "hl.method": "original",
+                                    "hl.maxAnalyzedChars": "-1")
     end
 
     def iiif_content_search(phrase_searching: true)


### PR DESCRIPTION
Fixes #5915 