### PR TITLE
Rebase Fedora 6 work onto 7.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           - POSTGRES_PASSWORD=password
       - image: fcrepo/fcrepo:6.4.0
         environment:
-          CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
+          CATALINA_OPTS: -Dfcrepo.autoversioning.enabled=false
       - image: zookeeper:3.9
         environment:
           ZOO_ADMINSERVER_ENABLED: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - image: avalonmediasystem/avalon:develop
         environment:
           - DATABASE_URL=postgresql://postgres@localhost:5432/postgres
-          - FEDORA_URL=http://localhost:8080/fcrepo/rest
+          - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@localhost:8080/fcrepo/rest
+          - FEDORA_BASE_PATH=/test
           - FEDORA_TIMEOUT=300
           - RAILS_ENV=test
       # Secondary container image on common network.
@@ -17,7 +18,7 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=avalon
           - POSTGRES_PASSWORD=password
-      - image: ualbertalib/docker-fcrepo4:4.7
+      - image: fcrepo/fcrepo:6.4.0
         environment:
           CATALINA_OPTS: '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC'
       - image: zookeeper:3.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
         default: 4
     docker:
       # Primary container image where all steps run.
-      - image: avalonmediasystem/avalon:7.5.0-dev-ruby3
+      - image: avalonmediasystem/avalon:7.6.0-dev
 
     working_directory: /home/app/avalon
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,10 @@ gem 'terser'
 gem 'shakapacker'
 
 # Core Samvera
-gem 'active-fedora', '~> 14.0', '>= 14.0.1'
-gem 'active_fedora-datastreams', '~> 0.5'
+#gem 'active-fedora', '~> 14.0', '>= 14.0.1'
+#gem 'active_fedora-datastreams', '~> 0.5'
+gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', branch: 'fedora6-cjcolvar-rebase'
+gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams.git', branch: 'fedora6_rebase'
 gem 'hydra-head', '~> 12.0'
 gem 'ldp', '~> 1.1.0'
 gem 'noid-rails', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/active_fedora-datastreams.git
-  revision: 3fe267ad5facbb2b66c74471ad7ed8732364711b
+  revision: 3e1b54f60e6d6316e114f608ee5c50c85d6598c6
   branch: fedora6_rebase
   specs:
     active_fedora-datastreams (0.5.0)
@@ -81,7 +81,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/active_fedora.git
-  revision: f242d45eefa5799c74a7dcebc37a7ab46a3b5760
+  revision: 3a8ff7b0384dba852ee70fc337c11c778afd7b58
   branch: fedora6-cjcolvar-rebase
   specs:
     active-fedora (14.0.1)
@@ -735,7 +735,7 @@ GEM
     rdf-turtle (3.2.1)
       ebnf (~> 2.3)
       rdf (~> 3.2)
-    rdf-vocab (3.2.3)
+    rdf-vocab (3.2.4)
       rdf (~> 3.2, >= 3.2.4)
     rdf-xsd (3.2.1)
       rdf (~> 3.2)
@@ -934,10 +934,11 @@ GEM
     sxp (1.2.3)
       matrix (~> 0.4)
       rdf (~> 3.2)
+    temple (0.10.0)
     terser (1.2.0)
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
-    tilt (2.0.11)
+    tilt (2.1.0)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,37 @@ GIT
       ims-lti
       omniauth
 
