### PR TITLE
Match correct route

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Avalon
         resource '/avalon_marker/*', headers: :any, credentials: true, methods: [:get, :post, :put, :delete]
         resource '/media_objects/*/manifest*', headers: :any, methods: [:get]
         resource '/master_files/*/thumbnail', headers: :any, methods: [:get]
-        resource '/master_files/*/transcript/*/*', headers: :any, methods: [:get]
+        resource '/master_files/*/transcript/*', headers: :any, methods: [:get]
         resource '/master_files/*/structure.json', headers: :any, methods: [:get, :post, :delete]
         resource '/master_files/*/waveform.json', headers: :any, methods: [:get]
         resource '/master_files/*/*.m3u8', headers: :any, credentials: true, methods: [:get, :head]


### PR DESCRIPTION
This PR updates the rack-cors route being matched to what it is according to `rails routes`.  I think at one point it may have been the other way while development was happening on it but got changed and the rack-cors configuration didn't get updated.