### PR TITLE
Use safe navigator in case comments or tags are nil

### DIFF
--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -31,8 +31,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% # Replace 2 or more consecutive sets of line break characters with <br> tags %>
     <% # This is because <p> tags force the show more link to a new line since it %>
     <% # is outside the element(s) containing the text. Avoiding <p> allows the link to be inline %>
-    <% comment = @playlist.comment.gsub(/(\r?\n){2,}/m, "<br/><br/>") %>
-    <% tags = @playlist.tags.map { |tag| "<span class='btn btn-sm btn-info'>#{tag}</span>" }.join(' ') %>
+    <% comment = @playlist.comment&.gsub(/(\r?\n){2,}/m, "<br/><br/>") %>
+    <% tags = @playlist.tags&.map { |tag| "<span class='btn btn-sm btn-info'>#{tag}</span>" }.join(' ') %>
     <%= react_component("PlaylistRamp",
       {
         urls: { base_url: request.protocol+request.host_with_port, fullpath_url: request.fullpath },


### PR DESCRIPTION
Should resolve https://app.honeybadger.io/projects/54117/faults/112541833

Most playlists in our production site have empty strings for comments but a few had `nil` which caused them not to open.  I changed all of those playlists to empty string in the database but this code change should also handle this edge case (and tags too for good measure).