### PR TITLE
Display video icon when video lacks thumbnail

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -246,6 +246,8 @@ class MasterFilesController < ApplicationController
     end
     if content
       send_data content, :filename => "#{params[:type]}-#{@master_file.id.split(':')[1]}", :disposition => :inline, :type => mimeType
+    elsif @master_file.is_video?
+      redirect_to ActionController::Base.helpers.asset_path('video_icon.png')
     else
       redirect_to ActionController::Base.helpers.asset_path('audio_icon.png')
     end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -373,6 +373,20 @@ describe MasterFilesController do
         expect(response.body).to eq('fake image content')
         expect(response.headers['Content-Type']).to eq('image/jpeg')
       end
+
+      context "video without thumbnail" do
+        subject(:mf) { FactoryBot.create(:master_file, :with_media_object) }
+        it "returns video_icon.png" do
+          expect(get :get_frame, params: { id: mf.id, type: 'thumbnail', size: 'bar' }).to redirect_to(ActionController::Base.helpers.asset_path('video_icon.png'))
+        end
+      end
+
+      context "audio" do
+        subject(:mf) { FactoryBot.create(:master_file, :audio, :with_media_object) }
+        it "returns audio_icon.png" do
+          expect(get :get_frame, params: { id: mf.id, type: 'thumbnail', size: 'bar' }).to redirect_to(ActionController::Base.helpers.asset_path('audio_icon.png'))
+        end
+      end
     end
 
     context 'read from solr' do


### PR DESCRIPTION
Related issue: #5955 

Audio items flow through the `#get_frame` logic when displaying in the index, so we still need the redirect to the audio icon.

**Merge after 7.8 release**