### PR TITLE
Machine gen icon for supplemental files

### DIFF
--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -96,7 +96,6 @@ $('.supplemental-file-form')
     isMachineGen
       ? $row.find('.fa-laptop').removeClass('d-none')
       : $row.find('.fa-laptop').addClass('d-none');
-    $row.find('.fa-laptop').removeClass('d-none');
     $row.find('.icon-success').removeClass('d-none');
     $row.find('.visible-inline').addClass('alert');
   })

--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -73,6 +73,8 @@ $('.supplemental-file-form')
   .on('ajax:success', (event, data, status, xhr) => {
     var $row = $(event.currentTarget.parentElement);
     const { masterfileId, fileId } = event.currentTarget.dataset;
+    // Get machine-generated checkbox input on form submission
+    var isMachineGen = $row.find(`input[id="machine_generated_${fileId}"]`)[0].checked;
 
     // Set the label to the new value
     var newLabel = $row
@@ -90,6 +92,11 @@ $('.supplemental-file-form')
 
     // Show flash message for success
     $row.find('.message-content').html('Successfully updated.');
+    // Show/hide icon based on the updated machine-generated form check
+    isMachineGen
+      ? $row.find('.fa-laptop').removeClass('d-none')
+      : $row.find('.fa-laptop').addClass('d-none');
+    $row.find('.fa-laptop').removeClass('d-none');
     $row.find('.icon-success').removeClass('d-none');
     $row.find('.visible-inline').addClass('alert');
   })

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -935,6 +935,9 @@ h5.card-title {
         .form-group {
           margin-bottom: 0.2rem;
         }
+        .fa-laptop {
+          display: none;
+        }
         display: flex;
       }
       margin-top: 0.75rem;

--- a/app/views/media_objects/_supplemental_files_list.html.erb
+++ b/app/views/media_objects/_supplemental_files_list.html.erb
@@ -98,6 +98,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       </small>
       <div class="btn-toolbar float-right">
         <%# Update button %>
+        <i class="fa fa-laptop align-content-center<%= file.machine_generated? ? '' : ' d-none' %>" title="Machine generated file"></i>
         <%= button_tag name: 'edit_label', class:'btn btn-outline btn-sm edit_label display-item', type: 'button' do %>
           <i class="fa fa-edit" title="Edit"></i> <span class="sm-hidden">Edit</span>
         <% end %>


### PR DESCRIPTION
Related issue: #5228

Displays a machine icon for machine-generated transcripts and shows tool-tip when mouse pointer is on top of the icon:
![Screenshot 2024-08-28 at 3 41 54 PM](https://github.com/user-attachments/assets/76d64b48-2ba4-45ea-853c-275b73b47ab8)

When form is opened the icon doesn't display:
![Screenshot 2024-08-28 at 3 42 11 PM](https://github.com/user-attachments/assets/bc513aac-d781-4744-9966-6983eb1345de)

Icon is shown/hidden on form submit:

https://github.com/user-attachments/assets/2f3ade16-388b-41b4-b3b9-7e00f6f26032
