### PR TITLE
Ensure that thumbnails show during migration/reindex

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,8 +61,8 @@ module ApplicationHelper
   def image_for(document)
     master_file_id = document["section_id_ssim"].try :first
 
-    video_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('moving image') } rescue 0
-    audio_count = document["avalon_resource_type_ssim"].count{|m| m.start_with?('sound recording') } rescue 0
+    video_count = document["avalon_resource_type_ssim"].count{|m| m.downcase.start_with?('moving image') } rescue 0
+    audio_count = document["avalon_resource_type_ssim"].count{|m| m.downcase.start_with?('sound recording') } rescue 0
 
     if master_file_id
       if video_count > 0


### PR DESCRIPTION
In Avalon 7.8 we changed the value of avalon_resource_type_ssim to be all lowercase from titlized.  This causes a matching problem until a full reindex of MediaObjects (done with the section list migration) can be completed.  This small change matches both cases so should keep showing thumbnails for both pre and post migrated objects.  This can be removed in a future Avalon release.