### PR TITLE
Playlist items list

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -287,7 +287,7 @@
   .ramp--structured-nav {
     margin-top: 0px;
     min-width: inherit;
-    max-height: 85%;
+    max-height: 100%;
     overflow: hidden;
   }
 


### PR DESCRIPTION
Related issue: #6083 

In the previous work done related to this issue `max-height: 85%` was set for playlist items list, which creates a vertical scroll-bar for short playlists. By setting it to 100% it eliminates this unnecessary scroll-bar.