### PR TITLE
Skip found in transcript if there are curly brackets in query

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -51,6 +51,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     return unless solr_parameters[:q].present? && SupplementalFile.with_tag('transcript').any? && !(blacklight_params[:controller] == 'bookmarks')
 
     terms = solr_parameters[:q].split
+    return if terms.any? { |term| term.match?(/[\{\}]/) }
     term_subquery = terms.map { |term| "transcript_tsim:#{RSolr.solr_escape(term)}" }.join(" OR ")
     solr_parameters[:defType] = "lucene"
     solr_parameters[:q] = "({!edismax v=\"#{RSolr.solr_escape(solr_parameters[:q])}\"}) {!join to=id from=isPartOf_ssim}{!join to=id from=isPartOf_ssim}#{term_subquery}"


### PR DESCRIPTION
On mco-staging, an Atom feed request was failing because the query was `other_identifier_sim:/GR[0-9]{8}/`. I eventually determined that it was not an issue with this being turned into `transcript_tsim:other_identifier_sim` and that it was not an issue with the Regex formatting of the query.

The behavior that I ultimately determined was the culprit was the curly braces. Any search conducted in Avalon that contains curly braces will fail, even though the search query is escaped for Solr. I do not know if this is a bug upstream in RSolr with the `solr_escape` method or if this is an issue in Solr itself where it is not respecting the escaping like it should in this context.

For now, skipping the transcript search if there are curly braces in the query seemed like the easiest approach.

Related issue: #5967 