### PR TITLE
Don't remove file_location since it is used to render the file's filename

### DIFF
--- a/app/jobs/master_file_management_jobs.rb
+++ b/app/jobs/master_file_management_jobs.rb
@@ -81,14 +81,8 @@ module MasterFileManagementJobs
         when 'file' then File.delete(oldpath)
         when 's3'   then FileLocator::S3File.new(locator.source).object.delete
         end
-      	masterfile.file_location = ""
-      	masterfile.save
       	Rails.logger.info "#{oldpath} has been deleted"
       else
-      	unless masterfile.file_location.empty?
-      	  masterfile.file_location = ""
-      	  masterfile.save
-      	end
       	Rails.logger.warn "MasterFile #{oldpath} does not exist"
       end
     end

--- a/spec/jobs/master_file_management_jobs_spec.rb
+++ b/spec/jobs/master_file_management_jobs_spec.rb
@@ -33,7 +33,7 @@ describe MasterFileManagementJobs do
       it "should delete masterfile" do
         MasterFileManagementJobs::Delete.perform_now(master_file.id)
         expect(File.exist? location).to be false
-        expect(MasterFile.find(master_file.id).file_location).to be_blank
+        expect(MasterFile.find(master_file.id).file_location).not_to be_blank
       end
     end
 


### PR DESCRIPTION
Thanks to John Merritt of University of Louisville for pointing out this issue in avalon slack.