### PR TITLE
OneDrive integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git"
 gem "omniauth-saml", "~> 2.0", ">= 2.2.1"
 
 # Media Access & Transcoding
-gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git", branch: 'main'
+gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git", branch: 'output_label_parsing'
 gem 'audio_waveform-ruby', '~> 1.0.7', require: 'audio_waveform'
 gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'sharepoint_integration'
 gem 'fastimage'

--- a/Gemfile
+++ b/Gemfile
@@ -76,9 +76,9 @@ gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git"
 gem "omniauth-saml", "~> 2.0", ">= 2.2.1"
 
 # Media Access & Transcoding
-gem 'active_encode', '>= 1.2.2'
+gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git", branch: 'main'
 gem 'audio_waveform-ruby', '~> 1.0.7', require: 'audio_waveform'
-gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'v1.4-avalon'
+gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'sharepoint_integration'
 gem 'fastimage'
 gem 'rest-client', '~> 2.0'
 gem 'roo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/browse-everything.git
-  revision: cbc4534255ab2634a18552adae12d6e1de3061c3
+  revision: be4bbdf47df0090a40bbce7bf5678e7c8fe68130
   branch: sharepoint_integration
   specs:
     browse-everything (1.4.0)
@@ -66,6 +66,15 @@ GIT
     omniauth-lti (0.0.2)
       ims-lti
       omniauth
+
+GIT
+  remote: https://github.com/samvera-labs/active_encode.git
+  revision: 49ab76ab6b2593ed250530aa3659dd5c8f5adb25
+  branch: output_label_parsing
+  specs:
+    active_encode (1.2.2)
+      addressable (~> 2.8)
+      rails
 
 GIT
   remote: https://github.com/samvera-labs/active_fedora-datastreams.git
@@ -472,9 +481,9 @@ GEM
       retriable (>= 2.0, < 4.a)
     google-apis-drive_v3 (0.57.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-env (2.2.0)
+    google-cloud-env (2.2.1)
       faraday (>= 1.0, < 3.a)
-    googleauth (1.11.0)
+    googleauth (1.11.1)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)
       jwt (>= 1.4, < 3.0)
@@ -550,7 +559,7 @@ GEM
       rack (>= 2.2, < 4)
       rdf (~> 3.3)
       rexml (~> 3.2)
-    jwt (2.9.1)
+    jwt (2.9.3)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,8 +33,8 @@ GIT
 
 GIT
   remote: https://github.com/avalonmediasystem/browse-everything.git
-  revision: 8fe3f9150fbc17ae84a36888f70f37fbd48f6e44
-  branch: v1.4-avalon
+  revision: cbc4534255ab2634a18552adae12d6e1de3061c3
+  branch: sharepoint_integration
   specs:
     browse-everything (1.4.0)
       addressable (~> 2.5)
