### PR TITLE
Wait on minio container before attempting to create buckets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
     ports: []
 
   minio:
-    image: minio/minio:RELEASE.2024-01-29T03-56-32Z
+    image: minio/minio
     command: minio server /data --console-address ":9090"
     environment:
       MINIO_ACCESS_KEY: minio
@@ -195,7 +195,8 @@ services:
   createbuckets:
     image: minio/mc
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc config host add myminio http://minio:9000 minio minio123;


### PR DESCRIPTION
As reported in #6190 creation of buckets sometimes fails.  This appears to be a timing issue where the minio container is not available when the createbuckets container attempts to connect.  This is resolved by changing the `depends_on` in the createbuckets container to check that the minio container is healthy instead of just created which is the default.  (See https://docs.docker.com/compose/how-tos/startup-order/#control-startup for more details.)

Also included in this PR: use minio latest tag