### PR TITLE
Don't show "Found in:" if no found in hits exist

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -23,7 +23,7 @@ module CatalogHelper
 
   def display_found_in(document)
     metadata_count = document.to_h.sum {|k,v| k =~ /metadata_tf_/ ? v : 0 }
-    transcript_count = document["sections"]["docs"].sum { |d| d["transcripts"]["docs"].sum {|s| s.sum {|k,v| k =~ /transcript_tf_/ ? v : 0 }}}
+    transcript_count = document["sections"]["docs"].sum { |d| Array(d.dig("transcripts", "docs")).sum {|s| s.sum {|k,v| k =~ /transcript_tf_/ ? v : 0 }}}
     section_count = document.to_h.sum {|k,v| k =~ /structure_tf_/ ? v : 0 }
 
     metadata = "metadata (#{metadata_count})" if metadata_count > 0

--- a/app/views/catalog/_index_media_object.html.erb
+++ b/app/views/catalog/_index_media_object.html.erb
@@ -23,8 +23,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       <dd class="blacklight-<%= field_presenter.key %> col-sm-9"><%= field_presenter.values.join(', ') %></dd>
     <% end %>
   <% end %>
-  <% if params[:q].present? %>
+  <% found_in_hits = display_found_in(doc_presenter.document) %>
+  <% if params[:q].present? && found_in_hits.present? %>
     <dt class="blacklight-found_in col-sm-3">Found in:</dt>
-    <dd class="blacklight-found_in col-sm-9"><%= display_found_in(doc_presenter.document) %></dd>
+    <dd class="blacklight-found_in col-sm-9"><%= found_in_hits %></dd>
   <% end %>
 </dl>

--- a/app/views/catalog/_index_media_object.html.erb
+++ b/app/views/catalog/_index_media_object.html.erb
@@ -23,8 +23,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <dd class="blacklight-<%= field_presenter.key %> col-sm-9"><%= field_presenter.values.join(', ') %></dd>
     <% end %>
   <% end %>
-  <% found_in_hits = display_found_in(doc_presenter.document) %>
-  <% if params[:q].present? && found_in_hits.present? %>
+  <% if params[:q].present? && (found_in_hits = display_found_in(doc_presenter.document)).present? %>
     <dt class="blacklight-found_in col-sm-3">Found in:</dt>
     <dd class="blacklight-found_in col-sm-9"><%= found_in_hits %></dd>
   <% end %>


### PR DESCRIPTION
This is an edge case but putting it in just to be safe.  
I found an example:  Search "avalon-dev.dlib.indiana.edu" on avalon-dev.dlib.indiana.edu .  There are currently 4 results which all have no found in hits in either metadata, structure, or transcript.