### PR TITLE
Send Referer header when fetching HLS for frame extraction

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -597,7 +597,7 @@ class MasterFile < ActiveFedora::Base
     # Fixes https://github.com/avalonmediasystem/avalon/issues/3474
     target_location = File.basename(details[:location]).split('?')[0]
     target = File.join(Dir.tmpdir, target_location)
-    File.open(target,'wb') { |f| URI.open(details[:location]) { |io| f.write(io.read) } }
+    File.open(target,'wb') { |f| URI.open(details[:location], "Referer" => Rails.application.routes.url_helpers.root_url) { |io| f.write(io.read) } }
     return target, details[:offset]
   end
 


### PR DESCRIPTION
The Referer header is used by the streaming server to do an auth callback.  Without this header, the request fails with a 403 Forbidden.