### PR TITLE
Fixes for single downloads from Google Drive

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -210,6 +210,7 @@ class MasterFile < ActiveFedora::Base
       else
         local_file = FileLocator.new(file, filename: file_name, auth_header: auth_header).local_location
         saveOriginal(File.open(local_file), file_name, dropbox_dir)
+        auth_header = nil
       end
     else #Batch
       saveOriginal(file, File.basename(file.path), dropbox_dir)

--- a/app/services/file_locator.rb
+++ b/app/services/file_locator.rb
@@ -104,8 +104,13 @@ class FileLocator
     end
   end
 
+  # Tempfile.create generates a regular File object instead of a Tempfile object:
+  # https://ruby-doc.org/stdlib-3.1.1/libdoc/tempfile/rdoc/Tempfile.html#method-c-create
+  # It is necessary for us to use this method to avoid issues with garbage collection.
+  # When calling this method ensure that the file gets unlinked/rm-ed explicitly
+  # after it is done being used.
   def local_file
-    @local_file ||= Tempfile.new(filename)
+    @local_file ||= Tempfile.create(filename)
     File.binwrite(@local_file, reader.read)
     @local_file
   ensure

--- a/lib/avalon/ffprobe.rb
+++ b/lib/avalon/ffprobe.rb
@@ -24,7 +24,12 @@ module Avalon
       return @json_output = {} unless valid_content_type?(@media_file)
       ffprobe = Settings&.ffprobe&.path || 'ffprobe'
       # Include authorization headers for cases like Google Drive
-      header = "-headers 'Authorization: #{@media_file.auth_header.fetch('Authorization')}'" if @media_file.auth_header.present?
+      header = case @media_file.uri.scheme
+               when "http", "https"
+                 "-headers 'Authorization: #{@media_file.auth_header.fetch('Authorization')}'" if @media_file.auth_header.present?
+               else
+                 nil
+               end
       raw_output = `#{ffprobe} #{header} -i "#{@media_file.location}" -v quiet -show_format -show_streams -of json`
       # $? is a variable for the exit status of the last executed process. 
       # Success == 0, any other value means the command failed in some way.


### PR DESCRIPTION
This commit includes three fixes:
1. The way that we were generating and referencing the temporary file marked it as ready for Garbage Collection before we were finished making use of it and so we would get intermittent "file does not exist" errors if the garbage collector ran at the wrong time. Switching to `Tempfile.create` fixes this issue, but requires us to manually remove the tempfile after use.
2. Even though we would download to a local file, we were still passing the google auth_headers around to the various modules and methods under the assumption it was safe. This was an incorrect assumption. FFProbe has been adjusted to only use the auth headers if the object passed in is http/https.
3. The final issue is the same as in #2 but related to active encode's processing. By setting the auth header to nil after it is no longer needed, we can prevent it getting passed further and causing issues.