### PR TITLE
Bump version of omniauth-saml and ruby-saml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'net-ldap'
 gem 'omniauth', '~> 2.0'
 gem 'omniauth-identity', '>= 2.0.0'
 gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'avalon-r4'
-gem "omniauth-saml", "~> 2.0"
+gem "omniauth-saml", "~> 2.0", ">= 2.2.1"
 
 # Media Access & Transcoding
 gem 'active_encode', '>= 1.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,9 +655,9 @@ GEM
     omniauth-identity (3.0.9)
       bcrypt
       omniauth
-    omniauth-saml (2.1.0)
-      omniauth (~> 2.0)
-      ruby-saml (~> 1.12)
+    omniauth-saml (2.2.1)
+      omniauth (~> 2.1)
+      ruby-saml (~> 1.17)
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.6.0)
@@ -872,7 +872,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.13.0)
-    ruby-saml (1.16.0)
+    ruby-saml (1.17.0)
       nokogiri (>= 1.13.10)
       rexml
     rubyzip (1.3.0)
@@ -1102,7 +1102,7 @@ DEPENDENCIES
   omniauth (~> 2.0)
   omniauth-identity (>= 2.0.0)
   omniauth-lti!
-  omniauth-saml (~> 2.0)
+  omniauth-saml (~> 2.0, >= 2.2.1)
   parallel
   pg
   pry-byebug


### PR DESCRIPTION
This deals with a security issue in these dependencies.  SAML auth is not configured/enabled by default so this is not an issue with out of the box avalon.