### PR TITLE
Add setting for alternative rack tempfile directory

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,7 +57,7 @@ module Avalon
       end
     end
 
-    config.middleware.use TempfileFactory
+    config.middleware.insert_before 0, TempfileFactory
 
     config.active_storage.service = (Settings&.active_storage&.service.presence || "local").to_sym
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative 'boot'
+require_relative '../lib/tempfile_factory'
 
 require 'rails/all'
 require 'resolv-replace'
@@ -55,6 +56,8 @@ module Avalon
         resource '/master_files/*/search', headers: :any, methods: [:get]
       end
     end
+
+    config.middleware.use TempfileFactory
 
     config.active_storage.service = (Settings&.active_storage&.service.presence || "local").to_sym
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -123,3 +123,8 @@ derivative:
   allow_download: true
 # Maximum size for uploaded files in bytes (default is disabled)
 #max_upload_size: 2147483648 # Use :none or comment out to disable limit
+# Rack Multipart creates temporary files when processing multipart form data with a large payload.
+# If the default system /tmp directory is storage constrained, you can define an alternative here. 
+# Leave commented out to use the system default.
+# tempfile:
+#   location: ''

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,4 +127,4 @@ derivative:
 # If the default system /tmp directory is storage constrained, you can define an alternative here. 
 # Leave commented out to use the system default.
 # tempfile:
-#   location: ''
+#   location: '/tmp'

--- a/lib/tempfile_factory.rb
+++ b/lib/tempfile_factory.rb
@@ -1,0 +1,25 @@
+# Middleware to override the default Rack::Multipart tempfile factory: 
+# https://www.rubydoc.info/gems/rack/Rack/Multipart/Parser#TEMPFILE_FACTORY-constant
+class TempfileFactory
+  def initialize(app)
+    @app = app
+    return unless Settings.tempfile.present?
+    if Settings.tempfile&.location.present? && File.directory?(Settings.tempfile&.location) && File.writable?(Settings.tempfile&.location)
+      @tempfile_location = Settings.tempfile.location
+    else
+      logger = ActiveSupport::TaggedLogging.new(Logger.new(File.join(Rails.root, 'log', "#{Rails.env}.log")))
+      logger.tagged('Rack::Multipart', 'Tempfile').warn "#{Settings.tempfile.location} is not a diretory or not writable. Falling back to #{Dir.tmpdir}."
+    end
+  end
+
+  def call(env)
+    if @tempfile_location
+      env["rack.multipart.tempfile_factory"] = lambda { |filename, content_type| 
+        extension = ::File.extname(filename.gsub("\0", '%00'))[0, 129]
+        Tempfile.new(["RackMultipart", extension], @tempfile_location)
+      }
+    end
+
+    @app.call(env)
+  end
+end

--- a/lib/tempfile_factory.rb
+++ b/lib/tempfile_factory.rb
@@ -7,8 +7,7 @@ class TempfileFactory
     if Settings.tempfile&.location.present? && File.directory?(Settings.tempfile&.location) && File.writable?(Settings.tempfile&.location)
       @tempfile_location = Settings.tempfile.location
     else
-      logger = ActiveSupport::TaggedLogging.new(Logger.new(File.join(Rails.root, 'log', "#{Rails.env}.log")))
-      logger.tagged('Rack::Multipart', 'Tempfile').warn "#{Settings.tempfile.location} is not a diretory or not writable. Falling back to #{Dir.tmpdir}."
+      logger.warn("[Rack::Multipart] [Tempfile] #{Settings.tempfile.location} is not a diretory or not writable. Falling back to #{Dir.tmpdir}.")
     end
   end
 
@@ -21,5 +20,11 @@ class TempfileFactory
     end
 
     @app.call(env)
+  end
+
+  private
+
+  def logger
+    @logger ||= Logger.new(File.join(Rails.root, 'log', "#{Rails.env}.log"))
   end
 end

--- a/spec/lib/tempfile_factory_spec.rb
+++ b/spec/lib/tempfile_factory_spec.rb
@@ -1,0 +1,61 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe TempfileFactory do
+  class MockApp
+    def call(env)
+      [200, {}, env]
+    end
+  end
+
+  let(:file) { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'videoshort.mp4'), 'video/mp4')}
+  let(:env) { Rack::MockRequest.env_for('/', method: :post, params: file) }
+  let(:app) { MockApp.new }
+  subject { TempfileFactory.new(app) }
+
+  context "when an alternate directory is defined" do
+    it "sets `env['rack.multipart.tempfile_factory']`" do
+      without_partial_double_verification do
+        allow(Settings.tempfile).to receive(:location).and_return(Rails.root.join('spec', 'fixtures').to_s)
+        subject.instance_variable_set(:@tempfile_location, Settings.tempfile.location)
+        status, headers, response = subject.call(env)
+        expect(response).to include 'rack.multipart.tempfile_factory'
+      end
+    end
+  end
+
+  context "when an alternate directory is NOT defined" do
+    it "does not set `env['rack.multipart.tempfile_factory']`" do
+      without_partial_double_verification do
+        allow(Settings.tempfile).to receive(:location).and_return(nil)
+        subject.instance_variable_set(:@tempfile_location, Settings.tempfile.location)
+        status, headers, response = subject.call(env)
+        expect(response).to_not include 'rack.multipart.tempfile_factory'
+      end
+    end
+  end
+
+  context "when there is a problem with the defined alternate directory" do
+    it "does not set `env['rack.multipart.tempfile_factory']`" do
+      without_partial_double_verification do
+        allow(Settings.tempfile).to receive(:location).and_return('does not exist')
+        subject.instance_variable_set(:@tempfile_loaction, Settings.tempfile.location)
+        status, headers, response = subject.call(env)
+        expect(response).to_not include 'rack.multipart.tempfile_factory'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related issue: #5948 

The variable that needs to be set to override the default factory is part of the Rack `request.env` hash. Creating a custom middleware to handle injecting the lambda seemed to be the best approach. 

Having the error handling in the initialize method will log any issues once during app startup. The factory logic can be called multiple times during a single upload, so this seemed like the simplest way to get the error logged without triggering, potentially multiple times, on every upload in the application. It does run the risk of not being noticed that way though so I'm not sure which approach is actually better.