### PR TITLE
Fix updated element in atom feed entries when query string present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -802,7 +802,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.3.6)
+    rexml (3.3.8)
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -65,7 +65,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     transcripts_present = SupplementalFile.with_tag('transcript').any?
 
     # List of fields for displaying on search results (Blacklight index fields)
-    fl = ['id', 'has_model_ssim', 'title_tesi', 'date_issued_ssi', 'creator_ssim', 'abstract_ssi', 'duration_ssi', 'section_id_ssim', 'avalon_resource_type_ssim']
+    fl = ['id', 'has_model_ssim', 'title_tesi', 'date_issued_ssi', 'creator_ssim', 'abstract_ssi', 'duration_ssi', 'section_id_ssim', 'avalon_resource_type_ssim',
+          'descMetadata_modified_dtsi', 'timestamp']
 
     # Add a field for matching child sections
     fl << "sections:[subquery]"


### PR DESCRIPTION
The two solr fields used to populate the updated element in entries were not being returned in solr responses when a query string is present.  This was because in Avalon 7.8 an explicit `fl` was added to the query for the 'Found in' functionality and these two fields were forgotten.  Adding them in resolves the issue.