### PR TITLE
Improve thumbnail load times

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
 
     if master_file_id
       if video_count > 0
-        thumbnail_master_file_path(master_file_id)
+        document["sections"][:docs].first["thumbnail"][:docs].first["content_ss"]
       elsif audio_count > 0
         asset_path('audio_icon.png')
       else
@@ -86,9 +86,14 @@ module ApplicationHelper
   end
 
   def avalon_image_tag(document, image_options)
-    image_url = image_for(document)
+    image = image_for(document)
     link_to(media_object_path(document[:id]), {class: 'result-thumbnail'}) do
-      image_url.present? ? image_tag(image_url) : image_tag('no_icon.png')
+      return image_tag('no_icon.png') unless image.present?
+      if image.start_with?(root_url)
+        image_tag(image)
+      else
+        image_tag("data:image/jpg;base64,#{image}")
+      end
     end
   end
 

--- a/app/models/indexed_file.rb
+++ b/app/models/indexed_file.rb
@@ -26,10 +26,11 @@ class IndexedFile < ActiveFedora::File
     return solr_doc unless opts[:external_index]
     solr_doc.tap do |doc|
       doc[:id] = id
+      doc[:isPartOf_ssi] = id.gsub(/\/.*/, '')
       doc[:has_model_ssim] = self.class.name
       doc[:uri_ss] = uri.to_s
       doc[:mime_type_ss] = mime_type
-      doc[:original_name_ss] = original_name
+      doc[:original_name_ssi] = original_name
       doc[:size_is] = content.present? ? content.size : 0
       doc[:'empty?_bs'] = content.blank?
       if index_content?

--- a/app/views/catalog/_thumbnail_media_object.html.erb
+++ b/app/views/catalog/_thumbnail_media_object.html.erb
@@ -15,9 +15,13 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 
 <div class="col-md-12 col-lg-4 row">
-  <% if image_url = image_for(document) %>
+  <% if image = image_for(document) %>
     <%= link_to(media_object_path(document[:id]), aria: { hidden: 'true'}, tabindex: -1, class: 'result-thumbnail') do %>
-      <%= image_tag( image_url, alt: "" ) %>
+      <% if image.start_with?(root_url) %>
+        <%= image_tag( image, alt: "") %>
+      <% else %>
+        <%= image_tag( "data:image/jpg;base64,#{image}", alt: "" ) %>
+      <% end %>
     <% end %>
   <% else %>
     <%= image_tag 'no_icon.png', alt: "", class: 'result-thumbnail no-icon' %>


### PR DESCRIPTION
IndexedFiles must be reindexed for this work to have an effect. Without reindexing all thumbnails will display as the missing content icon.

Improvements needed:
- Populate with icon data instead of `asset_path` when item is missing thumbnail
- Because of being in the term frequency method, the work as it stands breaks the browse page. 
    - Move thumbnail logic out of term frequency method and into its own method
    - Or rework the checks and search logic so that the term frequency method runs without causing an error when `solr_parameters[:q]` is missing.
- This work probably needs an explicit fallback for when a video is missing a thumbnail or `content_ss` is otherwise unable to be pulled from solr.

Investigation needed:
- Does this affect overall search load times? Need to test with larger datasets.
- Ensure that the thumbnails are returned for both browse and search, and that this doesn't break other routes that run through the search builder/catalog controller.
- Is there a way to return the thumbnail data without needing a reindex?