### PR TITLE
Download hosted files to tmp and move to dropbox when uploading

### DIFF
--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -16,7 +16,7 @@ require 'addressable/uri'
 require 'aws-sdk-s3'
 
 class FileLocator
-  attr_reader :source, :auth_header
+  attr_reader :source, :filename, :auth_header
 
   class S3File
     attr_reader :bucket, :key
@@ -48,6 +48,7 @@ class FileLocator
 
   def initialize(source, opts = {})
     @source = source
+    @filename = opts[:filename]
     @auth_header = opts[:auth_header]
   end
 
@@ -89,15 +90,27 @@ class FileLocator
     end
   end
 
-  # If S3, download object to /tmp
+  # If S3 or http(s), download object to /tmp
   def local_location
     @local_location ||= begin
-      if uri.scheme == 's3'
+      case uri.scheme
+      when 's3'
         S3File.new(uri).local_file.path
-      else
+      when 'file'
         location
+      else
+        local_file.path
       end
     end
+  end
+
+  def local_file
+    @local_file ||= Tempfile.new(filename)
+    File.binwrite(@local_file, reader.read)
+    @local_file.rewind
+    @local_file
+  ensure
+    @local_file.close
   end
 
   def exist?

--- a/app/services/file_mover.rb
+++ b/app/services/file_mover.rb
@@ -1,0 +1,45 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class FileMover
+  class << self
+    def s3_to_s3(source, dest)
+      source_object = FileLocator::S3File.new(source.source).object
+      dest_object = FileLocator::S3File.new(dest.source).object
+      if dest_object.copy_from(source_object, multipart_copy: source_object.size > 15.megabytes)
+        source_object.delete if FileLocator.new(dest.source).exists?
+      end
+    end
+
+    def s3_to_file(source, dest)
+      source_object = FileLocator::S3File.new(source.source).object
+      FileUtils.mkdir_p File.dirname(dest.uri.path) unless File.exist? File.dirname(dest.uri.path)
+      if source_object.download_file(dest.uri.path)
+        source_object.delete
+      end
+    end
+
+    def file_to_s3(source, dest)
+      dest_object = FileLocator::S3File.new(dest.source).object
+      if dest_object.upload_file(source.uri.path)
+        FileUtils.rm(source.uri.path)
+      end
+    end
+
+    def file_to_file(source, dest)
+      FileUtils.mkdir_p File.dirname(dest.location) unless File.exist? File.dirname(dest.location)
+      FileUtils.mv source.location, dest.location
+    end
+  end
+end


### PR DESCRIPTION
Related issue: #6129 (may also take care of #6152 but that needs to be more thoroughly tested)

Internet hosted files such as google drive or sharepoint were being downloaded multiple times during processing. By creating a tempfile and moving it into the dropbox, this should remove or at least minimize excess downloads.