@@ -230,13 +230,13 @@ GEM
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.968.0)
+    aws-partitions (1.976.0)
     aws-record (2.13.2)
       aws-sdk-dynamodb (~> 1, >= 1.85.0)
     aws-sdk-cloudfront (1.96.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-core (3.202.0)
+    aws-sdk-core (3.206.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.9)
@@ -247,8 +247,8 @@ GEM
     aws-sdk-elastictranscoder (1.57.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-kms (1.88.0)
-      aws-sdk-core (~> 3, >= 3.201.0)
+    aws-sdk-kms (1.91.0)
+      aws-sdk-core (~> 3, >= 3.205.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-rails (4.0.3)
       actionmailbox (>= 7.0.0)
@@ -261,8 +261,8 @@ GEM
       aws-sessionstore-dynamodb (~> 2)
       concurrent-ruby (~> 1.3, >= 1.3.1)
       railties (>= 7.0.0)
-    aws-sdk-s3 (1.159.0)
-      aws-sdk-core (~> 3, >= 3.201.0)
+    aws-sdk-s3 (1.162.0)
+      aws-sdk-core (~> 3, >= 3.205.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-ses (1.69.0)
@@ -281,7 +281,7 @@ GEM
       aws-sdk-dynamodb (~> 1, >= 1.85.0)
       rack (>= 2, < 4)
       rack-session (>= 1, < 3)
-    aws-sigv4 (1.9.1)
+    aws-sigv4 (1.10.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -470,7 +470,7 @@ GEM
       mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
-    google-apis-drive_v3 (0.55.0)
+    google-apis-drive_v3 (0.57.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-env (2.2.0)
       faraday (>= 1.0, < 3.a)
@@ -550,7 +550,7 @@ GEM
       rack (>= 2.2, < 4)
       rdf (~> 3.3)
       rexml (~> 3.2)
-    jwt (2.8.2)
+    jwt (2.9.1)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -621,7 +621,7 @@ GEM
     mysql2 (0.5.6)
     net-http (0.4.1)
       uri
-    net-imap (0.4.15)
+    net-imap (0.4.16)
       date
       net-protocol
     net-ldap (0.19.0)
@@ -814,7 +814,7 @@ GEM
     redlock (2.0.6)
       redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.9.2)
-    reline (0.5.9)
+    reline (0.5.10)
       io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -979,7 +979,7 @@ GEM
     temple (0.10.3)
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
-    thor (1.3.1)
+    thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
@@ -1027,7 +1027,7 @@ GEM
       rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.18)
     zk (1.10.0)
       zookeeper (~> 1.5.0)
     zookeeper (1.5.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,9 +182,6 @@ GEM
     active_elastic_job (3.3.0)
       aws-sdk-sqs (~> 1)
       rails (>= 5.2.6, < 8)
-    active_encode (1.2.2)
-      addressable (~> 2.8)
-      rails
     activejob (7.2.1)
       activesupport (= 7.2.1)
       globalid (>= 0.3.6)
@@ -1050,7 +1047,7 @@ DEPENDENCIES
   active-fedora!
   active_annotations!
   active_elastic_job
-  active_encode (>= 1.2.2)
+  active_encode!
   active_fedora-datastreams!
   activejob-traffic_control
   activejob-uniqueness

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -118,8 +118,17 @@ class FileLocator
     when 'file'
       File.open(location,'r')
     else
-      URI.open(uri, 'r')
+      open_uri
     end
+  end
+
+  # Ruby 3.0 removed URI#open from being called by Kernel#open.
+  # Prioritize using URI#open, attempt to fallback to Kernel#open
+  # if URI fails.
+  def open_uri
+    URI.open(uri, 'r')
+  rescue
+    Kernel::open(uri.to_s, 'r')
   end
 
   def attachment

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -118,7 +118,7 @@ class FileLocator
     when 'file'
       File.open(location,'r')
     else
-      Kernel::open(uri.to_s, 'r')
+      URI.open(uri, 'r')
     end
   end
 

--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -18,3 +18,9 @@ file_system:
 # sky_drive:
 #   :client_id: YOUR_MS_LIVE_CONNECT_CLIENT_ID
 #   :client_secret: YOUR_MS_LIVE_CONNECT_CLIENT_SECRET
+# sharepoint:
+#   client_id: YOUR_MICROSOFT_GRAPH_CLIENT_ID
+#   client_secret: YOUR_MICROSOFT_GRAPH_CLIENT_SECRET
+#   tenant_id: YOUR_MICROSOFT_GRAPH_TENANT_ID
+#   scope: offline_access https://graph.microsoft.com/.default
+#   redirect_uri: https://example.com/browse/connect

--- a/config/initializers/browse_everything.rb
+++ b/config/initializers/browse_everything.rb
@@ -11,5 +11,14 @@ Rails.application.config.to_prepare do
   else
     settings['file_system'] = { name: 'File Dropbox', home: Settings.dropbox.path }
   end
+  if Settings.dropbox.sharepoint
+    settings['sharepoint'] = { client_id: Settings.dropbox.sharepoint.client_id,
+                               client_secret: Settings.dropbox.sharepoint.client_secret,
+                               tenant_id: Settings.dropbox.sharepoint.tenant_id,
+                               grant_type: Settings.dropbox.sharepoint.grant_type,
+                               scope: Settings.dropbox.sharepoint.scope,
+                               redirect_uri: Settings.dropbox.sharepoint.redirect_uri
+                             }
+  end
   BrowseEverything.configure(settings)
 end


### PR DESCRIPTION
This PR adds support for file upload from a user's OneDrive site. The work is primarily contained in our fork of browse-everything, but also includes an updated ActiveEncode to properly parse the download links provided by the Microsoft API.

To implement on Avalon, we will need to have the application registered in the Entra admin center. For initial testing we may be able to use the application information I registered for my local testing, but it may be worthwhile to go ahead and set up an application profile specifically for Avalon-dev. If you go to [entra.microsoft.com](https://entra.microsoft.com/) and login with your IU info, you should be able to go to "Applications -> App Registrations" and look up my test which is called "browseeverything-test" to see the current permissions, ids, redirects, etc.

Once the app is registered, the information can be plugged into Avalon-dev's `settings.yml` and hopefully everything will just work...