### PR TITLE
Set timelines without structure from full length of item

### DIFF
--- a/app/assets/javascripts/ramp_utils.js
+++ b/app/assets/javascripts/ramp_utils.js
@@ -108,6 +108,11 @@ function getTimelineScopes() {
   }
 
   let parent = currentStructureItem.closest('ul').closest('li');
+  if (parent.length === 0) {
+    let begin = 0;
+    let end = activeItem.times.end;
+    scopes[0].times = { begin: 0, end: end }
+  }
   while (parent.length > 0) {
     let next = parent.closest('ul').closest('li');
     let begin = 0;


### PR DESCRIPTION
Related issue: #5920 

Unstructured items were generating timelines based off of the current playhead for non-custom timelines when they should have been being set off the full length of the item. Adding a case for unstructured items to set the scope off the full length of the item takes care of it.