### PR TITLE
Align sections text in the structures UI

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -19,6 +19,10 @@
 }
 
 .ramp--all-components {
+  .ramp--structured-nav.display>.ramp--structured-nav__sections {
+    align-items: center;
+  }
+
   .ramp--media_player {
     .video-js .vjs-big-play-button {
       left: 55% !important;
@@ -42,15 +46,6 @@
 
   .ramp--structured-nav {
     max-width: initial;
-    .ramp--structured-nav__collapse-all-btn {
-      background-color: white;
-      color: #0e1825;
-      border: 1px solid #999;
-      height: fit-content;
-      i {
-        border-color: #0e1825 !important;
-      }
-    }
   }
 
   .ramp--rails-title {


### PR DESCRIPTION
Align sections text and remove collapse all button CSS from previous implementation when it was placed outside of the structures container.
Before:
<img width="876" alt="Screenshot 2024-10-31 at 10 49 04 AM" src="https://github.com/user-attachments/assets/ca5339b3-f0d3-4454-8332-01b9f247b560">
After:
<img width="876" alt="Screenshot 2024-10-31 at 10 49 20 AM" src="https://github.com/user-attachments/assets/e45c1321-1676-44d1-b899-9b0f6a6a62eb">
