### PR TITLE
Use auto-submitting form to workaround omniauth2 requirement for only POST requests to auth endpoints

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,10 +15,7 @@
 class Users::SessionsController < Devise::SessionsController
   def new
     if Avalon::Authentication::VisibleProviders.length == 1 && params[:admin].blank?
-      omniauth_params = params.reject { |k,v| ['controller','action'].include?(k) }
-      omniauth_params.permit!
-      login_path = user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider], omniauth_params)
-      redirect_to login_path
+      render :omniauth_new, layout: false
     else
       super
     end

--- a/app/views/users/sessions/omniauth_new.html.erb
+++ b/app/views/users/sessions/omniauth_new.html.erb
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <%= csrf_meta_tags %>
+</head>
+<body onLoad="doSave()">
+<%= button_to 'Login', user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider], params.slice(:provider).permit!), form: { name: 'form1' } %>
+</body>
+<script>
+  function doSave() { document.form1.submit() }
+</script>
+</html>


### PR DESCRIPTION
Necessary for setting up omniauth strategies other than identity (local password).

Part of #6005 