### PR TITLE
Prevent bad encode status from breaking encode record pages

### DIFF
--- a/app/controllers/encode_records_controller.rb
+++ b/app/controllers/encode_records_controller.rb
@@ -71,7 +71,7 @@ class EncodeRecordsController < ApplicationController
       "recordsFiltered": filtered_records_total,
       "data": @encode_records.collect do |encode|
         encode_presenter = EncodePresenter.new(encode)
-        encode_status = encode_presenter.status.downcase
+        encode_status = encode_presenter.status&.downcase
         unless encode_status == 'completed'
           progress_class = 'progress-bar-striped'
         end
@@ -117,7 +117,7 @@ class EncodeRecordsController < ApplicationController
 
     def format_progress(presenter)
       # Set progress = 100.0 when job failed
-      if presenter.status.casecmp("failed") == 0
+      if presenter.status&.casecmp("failed") == 0
         100.0
       else
         presenter.progress

--- a/app/presenters/encode_presenter.rb
+++ b/app/presenters/encode_presenter.rb
@@ -29,7 +29,7 @@ class EncodePresenter
   delegate :id, :adapter, :display_title, :master_file_id, :media_object_id, :created_at, :progress, to: :encode_record
 
   def status
-    @encode_record.state.capitalize
+    @encode_record.state&.capitalize
   end
 
   def global_id

--- a/spec/controllers/encode_records_controller_spec.rb
+++ b/spec/controllers/encode_records_controller_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe EncodeRecordsController, type: :controller do
         expect(response).to render_template('errors/restricted_pid')
       end
     end
+
+    context "when state is nil" do
+      let(:encode_record_test) { FactoryBot.create(:encode_record, state: nil) }
+      it "returns a success response" do
+        get :index, params: {}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "GET #show" do
@@ -75,8 +83,16 @@ RSpec.describe EncodeRecordsController, type: :controller do
       let(:user) { FactoryBot.create(:user) }
 
       it "redirects to restricted content page" do
-        get :index, params: {}, session: valid_session
+        get :show, params: { id: encode_record_test.to_param }, session: valid_session
         expect(response).to render_template('errors/restricted_pid')
+      end
+    end
+
+    context "when state is nil" do
+      let(:encode_record_test) { FactoryBot.create(:encode_record, state: nil) }
+      it "returns a success response" do
+        get :show, params: { id: encode_record_test.to_param }, session: valid_session
+        expect(response).to be_successful
       end
     end
   end
@@ -132,6 +148,20 @@ RSpec.describe EncodeRecordsController, type: :controller do
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['data'][0][3]).to eq('Title 998')
         expect(parsed_response['data'][1][3]).to eq('Title 997')
+      end
+    end
+
+    context "when state is nil" do
+      let(:params) { { start: 0, length: 20, order: { '0': { column: 3, dir: 'asc' } }, search: { value: '' } } }
+      before do
+        FactoryBot.create(:encode_record, state: nil)
+      end
+
+      it "returns a success response" do
+        post :paged_index, format: 'json', params: params, session: valid_session
+        expect(response).to be_successful
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['recordsTotal']).to eq(12)
       end
     end
   end


### PR DESCRIPTION
![Screenshot_20241007_150959](https://github.com/user-attachments/assets/9a46eff8-e6b8-456c-9455-62de3a8cd114)


Related issue: #6018 