### PR TITLE
Reduce number of solr calls by preemptively loading reflections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', git: 'https://github.com/samvera-labs/samvera-persona.git', branch: 'rails_7-2'
-gem 'speedy-af', '~> 0.3'
+gem 'speedy-af', git: 'https://github.com/samvera-labs/speedy_af.git', branch: 'empty_reflection'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/samvera-persona.git
-  revision: 879fed8e7a3a86fb28eb1dba46bcf926a18dd330
+  revision: ce6ada95684fe1c5487e8ee5d698b8529c69bf75
   branch: rails_7-2
   specs:
     samvera-persona (0.4.1)
@@ -77,6 +77,14 @@ GIT
       devise_invitable (>= 1.7, < 3.0)
       paranoia (~> 3.0)
       pretender
+
+GIT
+  remote: https://github.com/samvera-labs/speedy_af.git
+  revision: 223abe9e2a7cdc68b033398bf69922523aeff47e
+  branch: empty_reflection
+  specs:
+    speedy-af (0.3.0)
+      activesupport (> 5.2)
 
 GIT
   remote: https://github.com/samvera/active_fedora.git
@@ -931,9 +939,6 @@ GEM
       nokogiri
       stomp
       xml-simple
-    speedy-af (0.3.0)
-      active-fedora (>= 11.0.0)
-      activesupport (> 5.2)
     sprockets (3.7.3)
       base64
       concurrent-ruby (~> 1.0)
@@ -1137,7 +1142,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.9)
   simplecov
   solr_wrapper (>= 0.16)
-  speedy-af (~> 0.3)
+  speedy-af!
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -370,10 +370,10 @@ protected
   end
 
   def set_masterfile_proxy
-    if params[:id].blank? || SpeedyAF::Proxy::MasterFile.find(params[:id]).nil?
+    @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id], load_reflections: true)
+    if params[:id].blank? || @master_file.nil?
       flash[:notice] = "MasterFile #{params[:id]} does not exist"
     end
-    @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id])
   end
 
   # return deflated waveform content. deflate only if necessary


### PR DESCRIPTION
This works around an inefficiency in SpeedyAF where loading reflections lazily doesn't get cached.

This reduces the number of solr calls for HLS manifest generation on mco-staging from about 10 to 4 saving 1-2 seconds.

Part of #5993 