### PR TITLE
Retain user entered playlist item title during playback

### DIFF
--- a/app/assets/javascripts/player_listeners.js
+++ b/app/assets/javascripts/player_listeners.js
@@ -20,6 +20,7 @@ let addToPlaylistListenersAdded = false;
 let firstLoad = true;
 let streamId = '';
 let isMobile = false;
+let isPlaying = false;
 
 /**
  * Bind action buttons on the page with player events and re-populate details
@@ -69,16 +70,20 @@ function addActionButtonListeners(player, mediaObjectId, sectionIds) {
     }
 
     /* Add player event listeners to update UI components on the page */
-    // Listen to 'timeupdate' event to udate add to playlist form when using while media is playing or manually seeking
-    player.player.on('timeupdate', () => {
+    // Listen to 'seeked' event to udate add to playlist form
+    player.player.on('seeked', () => {
       if (getActiveItem() != undefined) {
         activeTrack = getActiveItem(false);
         if (activeTrack != undefined) {
           streamId = activeTrack.streamId;
         }
-        disableEnableCurrentTrack(activeTrack, player.player.currentTime(), true, currentSectionLabel);
+        disableEnableCurrentTrack(activeTrack, player.player.currentTime(), isPlaying, currentSectionLabel);
       }
     });
+
+    player.player.on('play', () => { isPlaying = true; });
+
+    player.player.on('pause', () => { isPlaying = false; });
 
     /*
       Disable action buttons tied to player related information on player's 'loadstart' event which functions
@@ -273,7 +278,7 @@ function addToPlaylistListeners(sectionIds, mediaObjectId) {
     disableEnableCurrentTrack(
       activeTrack,
       currentTime,
-      false,
+      isPlaying,
       $('#playlist_item_title').val() || currentSectionLabel // Preserve user edits for the title when available
     );
     $('#current-section-name').text(currentSectionLabel);

--- a/app/assets/javascripts/ramp_utils.js
+++ b/app/assets/javascripts/ramp_utils.js
@@ -111,7 +111,7 @@ function getTimelineScopes() {
   if (parent.length === 0) {
     let begin = 0;
     let end = activeItem.times.end;
-    scopes[0].times = { begin: 0, end: end }
+    scopes[0].times = { begin: 0, end: end };
   }
   while (parent.length > 0) {
     let next = parent.closest('ul').closest('li');
@@ -209,10 +209,10 @@ function collapseMoreDetails() {
  * disable the option otherwise enable it.
  * @param {Object} activeTrack JSON object for the active timespans
  * @param {Number} currentTime player's playhead position
- * @param {Boolean} isSeeked flag to indicate player 'seeked' event happened/not
+ * @param {Boolean} isPlaying flag to inidicate media is playing or not
  * @param {String} sectionTitle name of the current section
  */
-function disableEnableCurrentTrack(activeTrack, currentTime, isSeeked, sectionTitle) {
+function disableEnableCurrentTrack(activeTrack, currentTime, isPlaying, sectionTitle) {
   // Return when add to playlist form is not visible
   let playlistForm = $('#add_to_playlist')[0];
   if (!playlistForm) {
@@ -222,7 +222,8 @@ function disableEnableCurrentTrack(activeTrack, currentTime, isSeeked, sectionTi
   if (activeTrack != undefined) {
     streamId = activeTrack.streamId;
     let { label, times, sectionLabel } = activeTrack;
-    let starttime = currentTime || times.begin;
+    // Update starttime when media is not playing
+    let starttime = isPlaying ? times.begin : currentTime || times.begin;
     $('#playlist_item_start').val(createTimestamp(starttime, true));
     $('#playlist_item_end').val(createTimestamp(times.end, true));
     title = `${sectionLabel} - ${label}`;
@@ -245,9 +246,7 @@ function disableEnableCurrentTrack(activeTrack, currentTime, isSeeked, sectionTi
       $('#playlistitem_scope_track').prop('checked', false);
     }
   }
-  // Only change the title when user actively seeked to a different timestamp,
-  // persisting the user changes to the field unless the active track is changed
-  if (isSeeked && sectionTitle != undefined) {
+  if (sectionTitle != undefined) {
     $('#playlist_item_title').val(title);
   }
 }
@@ -345,4 +344,10 @@ function resetAddToPlaylistForm() {
 function closeAlert() {
   $('#add_to_playlist_alert').slideUp();
   $('#add_to_playlist_form_group').slideDown();
+  // Set default selection in options list when alert is closed
+  if ($('#playlistitem_scope_track')[0].disabled) {
+    $('#playlistitem_scope_section').prop('checked', true);
+  } else {
+    $('#playlistitem_scope_track').prop('checked', true);
+  }
 }


### PR DESCRIPTION
Related issue: #5949 

Additional fix: reset default option selection in the add to playlist forn when alert is cleared after adding a playlist item.