### PR TITLE
Fix links in footer

### DIFF
--- a/app/assets/stylesheets/avalon/_footer.scss
+++ b/app/assets/stylesheets/avalon/_footer.scss
@@ -21,7 +21,7 @@
   width: 100%;
   min-height: 2.5rem;
   color: #999999;
-  z-index: -1000;
+  z-index: 0;
 }
 
 footer {

--- a/app/assets/stylesheets/avalon/_playlists.scss
+++ b/app/assets/stylesheets/avalon/_playlists.scss
@@ -176,6 +176,7 @@
 
 #Playlists_paginate {
   float: right;
+  z-index: 10;
 }
 
 /* Playlist copy modal */


### PR DESCRIPTION
In #5879, we set the footer to a negative z-index in order to get playlist paging to work. We did not catch/realize that negative z-indexes disable links, because elements are actually placed behind their containers. This PR sets the footer z-index explicitly to 0 to reenable the "Contact Us" and other links in the footer. It also sets the playlist pagination z-index to 10, so that its actions will not be covered by the footer again.