### PR TITLE
Always return 0 from docker init script 

### DIFF
--- a/docker_init.sh
+++ b/docker_init.sh
@@ -8,3 +8,5 @@ cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 rm -f tmp/pids/server.pid
 bundle exec rake db:migrate
 
+#Ignore any errors with db:migrate and go ahead with startup
+exit 0


### PR DESCRIPTION
Avalon-dev has been having a timing issue where both the avalon and worker containers try to run `db:migrate` at the same time leading to concurrent db migrate errors.  When these errors occur the container stops running.  I believe returning a 0 exit code from this script will allow startup to proceed and any db:migrate errors will still be logged.  This isn't an issue in other environments because `db:migrate` isn't run automatically as part of container startup.