### PR TITLE
Bump version of webrick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1002,7 +1002,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
For security fix.  We only use webrick in local development so I don't think we're vulnerable.