### PR TITLE
Pin to specific revisions in github until releases of gems are made.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,8 @@ gem 'shakapacker'
 
 # Core Samvera
 #gem 'active-fedora', '~> 15.0'
-#gem 'active_fedora-datastreams', '~> 0.5'
-gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', branch: 'fedora6_rebase'
-gem 'active_fedora-datastreams', git: 'https://github.com/samvera-labs/active_fedora-datastreams.git', branch: 'fedora6_rebase'
+gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', ref: '0f5ccb1536224efec750941ce9a1f58f2e09cd3c'
+gem 'active_fedora-datastreams', '~> 0.5'
 gem 'hydra-head', '~> 13.0'
 gem 'ldp', '~> 1.1.0'
 gem 'noid-rails', '~> 3.2'
@@ -60,7 +59,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', '~> 0.5.0'
-gem 'speedy-af', git: 'https://github.com/samvera-labs/speedy_af.git', branch: 'empty_reflection'
+gem 'speedy-af', '~> 0.4.0'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,31 +58,9 @@ GIT
       omniauth
 
 GIT
-  remote: https://github.com/samvera-labs/active_fedora-datastreams.git
-  revision: 3e1b54f60e6d6316e114f608ee5c50c85d6598c6
-  branch: fedora6_rebase
-  specs:
-    active_fedora-datastreams (0.5.0)
-      active-fedora (>= 11.0.0.pre)
-      activemodel (>= 5.2)
-      nom-xml (>= 0.5.1)
-      om (~> 3.1)
-      rdf (~> 3.2)
-      rdf-rdfa (= 3.2.0)
-      rdf-rdfxml (~> 3.2)
-
-GIT
-  remote: https://github.com/samvera-labs/speedy_af.git
-  revision: 223abe9e2a7cdc68b033398bf69922523aeff47e
-  branch: empty_reflection
-  specs:
-    speedy-af (0.3.0)
-      activesupport (> 5.2)
-
-GIT
   remote: https://github.com/samvera/active_fedora.git
   revision: 0f5ccb1536224efec750941ce9a1f58f2e09cd3c
-  branch: fedora6_rebase
+  ref: 0f5ccb1536224efec750941ce9a1f58f2e09cd3c
   specs:
     active-fedora (15.0.1)
       active-triples (>= 0.11.0, < 2.0.0)
@@ -159,6 +137,13 @@ GEM
     active_encode (1.2.3)
       addressable (~> 2.8)
       rails
+    active_fedora-datastreams (0.5.0)
+      active-fedora (>= 11.0.0.pre)
+      activemodel (>= 5.2)
+      nom-xml (>= 0.5.1)
+      om (~> 3.1)
+      rdf (~> 3.2)
+      rdf-rdfxml (~> 3.2)
     activejob (7.2.2)
       activesupport (= 7.2.2)
       globalid (>= 0.3.6)
@@ -466,9 +451,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    haml (5.2.2)
-      temple (>= 0.8.0)
-      tilt
     hashdiff (1.1.1)
     hashie (5.0.0)
     hooks (0.4.1)
@@ -740,20 +722,11 @@ GEM
       bcp47_spec (~> 0.2)
       bigdecimal (~> 3.1, >= 3.1.5)
       link_header (~> 0.0, >= 0.0.8)
-    rdf-aggregate-repo (3.3.0)
-      rdf (~> 3.3)
     rdf-isomorphic (3.3.0)
       rdf (~> 3.3)
     rdf-ldp (0.1.0)
       deprecation
       rdf
-    rdf-rdfa (3.2.0)
-      haml (~> 5.2)
-      htmlentities (~> 4.3)
-      rdf (~> 3.2)
-      rdf-aggregate-repo (~> 3.2)
-      rdf-vocab (~> 3.2)
-      rdf-xsd (~> 3.2)
     rdf-rdfxml (3.3.0)
       builder (~> 3.2, >= 3.2.4)
       htmlentities (~> 4.3)
@@ -940,6 +913,9 @@ GEM
       nokogiri
       stomp
       xml-simple
+    speedy-af (0.4.0)
+      active-fedora (>= 11.0.0)
+      activesupport (> 5.2)
     sprockets (3.7.3)
       base64
       concurrent-ruby (~> 1.0)
@@ -967,7 +943,6 @@ GEM
     sxp (2.0.0)
       matrix (~> 0.4)
       rdf (~> 3.3)
-    temple (0.10.3)
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
@@ -1033,7 +1008,7 @@ DEPENDENCIES
   active_annotations (~> 0.5.0)
   active_elastic_job
   active_encode (~> 1.2)
-  active_fedora-datastreams!
+  active_fedora-datastreams (~> 0.5)
   activejob-traffic_control
   activejob-uniqueness
   activerecord-session_store (>= 2.0.0)
@@ -1143,7 +1118,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.9)
   simplecov
   solr_wrapper (>= 0.16)
-  speedy-af!
+  speedy-af (~> 0.4.0)
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3


### PR DESCRIPTION
Turns out that `active_fedora-datastreams` didn't need a release or any code changes so I reverted to `~> 0.5.0`.  `speedy_af` got a release because it didn't actually depend on an `active_fedora` release.  This leaves `active_fedora` as the only dependency without a tag or release so I pinned it to a specific git commit.  I did this because I think it might take some time for community review of the Fedora 6 support in ActiveFedora and a release to be cut.