### PR TITLE
Get rid of nil ids when migrating to section lists

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -177,7 +177,7 @@ class MediaObject < ActiveFedora::Base
     return @section_ids if @section_ids
 
     # Do migration
-    self.section_ids = self.ordered_master_file_ids if self.section_list.nil?
+    self.section_ids = self.ordered_master_file_ids.compact if self.section_list.nil?
 
     return [] if self.section_list.nil?
     @section_ids = JSON.parse(self.section_list)


### PR DESCRIPTION
This fixes an edge case where ordered_master_file_ids contain nils.