### PR TITLE
Don't add asset_host to assets in packs manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ COPY        --from=node-modules --chown=app:app /node_modules ./node_modules
 USER        app
 ENV         RAILS_ENV=production
 
-RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') bundle exec rake assets:precompile
+RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') SHAKAPACKER_ASSET_HOST='' bundle exec rake assets:precompile
 RUN         cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 
 


### PR DESCRIPTION
We set asset_host in config/initializers/default_host.rb for correctly generating links to assets, but when building the production docker image asset_host is set to localhost because the host configuration is unknown at this point.  The asset_host doesn't need to be written into the packs manifest and before setting asset_host in the initializers in this version of avalon previous versions had relative asset paths in the packs manifest.

See https://github.com/shakacode/shakapacker/blob/main/docs/troubleshooting.md#wrong-cdn-src-from-javascript_pack_tag