### PR TITLE
Fix processing of google drive files

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -727,7 +727,7 @@ class MasterFile < ActiveFedora::Base
 
   def reloadTechnicalMetadata!
     # Reset ffprobe
-    @ffprobe = Avalon::FFprobe.new(FileLocator.new(file_location))
+    @ffprobe = Avalon::FFprobe.new(FileLocator.new(file_location, { auth_header: @auth_header }))
 
     # Formats like MP4 can be caught as both audio and video
     # so the case statement flows in the preferred order

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -16,7 +16,7 @@ require 'addressable/uri'
 require 'aws-sdk-s3'
 
 class FileLocator
-  attr_reader :source
+  attr_reader :source, :auth_header
 
   class S3File
     attr_reader :bucket, :key
@@ -46,8 +46,9 @@ class FileLocator
     end
   end
 
-  def initialize(source)
+  def initialize(source, opts = {})
     @source = source
+    @auth_header = opts[:auth_header]
   end
 
   def uri
@@ -126,7 +127,14 @@ class FileLocator
   # Prioritize using URI#open, attempt to fallback to Kernel#open
   # if URI fails.
   def open_uri
-    URI.open(uri, 'r')
+    # Google Drive download urls have the auth as a param
+    # so we need to make sure the auth gets passed in
+    # when we try to access files
+    if auth_header.present? && auth_header.is_a?(Hash)
+      URI.open(uri, 'r', auth_header)
+    else
+      URI.open(uri, 'r')
+    end
   rescue
     Kernel::open(uri.to_s, 'r')
   end

--- a/lib/avalon/ffprobe.rb
+++ b/lib/avalon/ffprobe.rb
@@ -23,7 +23,9 @@ module Avalon
       return @json_output unless @json_output.nil?
       return @json_output = {} unless valid_content_type?(@media_file)
       ffprobe = Settings&.ffprobe&.path || 'ffprobe'
-      raw_output = `#{ffprobe} -i "#{@media_file.location}" -v quiet -show_format -show_streams -of json`
+      # Include authorization headers for cases like Google Drive
+      header = "-headers 'Authorization: #{@media_file.auth_header.fetch('Authorization')}'" if @media_file.auth_header.present?
+      raw_output = `#{ffprobe} #{header} -i "#{@media_file.location}" -v quiet -show_format -show_streams -of json`
       # $? is a variable for the exit status of the last executed process. 
       # Success == 0, any other value means the command failed in some way.
       unless $?.exitstatus == 0


### PR DESCRIPTION
When we made the switch from mediainfo to ffprobe, we created a new class for processing the file. Because Google Drive utilizes headers/params for its authorization flow, this change resulted in the file information becoming divorced from the auth token. By explicitly passing the auth token through to the classes downloading and processing the file, we are able to fix this oversight.