### PR TITLE
Enable rubyconfig to work with array ENV variables

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -28,4 +28,7 @@ Config.setup do |config|
 
   # Parse numeric values as integers instead of strings.
   config.env_parse_values = true
+
+  # Allow env variables for array settings
+  config.env_parse_arrays = true
 end


### PR DESCRIPTION
With this flag set environment variables with sequential suffixes can be used to set array Settings.

For example,
```
export SETTINGS__BIB_RETRIEVER__DEFAULT__QUERY__0="cql.serverChoice='^C%{bib_id}'"
export SETTINGS__BIB_RETRIEVER__DEFAULT__QUERY__1="cql.serverChoice exact '%{bib_id}'"
export SETTINGS__BIB_RETRIEVER__DEFAULT__QUERY__2="cql.serverChoice='%{bib_id}'"
```
will result in
```
Settings.bib_retriever.default.query
# ["cql.serverChoice='^C%{bib_id}'", "cql.serverChoice exact '%{bib_id}'", "cql.serverChoice='%{bib_id}'"]
```