### PR TITLE
Reduce max rows in solr queries to 100_000 to improve solr performance

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -329,7 +329,7 @@ class MediaObject < ActiveFedora::Base
         fill_in_solr_fields_that_need_sections(solr_doc)
       elsif id.present? # avoid error in test suite
         # Fill in other identifier so these values aren't stripped from the solr doc while waiting for the background job
-        mf_docs = ActiveFedora::SolrService.query("isPartOf_ssim:#{id}", rows: 1_000_000)
+        mf_docs = ActiveFedora::SolrService.query("isPartOf_ssim:#{id}", rows: 100_000)
         solr_doc["other_identifier_sim"] +=  mf_docs.collect { |h| h['identifier_ssim'] }.flatten
       end
 
@@ -470,7 +470,7 @@ class MediaObject < ActiveFedora::Base
       # in the section_list
       return [] unless section_ids.present?
       query = "id:" + section_ids.join(" id:")
-      @section_docs ||= ActiveFedora::SolrService.query(query, rows: 1_000_000)
+      @section_docs ||= ActiveFedora::SolrService.query(query, rows: 100_000)
     end
 
     def calculate_duration

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -115,4 +115,7 @@ Rails.application.config.to_prepare do
       @real_object
     end
   end
+
+  # Reduce from 10_000_000 to reduce solr QTimes from triple digits to single digits
+  SpeedyAF::Base::SOLR_ALL = 100_000
 end


### PR DESCRIPTION
Making this change particularly in SpeedyAF reduces solr queries with triple-digit QTimes to single digits.  The overall page load for a single section item is about 20% faster.  This change should hopefully reduce load on solr and allow it to scale more.

`100_000` should still be plenty large for any of these queries as they are for children of media objects or sections.  If we start using SpeedyAF for gathering the members of a collection then we may need to consider increasing this number again.  FWIW `1_000_000` rows increased QTimes to double digits.