+GIT
+  remote: https://github.com/samvera-labs/active_fedora-datastreams.git
+  revision: 3fe267ad5facbb2b66c74471ad7ed8732364711b
+  branch: fedora6_rebase
+  specs:
+    active_fedora-datastreams (0.5.0)
+      active-fedora (>= 11.0.0.pre)
+      activemodel (>= 5.2)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (~> 3.2)
+      rdf-rdfa (= 3.2.0)
+      rdf-rdfxml (~> 3.2)
+
+GIT
+  remote: https://github.com/samvera/active_fedora.git
+  revision: f242d45eefa5799c74a7dcebc37a7ab46a3b5760
+  branch: fedora6-cjcolvar-rebase
+  specs:
+    active-fedora (14.0.1)
+      active-triples (>= 0.11.0, < 2.0.0)
+      activemodel (>= 5.1)
+      activesupport (>= 5.1)
+      deprecation
+      faraday (>= 2.0)
+      faraday-encoding (>= 0.0.5)
+      faraday-follow_redirects
+      ldp (>= 0.7.0, < 2)
+      rsolr (>= 1.1.2, < 3)
+      ruby-progressbar (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -113,16 +144,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active-fedora (14.0.1)
-      active-triples (>= 0.11.0, < 2.0.0)
-      activemodel (>= 5.1)
-      activesupport (>= 5.1)
-      deprecation
-      faraday (>= 1.0)
-      faraday-encoding (>= 0.0.5)
-      ldp (>= 0.7.0, < 2)
-      rsolr (>= 1.1.2, < 3)
-      ruby-progressbar (~> 1.0)
     active-triples (1.2.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -138,13 +159,6 @@ GEM
     active_encode (1.2.2)
       addressable (~> 2.8)
       rails
-    active_fedora-datastreams (0.5.0)
-      active-fedora (>= 11.0.0.pre)
-      activemodel (>= 5.2)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf (~> 3.2)
-      rdf-rdfxml (~> 3.2)
     activejob (7.0.8.4)
       activesupport (= 7.0.8.4)
       globalid (>= 0.3.6)
@@ -425,6 +439,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-encoding (0.0.5)
       faraday
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     fastimage (2.2.7)
     fcrepo_wrapper (0.9.0)
@@ -979,11 +995,11 @@ PLATFORMS
 
 DEPENDENCIES
   about_page!
-  active-fedora (~> 14.0, >= 14.0.1)
+  active-fedora!
   active_annotations (~> 0.4)
   active_elastic_job
   active_encode (>= 1.2.2)
-  active_fedora-datastreams (~> 0.5)
+  active_fedora-datastreams!
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -187,15 +187,6 @@ class MediaObject < ActiveFedora::Base
     !avalon_publisher.blank?
   end
 
-  alias_method :'_master_files=', :'master_files='
-  define_attribute_methods :master_files
-  def master_files=(mfs)
-    master_files_will_change!
-    ids = mfs.map(&:id).reject(&:blank?)
-    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, ids)
-    self._master_files = mfs
-  end
-
   def destroy
     # attempt to stop the matterhorn processing job
     self.sections.each(&:stop_processing!)

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -182,6 +182,19 @@ class MediaObject < ActiveFedora::Base
     return [] if self.section_list.nil?
     @section_ids = JSON.parse(self.section_list)
   end
+  
+  def published?
+    !avalon_publisher.blank?
+  end
+
+  alias_method :'_master_files=', :'master_files='
+  define_attribute_methods :master_files
+
+  def master_files=(mfs)
+    master_files_will_change!
+    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, mfs.map(&:id))
+    self._master_files = mfs
+  end
 
   def destroy
     # attempt to stop the matterhorn processing job

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -189,10 +189,10 @@ class MediaObject < ActiveFedora::Base
 
   alias_method :'_master_files=', :'master_files='
   define_attribute_methods :master_files
-
   def master_files=(mfs)
     master_files_will_change!
-    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, mfs.map(&:id))
+    ids = mfs.map(&:id).reject(&:blank?)
+    self.ldp_source.graph.set_value(::RDF::Vocab::DC.hasPart, ids)
     self._master_files = mfs
   end
 

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -137,6 +137,8 @@ ActiveFedora::ChangeSet.class_eval do
         if object.association(key.to_sym).is_a? ActiveFedora::Associations::Association
           # ActiveFedora::Reflection::RDFPropertyReflection
           predicate = object.association(key.to_sym).reflection.predicate
+          # ActiveFedora::Reflection::IndirectlyContainsReflection for ordered_aggregation
+          predicate ||= object.association(key.to_sym).reflection&.options[:has_member_relation]
           values = graph.query({ subject: object.rdf_subject, predicate: predicate })
           result[predicate] = values if predicate.present?
         elsif object.class.properties.keys.include?(key)

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -92,6 +92,13 @@ Hydra::AccessControls::Permissions.module_eval do
 end
 # End of overrides for AccessControl dirty tracking and autosaving
 
+class UUIDIdentifierService
+  def mint
+    SecureRandom.uuid
+  end
+end
+ActiveFedora::Base.identifier_service_class = UUIDIdentifierService
+
 # Override ActiveFedora::Associations::Builder::Orders::FixFirstLast to remove attempts to set first and last from list_source on saving
 ActiveFedora::Associations::Builder::Orders::FixFirstLast.module_eval do
   def save(*args)

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -167,30 +167,32 @@ ActiveFedora::Reflection::IndirectlyContainsReflection.class_eval do
 end
 
 ActiveFedora::Associations::IndirectlyContainsAssociation.class_eval do
-      def insert_record(record, force = true, validate = true)
-        container.save!
-        if force
-          record.save!
-        else
-          return false unless record.save(validate: validate)
-        end
+  def insert_record(record, force = true, validate = true)
+    container.save!
+    if force
+      record.save!
+    else
+      return false unless record.save(validate: validate)
+    end
 
-        save_through_record(record)
+    save_through_record(record)
 
-        owner.send(:attribute_will_change!, reflection.name)
-        owner.resource << ::RDF::Statement(owner.resource, reflection.predicate, record.id)
-        owner.save
+    # Add triples to the parent object
+    owner.send(:attribute_will_change!, reflection.name)
+    owner.resource << ::RDF::Statement(owner.resource, reflection.predicate, record.id)
+    owner.save
 
-        true
-      end
+    true
+  end
 
   private
 
