### PR TITLE
Skip checkouts belonging to deleted items

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -29,7 +29,7 @@ class CheckoutsController < ApplicationController
             else
               user_array(checkout)
             end
-          end
+          end.compact
         }
         render json: response
       end
@@ -125,7 +125,8 @@ class CheckoutsController < ApplicationController
     end
 
     def admin_array(checkout)
-      [checkout.user.user_key] + user_array(checkout)
+      checkout_array = user_array(checkout)
+      checkout_array.present? ? [checkout.user.user_key] + checkout_array : nil
     end
 
     def user_array(checkout)
@@ -136,6 +137,8 @@ class CheckoutsController < ApplicationController
         time_remaining(checkout),
         checkout_actions(checkout)
       ]
+    rescue ActiveFedora::ObjectNotFoundError
+      nil
     end
 
     def time_remaining(checkout)

--- a/spec/requests/checkouts_spec.rb
+++ b/spec/requests/checkouts_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe "/checkouts", type: :request do
             parsed_body = JSON.parse(response.body)
             expect(parsed_body['data'].count).to eq(2)
           end
+
+          context "with deleted parent" do
+            before :each do
+              media_object = MediaObject.find(checkout.media_object.id)
+              media_object.destroy!
+            end
+            it "renders a successful JSON response" do
+              get checkouts_url(format: :json, params: { display_returned: true } )
+              expect(response).to be_successful
+              expect(response.content_type).to eq("application/json; charset=utf-8")
+            end
+            it "returns checkouts with existing parents" do
+              get checkouts_url(format: :json, params: { display_returned: true } )
+              parsed_body = JSON.parse(response.body)
+              expect(parsed_body['data'].count).to eq(1)
+            end
+          end
         end
 
         context "as an admin user" do
@@ -123,6 +140,23 @@ RSpec.describe "/checkouts", type: :request do
             get checkouts_url(format: :json, params: { display_returned: true } )
             parsed_body = JSON.parse(response.body)
             expect(parsed_body['data'].count).to eq(4)
+          end
+
+          context "with deleted parent" do
+            before :each do
+              media_object = MediaObject.find(checkout.media_object.id)
+              media_object.destroy!
+            end
+            it "renders a successful JSON response" do
+              get checkouts_url(format: :json, params: { display_returned: true } )
+              expect(response).to be_successful
+              expect(response.content_type).to eq("application/json; charset=utf-8")
+            end
+            it "returns checkouts with existing parents" do
+              get checkouts_url(format: :json, params: { display_returned: true } )
+              parsed_body = JSON.parse(response.body)
+              expect(parsed_body['data'].count).to eq(3)
+            end
           end
         end
       end


### PR DESCRIPTION
Related issue: #6134 

Checkouts created for items that were subsequently deleted are not cleared from the database. This caused a datatables error when looking at the Checkouts page. This PR sets these errored checkouts to nil and then clears them from the results JSON so that datatables populated correctly.

This is out of scope for this issue, but should we have some sort of handling to delete checkout records when the referenced media object is deleted? Or a rake task/cron job for clearing these orphaned records semi-regularly?