### PR TITLE
Use tags and releases instead of git branches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,11 @@ gem 'rsolr', '~> 2.0'
 
 # Rails & Samvera Plugins
 gem 'about_page', git: 'https://github.com/avalonmediasystem/about_page.git', tag: 'avalon-r6.5'
-gem 'active_annotations', git: 'https://github.com/avalonmediasystem/active_annotations.git', branch: 'rails_upgrade'
+gem 'active_annotations', '~> 0.5.0'
 gem 'activerecord-session_store', '>= 2.0.0'
 gem 'acts_as_list'
 gem 'api-pagination'
-gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git', branch: 'main'
+gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git', tag: 'avalon-r8.0'
 #gem 'bootstrap-sass', '< 3.4.1' # Pin to less than 3.4.1 due to change in behavior with popovers
 gem 'bootstrap-toggle-rails'
 gem 'bootstrap_form'
@@ -59,11 +59,11 @@ gem 'iiif_manifest', '~> 1.6'
 gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
-gem 'samvera-persona', git: 'https://github.com/samvera-labs/samvera-persona.git', branch: 'rails_7-2'
+gem 'samvera-persona', '~> 0.5.0'
 gem 'speedy-af', git: 'https://github.com/samvera-labs/speedy_af.git', branch: 'empty_reflection'
 
 # Avalon Components
-gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", branch: 'failed_update_setup_edit'
+gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r8.0'
 
 # Authentication & Authorization
 gem 'devise', '~> 4.8'
@@ -76,7 +76,7 @@ gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git"
 gem "omniauth-saml", "~> 2.0", ">= 2.2.1"
 
 # Media Access & Transcoding
-gem 'active_encode', git: "https://github.com/samvera-labs/active_encode.git", branch: 'output_label_parsing'
+gem 'active_encode', '~> 1.2'
 gem 'audio_waveform-ruby', '~> 1.0.7', require: 'audio_waveform'
 gem 'browse-everything', git: "https://github.com/avalonmediasystem/browse-everything.git", branch: 'sharepoint_integration'
 gem 'fastimage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,27 +7,17 @@ GIT
       rails (>= 3.2)
 
 GIT
-  remote: https://github.com/avalonmediasystem/active_annotations.git
-  revision: 18233f5f100f0419c344de0a1c47c922f9802044
-  branch: rails_upgrade
-  specs:
-    active_annotations (0.4.0)
-      json-ld
-      rails (>= 5.2, < 7.3)
-      rdf-vocab (>= 2.1.0)
-
-GIT
   remote: https://github.com/avalonmediasystem/avalon-about.git
   revision: f3106d139d9092ffb0e9ca468fac9e85188ad339
-  branch: main
+  tag: avalon-r8.0
   specs:
     avalon-about (0.1.0)
       about_page
 
 GIT
   remote: https://github.com/avalonmediasystem/avalon-workflow.git
-  revision: df6cdec6fb0ed69b33f843a18ead18979a6c87d3
-  branch: failed_update_setup_edit
+  revision: 503f5fd195359ca73e7facf79843381c611cfa0b
+  tag: avalon-r8.0
   specs:
     avalon-workflow (0.0.3)
 
@@ -68,15 +58,6 @@ GIT
       omniauth
 
 GIT
-  remote: https://github.com/samvera-labs/active_encode.git
-  revision: 49ab76ab6b2593ed250530aa3659dd5c8f5adb25
-  branch: output_label_parsing
-  specs:
-    active_encode (1.2.2)
-      addressable (~> 2.8)
-      rails
-
-GIT
   remote: https://github.com/samvera-labs/active_fedora-datastreams.git
   revision: 3e1b54f60e6d6316e114f608ee5c50c85d6598c6
   branch: fedora6_rebase
@@ -89,17 +70,6 @@ GIT
       rdf (~> 3.2)
       rdf-rdfa (= 3.2.0)
       rdf-rdfxml (~> 3.2)
-
-GIT
-  remote: https://github.com/samvera-labs/samvera-persona.git
-  revision: ce6ada95684fe1c5487e8ee5d698b8529c69bf75
-  branch: rails_7-2
-  specs:
-    samvera-persona (0.4.1)
-      devise (~> 4.6)
-      devise_invitable (>= 1.7, < 3.0)
-      paranoia (~> 3.0)
-      pretender
 
 GIT
   remote: https://github.com/samvera-labs/speedy_af.git
@@ -179,9 +149,16 @@ GEM
       activesupport (>= 3.0.0)
       rdf (>= 2.0.2, < 4.0)
       rdf-vocab (>= 2.0, < 4.0)
+    active_annotations (0.5.0)
+      json-ld
+      rails (>= 5.2, < 7.3)
+      rdf-vocab (>= 2.1.0)
     active_elastic_job (3.3.0)
       aws-sdk-sqs (~> 1)
       rails (>= 5.2.6, < 8)
+    active_encode (1.2.3)
+      addressable (~> 2.8)
+      rails
     activejob (7.2.2)
       activesupport (= 7.2.2)
       globalid (>= 0.3.6)
@@ -900,6 +877,12 @@ GEM
       nokogiri (>= 1.13.10)
       rexml
     rubyzip (1.3.0)
+    samvera-persona (0.5.0)
+      devise (~> 4.6)
+      devise_invitable (>= 1.7, < 3.0)
+      paranoia (~> 3.0)
+      pretender
+      rails (>= 5.2.4.3, < 8.0)
     sass (3.4.22)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -1047,9 +1030,9 @@ PLATFORMS
 DEPENDENCIES
   about_page!
   active-fedora!
-  active_annotations!
+  active_annotations (~> 0.5.0)
   active_elastic_job
-  active_encode!
+  active_encode (~> 1.2)
   active_fedora-datastreams!
   activejob-traffic_control
   activejob-uniqueness
@@ -1150,7 +1133,7 @@ DEPENDENCIES
   rspec-rails
   rspec-retry
   rspec_junit_formatter
-  samvera-persona!
+  samvera-persona (~> 0.5.0)
   sass (= 3.4.22)
   selenium-webdriver
   sequel


### PR DESCRIPTION
This is most of the dependencies that are currently on branches in `develop`.  
Work still to do:
- `active-fedora` and gems that depend on it (`active_fedora-datastreams` and `speedy-af`)
-  `browse-everything` fork needs a tag after sharepoint PR is merged