-        def delete_record(record)
-          record_proxy_finder.find(record).delete
+    def delete_record(record)
+      record_proxy_finder.find(record).delete
 
-          owner.send(:attribute_will_change!, reflection.name)
-          owner.resource.delete({ predicate: reflection.predicate, object: record.id})
-          owner.save
-        end
+      # Remove triples from the parent object
+      owner.send(:attribute_will_change!, reflection.name)
+      owner.resource.delete({ predicate: reflection.predicate, object: record.id})
+      owner.save
+    end
 end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -165,3 +165,32 @@ ActiveFedora::Reflection::IndirectlyContainsReflection.class_eval do
     options[:has_member_relation] || ::RDF::Vocab::LDP.contains
   end
 end
+
+ActiveFedora::Associations::IndirectlyContainsAssociation.class_eval do
+      def insert_record(record, force = true, validate = true)
+        container.save!
+        if force
+          record.save!
+        else
+          return false unless record.save(validate: validate)
+        end
+
+        save_through_record(record)
+
+        owner.send(:attribute_will_change!, reflection.name)
+        owner.resource << ::RDF::Statement(owner.resource, reflection.predicate, record.id)
+        owner.save
+
+        true
+      end
+
+  private
+
+        def delete_record(record)
+          record_proxy_finder.find(record).delete
+
+          owner.send(:attribute_will_change!, reflection.name)
+          owner.resource.delete({ predicate: reflection.predicate, object: record.id})
+          owner.save
+        end
+end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -137,8 +137,6 @@ ActiveFedora::ChangeSet.class_eval do
         if object.association(key.to_sym).is_a? ActiveFedora::Associations::Association
           # ActiveFedora::Reflection::RDFPropertyReflection
           predicate = object.association(key.to_sym).reflection.predicate
-          # ActiveFedora::Reflection::IndirectlyContainsReflection for ordered_aggregation
-          predicate ||= object.association(key.to_sym).reflection&.options[:has_member_relation]
           values = graph.query({ subject: object.rdf_subject, predicate: predicate })
           result[predicate] = values if predicate.present?
         elsif object.class.properties.keys.include?(key)

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -103,6 +103,10 @@ Rails.application.config.to_prepare do
 	ng_xml.xpath(*args)
       end
     end
+
+    sp.config IndexedFile do
+      self.defaults = { original_name: nil }
+    end
   end
 
   SpeedyAF::Base.class_eval do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,14 @@ services:
     environment:
       - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
     networks:
+      external:
       internal:
+    ports:
+      - '8080:8080'
     ulimits:
       nofile:
-        soft: 65536
-        hard: 65536
+        soft: "65536"
+        hard: "65536"
   fedora-test:
     <<: *fedora
     volumes: []
@@ -56,6 +59,10 @@ services:
       - /opt/solr/avalon_conf
     networks:
       internal:
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
   solr-test:
     <<: *solr
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
     volumes: []
 
   fedora: &fedora
-    image: avalonmediasystem/fedora:4.7.5
+    image: fcrepo/fcrepo:6.4.0
     depends_on:
       - db
     volumes:
       - fedora:/data
     environment:
-      - JAVA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json -Dfcrepo.home=/data
+      - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
     networks:
       internal:
     ulimits:
@@ -102,7 +102,8 @@ services:
       - DATABASE_URL=postgres://postgres:password@db/avalon
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - FEDORA_NAMESPACE=avalon
-      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
+      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fcrepo/rest
+      - FEDORA_BASE_PATH=/test
       - RAILS_ENV=development
       - RAILS_ADDITIONAL_HOSTS=avalon
       - SETTINGS__REDIS__HOST=redis

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1274,8 +1274,8 @@ describe MediaObject do
         expect(mo.section_list).not_to eq nil
         expect(mo.sections).not_to eq mo.ordered_master_files.to_a
         expect(mo.section_ids).to eq [section.id, section2.id, new_section.id]
-        expect(mo.master_file_ids).to eq mo.section_ids
-        expect(mo.master_files).to eq mo.sections
+        expect(mo.master_file_ids).to match_array mo.section_ids
+        expect(mo.master_files).to match_array mo.sections
       end
     end
   end


### PR DESCRIPTION
@cjcolvar's notes from previous PR:

>It might be possible that these changes to Avalon would still work with Fedora 4 without the overrides.  That might be useful for implementors who aren't ready to upgrade Fedora but want to upgrade their avalon.
>
>TODO:
>- [x] Manual testing to ensure it really works
>- [ ] Write passing tests in ActiveFedora for Fedora 4 to prove hasPart triples were automatically managed before
>- [ ] Port tests to ActiveFedora for Fedora 6 and port code that adds management of hasPart triples
>- [ ] Port rest of overrides to Fedora 6 ActiveFedora branch
>- [ ] Remove overrides from initializer

Supersedes #5363 