### PR TITLE
Force vertical alignment of horizontal volume slider thumb to top

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -38,6 +38,9 @@
         min-height: 2.9em;
       }
     }
+    .vjs-volume-horizontal .vjs-volume-level .vjs-svg-icon>svg {
+      vertical-align: top;
+    }
   }
 
   .ramp--structured-nav {

--- a/app/javascript/components/embeds/Ramp.scss
+++ b/app/javascript/components/embeds/Ramp.scss
@@ -45,4 +45,7 @@
       min-height: 2.9em;
     }
   }
+  .vjs-volume-horizontal .vjs-volume-level .vjs-svg-icon>svg {
+    vertical-align: top;
+  }
 }


### PR DESCRIPTION
I couldn't find anything within Avalon's CSS that was overriding Ramp's CSS to cause this difference so I added a new override.

Before:
![Screenshot from 2024-07-10 17-19-48](https://github.com/avalonmediasystem/avalon/assets/1053603/86a14445-96ce-488a-aa61-683402364c1b)


After (including https://github.com/samvera-labs/ramp/pull/562 which is not part of this PR):
![Screenshot from 2024-07-10 17-19-14](https://github.com/avalonmediasystem/avalon/assets/1053603/4ca9e74c-473e-4344-a142-8d5c29cd0b89)


Resolves https://github.com/samvera-labs/ramp/pull/559
