### PR TITLE
Make override explicit by doing it in the original module in an initializer

### DIFF
--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -25,10 +25,6 @@ module Blacklight::LocalBlacklightHelper
     blacklight_config.facet_fields.map {|facet,opts| opts[:group]}.uniq
   end
 
-  def url_for_document doc, options = {}
-    SpeedyAF::Base.for(doc.to_h.with_indifferent_access)
-  end
-
   def contributor_index_display args
     args[:document][args[:field]].first(3).join("; ")
   end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,0 +1,8 @@
+require 'blacklight'
+Rails.application.config.to_prepare do
+  module Blacklight::UrlHelperBehavior
+    def url_for_document doc, options = {}
+      SpeedyAF::Base.for(doc.to_h.with_indifferent_access)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #6124 

Before this change the overridden helper method was not loading correctly and Blacklight's original implementation was executing causing the return value to be a SolrDocument which led to incorrect urls in the search results.  This is probably due to a change in the way zeitwerk autoloading works in Rails 7.2 and only manifests in production environment.  It doesn't appear in the development environment because of a reloading workaround that targets the development environment (see https://github.com/avalonmediasystem/avalon/pull/1747).  This workaround also fixes the issue in production but it the change in this PR feels like a better solution for this specific problem as well as being more limited in scope.