### PR TITLE
Fail SupplementalFile Binary update if no Accept header

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -100,6 +100,7 @@ class SupplementalFilesController < ApplicationController
       raise Avalon::BadRequest, "Missing required Content-type headers" unless request.headers["Content-Type"] == 'application/json'
     elsif request.headers['Avalon-Api-Key'].present?
       raise Avalon::BadRequest, "Incorrect request format. Use JSON if updating metadata." unless attachment
+      raise Avalon::BadRequest, "Missing required Accept headers" unless request.headers["Accept"] == 'application/json'
     end
     raise Avalon::BadRequest, "Missing required parameters" unless validate_params
 

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -527,6 +527,14 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
           expect(response).to have_http_status(:ok)
           expect(response.body).to eq({ "id": supplemental_file.id }.to_json)
         end
+
+        context "without Accept header" do
+          it "returns a 400" do
+            request.headers['Avalon-Api-Key'] = 'secret_token'
+            put :update, params: { class_id => object.id, id: supplemental_file.id, file: file_update, format: :html }, session: valid_session
+            expect(response).to have_http_status(400)
+          end
+        end
       end
 
       context "API without file" do


### PR DESCRIPTION
Users updating supplemental files via CLI should use `-H "Accept:application/json"` in their requests to ensure a JSON response from an endpoint. For updating the binary file specifically, the request is through the HTML format endpoint and so having Accept headers needs to be required to force a JSON response in the CLI environment.

Related issue: #5918 