### PR TITLE
Make sure that ActiveStorage service is set

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,2 @@
+# This is set in config/application.rb but it seems like the settings aren't loaded at that point so doing it again here
+Rails.application.config.active_storage.service = (Settings&.active_storage&.service.presence || "local").to_sym


### PR DESCRIPTION
Avalon sets the ActiveStorage service based up the configuration in Settings in config/application.rb, but it appears that the Settings aren't always loaded by the time that config/application.rb runs.  Adding in this initializer ensures that the service in the Settings is configured in Rails.

Related to #5941 