### PR TITLE
Speed up section list migration by optimizing solr queries

### DIFF
--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -97,7 +97,7 @@ namespace :avalon do
     task media_object_section_list: :environment do
       error_ids = []
       mo_count = MediaObject.count
-      ids_to_migrate = ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", rows: mo_count).pluck("id")
+      ids_to_migrate = ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", fl: [:id], rows: mo_count).pluck("id")
       puts "Migrating #{ids_to_migrate.size} out of #{mo_count} Media Objects."
       ids_to_migrate.each do |id|
         MediaObject.find(id).save!(validate: false)
@@ -105,7 +105,7 @@ namespace :avalon do
         error_ids += [id]
         puts "Error migrating #{id}: #{error.message}"
       end
-      remaining_ids_count = ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", rows: mo_count).size
+      remaining_ids_count = ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", fl: [:id], rows: mo_count).size
       if error_ids.size > 0
         puts "Migration finished running but #{error_ids.size} Media Objects failed to migrate.  Try running the migration again."
       elsif remaining_ids_count > 0


### PR DESCRIPTION
Only return ids since we're only using ids.

Before:
```
Benchmark.measure { ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", rows: MediaObject.count).pluck("id") }
/srv/services/avalon_mco-stage-8130/avalon/shared/bundle/ruby/3.2.0/gems/rsolr-2.5.0/lib/rsolr/client.rb:218:in `rescue in execute': Connection refused - {:data=>"rows=196430&q=has_model_ssim%3AMediaObject+AND+NOT+section_list_ssim%3A%5B*+TO+*%5D&qt=standard", :method=>:post, :params=>{:wt=>:json}, :query=>"wt=json", :headers=>{"Content-Type"=>"application/x-www-form-urlencoded; charset=UTF-8"}, :path=>"select", :uri=>#<URI::HTTPS https://XXX.XXX/solr/avalon/select?wt=json>} (RSolr::Error::ConnectionRefused)
/N/dragon/home/app_avalon/.rbenv/versions/3.2.2/lib/ruby/3.2.0/openssl/buffering.rb:214:in `sysread_nonblock': Connection reset by peer (Faraday::ConnectionFailed)
/N/dragon/home/app_avalon/.rbenv/versions/3.2.2/lib/ruby/3.2.0/openssl/buffering.rb:214:in `sysread_nonblock': Connection reset by peer (Errno::ECONNRESET)
```

After:
```
Benchmark.measure { ActiveFedora::SolrService.query("has_model_ssim:MediaObject AND NOT section_list_ssim:[* TO *]", fl: [:id], rows: MediaObject.count).pluck("id") }
=> #<Benchmark::Tms:0x00007fe16e33ff70 @cstime=0.0, @cutime=0.0, @label="", @real=19.47818299755454, @stime=0.017693999999999876, @total=0.6288720000000005, @utime=0.6111780000000007>
```