### PR TITLE
Skip transcript search in bookmark context

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -48,7 +48,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def search_section_transcripts(solr_parameters)
-    return unless solr_parameters[:q].present? && SupplementalFile.with_tag('transcript').any?
+    return unless solr_parameters[:q].present? && SupplementalFile.with_tag('transcript').any? && !(blacklight_params[:controller] == 'bookmarks')
 
     terms = solr_parameters[:q].split
     term_subquery = terms.map { |term| "transcript_tsim:#{RSolr.solr_escape(term)}" }.join(" OR ")
@@ -57,7 +57,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def term_frequency_counts(solr_parameters)
-    return unless solr_parameters[:q].present?
+    return unless solr_parameters[:q].present? && !(blacklight_params[:controller] == 'bookmarks')
     # Any search or filtering using a `q` parameter when transcripts are not present fails because
     # the transcript_tsim field does not get created. We need to only add the transcript searching
     # when transcripts are present.


### PR DESCRIPTION
The "Selected Items" page was returning a 400 error because the search service that populates the page runs through our SearchBuilder model and generates a `q` solr_parameter. This triggered the transcript search logic. Something about the `q` generated by the search service broke the query building for `transcript_tsim`, possibly that the search service generates `q="{!lucene}(#object_ids)"`. Checking if we are in the bookmark controller context and skipping the transcript searching allows us to bypass the error.

Related issue: #5922 