### PR TITLE
Additional fixes for read-only mode

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -91,18 +91,18 @@ class CatalogController < ApplicationController
     config.add_facet_field 'rights_statement_ssi', label: 'Rights Statement', limit: 5, helper_method: :rights_statement_facet_display, solr_params: { "facet.contains" => "http"}
 
     # Hide these facets if not a Collection Manager
-    config.add_facet_field 'workflow_published_sim', label: 'Published', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow"
-    config.add_facet_field 'avalon_uploader_ssi', label: 'Created by', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow"
-    config.add_facet_field 'read_access_group_ssim', label: 'Item access', if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow", query: {
+    config.add_facet_field 'workflow_published_sim', label: 'Published', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
+    config.add_facet_field 'avalon_uploader_ssi', label: 'Created by', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
+    config.add_facet_field 'read_access_group_ssim', label: 'Item access', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", query: {
       public: { label: "Public", fq: "has_model_ssim:MediaObject AND read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC}" },
       restricted: { label: "Authenticated", fq: "has_model_ssim:MediaObject AND read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED}" },
       private: { label: "Private", fq: "has_model_ssim:MediaObject AND NOT read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC} AND NOT read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED}" }
     }
-    config.add_facet_field 'read_access_virtual_group_ssim', label: 'External Group', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow", helper_method: :vgroup_display
-    config.add_facet_field 'date_digitized_ssim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow"#, partial: 'blacklight/hierarchy/facet_hierarchy'
-    config.add_facet_field 'date_ingested_ssim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow"
-    config.add_facet_field 'has_captions_bsi', label: 'Has Captions', if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow", helper_method: :display_has_caption_or_transcript
-    config.add_facet_field 'has_transcripts_bsi', label: 'Has Transcripts', if: Proc.new {|context, config, opts| context.current_ability.can? :create, MediaObject}, group: "workflow", helper_method: :display_has_caption_or_transcript
+    config.add_facet_field 'read_access_virtual_group_ssim', label: 'External Group', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :vgroup_display
+    config.add_facet_field 'date_digitized_ssim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"#, partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'date_ingested_ssim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
+    config.add_facet_field 'has_captions_bsi', label: 'Has Captions', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :display_has_caption_or_transcript
+    config.add_facet_field 'has_transcripts_bsi', label: 'Has Transcripts', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :display_has_caption_or_transcript
 
     config.add_facet_field 'subject_ssim', label: 'Subject', if: false
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -91,18 +91,18 @@ class CatalogController < ApplicationController
     config.add_facet_field 'rights_statement_ssi', label: 'Rights Statement', limit: 5, helper_method: :rights_statement_facet_display, solr_params: { "facet.contains" => "http"}
 
     # Hide these facets if not a Collection Manager
-    config.add_facet_field 'workflow_published_sim', label: 'Published', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
-    config.add_facet_field 'avalon_uploader_ssi', label: 'Created by', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
-    config.add_facet_field 'read_access_group_ssim', label: 'Item access', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", query: {
+    config.add_facet_field 'workflow_published_sim', label: 'Published', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow"
+    config.add_facet_field 'avalon_uploader_ssi', label: 'Created by', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow"
+    config.add_facet_field 'read_access_group_ssim', label: 'Item access', if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow", query: {
       public: { label: "Public", fq: "has_model_ssim:MediaObject AND read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC}" },
       restricted: { label: "Authenticated", fq: "has_model_ssim:MediaObject AND read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED}" },
       private: { label: "Private", fq: "has_model_ssim:MediaObject AND NOT read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC} AND NOT read_access_group_ssim:#{Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED}" }
     }
-    config.add_facet_field 'read_access_virtual_group_ssim', label: 'External Group', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :vgroup_display
-    config.add_facet_field 'date_digitized_ssim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"#, partial: 'blacklight/hierarchy/facet_hierarchy'
-    config.add_facet_field 'date_ingested_ssim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow"
-    config.add_facet_field 'has_captions_bsi', label: 'Has Captions', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :display_has_caption_or_transcript
-    config.add_facet_field 'has_transcripts_bsi', label: 'Has Transcripts', if: Proc.new {|context, config, opts| context.current_ability.is_member_of_any_collection?}, group: "workflow", helper_method: :display_has_caption_or_transcript
+    config.add_facet_field 'read_access_virtual_group_ssim', label: 'External Group', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow", helper_method: :vgroup_display
+    config.add_facet_field 'date_digitized_ssim', label: 'Date Digitized', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow"#, partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field 'date_ingested_ssim', label: 'Date Ingested', limit: 5, if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow"
+    config.add_facet_field 'has_captions_bsi', label: 'Has Captions', if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow", helper_method: :display_has_caption_or_transcript
+    config.add_facet_field 'has_transcripts_bsi', label: 'Has Transcripts', if: Proc.new {|context, config, opts| context.current_ability.can?(:read, :administrative_facets)}, group: "workflow", helper_method: :display_has_caption_or_transcript
 
     config.add_facet_field 'subject_ssim', label: 'Subject', if: false
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -263,10 +263,10 @@ class Ability
 
   def repository_read_only_permissions
     if Settings.repository_read_only_mode
-      cannot [:create, :edit, :update, :destroy, :update_access_control, :unpublish], [MediaObject, SpeedyAF::Proxy::MediaObject]
+      cannot [:create, :edit, :update, :destroy, :update_access_control, :unpublish, :intercom_push], [MediaObject, SpeedyAF::Proxy::MediaObject]
       cannot [:create, :edit, :update, :destroy], [MasterFile, SpeedyAF::Proxy::MasterFile]
       cannot [:create, :edit, :update, :destroy], [Derivative, SpeedyAF::Proxy::Derivative]
-      cannot [:create, :edit, :update, :destroy, :update_unit, :update_access_control, :update_managers, :update_editors, :update_depositors], [Admin::Collection, SpeedyAF::Proxy::Admin::Collection]
+      cannot [:create, :edit, :update, :destroy, :update_unit, :update_access_control, :update_managers, :update_editors, :update_depositors], [Admin::Collection, SpeedyAF::Proxy::Admin::Collection, Admin::CollectionPresenter]
       cannot [:create, :edit, :update, :destroy], SpeedyAF::Base
     end
   end

--- a/app/models/collection_search_builder.rb
+++ b/app/models/collection_search_builder.rb
@@ -64,7 +64,7 @@ class CollectionSearchBuilder < Blacklight::SearchBuilder
 
     # Copied from SearchBuilder
     def only_published_items(solr_parameters, ability = current_ability)
-      if !ability.is_member_of_any_collection?
+      if ability.cannot? :discover_unpublished, MediaObject
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] << 'workflow_published_sim:"Published"'
       end

--- a/app/models/collection_search_builder.rb
+++ b/app/models/collection_search_builder.rb
@@ -64,7 +64,7 @@ class CollectionSearchBuilder < Blacklight::SearchBuilder
 
     # Copied from SearchBuilder
     def only_published_items(solr_parameters, ability = current_ability)
-      if ability.cannot? :create, MediaObject
+      if !ability.is_member_of_any_collection?
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] << 'workflow_published_sim:"Published"'
       end

--- a/app/views/admin/collections/index.html.erb
+++ b/app/views/admin/collections/index.html.erb
@@ -82,7 +82,3 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   </div>
 <% end %>
-
-
-
-<% @collection = Admin::Collection.new %>

--- a/app/views/modules/_special_access.html.erb
+++ b/app/views/modules/_special_access.html.erb
@@ -40,7 +40,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= bootstrap_form_for object, html: { id: 'special_access_form' }  do |vid| %>
     <%= hidden_field_tag :save_field, 'special_access' %>
       <div class='form-group'>
-        <%= button_tag "Apply to All Existing Items", type: 'button', class: "btn btn-outline", data: { toggle:"modal", target:"#access_control_modal" } %>
+        <%= button_tag "Apply to All Existing Items", type: 'button', class: "btn btn-outline", data: { toggle:"modal", target:"#access_control_modal"}, disabled: !can_update %>
       </div>
 
       <%= render modal[:partial], modal_title: modal[:title], affected: object.media_objects.count if defined? modal %>

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -53,6 +53,7 @@ describe Ability, type: :model do
         expect(subject.can?(:destroy, MediaObject)).to eq false
         expect(subject.can?(:update_access_control, MediaObject)).to eq false
         expect(subject.can?(:unpublish, MediaObject)).to eq false
+        expect(subject.can?(:intercom_push, MediaObject)).to eq false
 
         expect(subject.can?(:create, SpeedyAF::Proxy::MediaObject)).to eq false
         expect(subject.can?(:read, SpeedyAF::Proxy::MediaObject)).to eq true
@@ -107,6 +108,8 @@ describe Ability, type: :model do
         expect(subject.can?(:update_managers, SpeedyAF::Proxy::Admin::Collection)).to eq false
         expect(subject.can?(:update_editors, SpeedyAF::Proxy::Admin::Collection)).to eq false
         expect(subject.can?(:update_depositors, SpeedyAF::Proxy::Admin::Collection)).to eq false
+
+        expect(subject.can?(:destroy, Admin::CollectionPresenter)).to eq false
       end
     end
 
@@ -136,6 +139,7 @@ describe Ability, type: :model do
         expect(subject.can?(:destroy, SpeedyAF::Proxy::MediaObject)).to eq true
         expect(subject.can?(:update_access_control, SpeedyAF::Proxy::MediaObject)).to eq true
         expect(subject.can?(:unpublish, SpeedyAF::Proxy::MediaObject)).to eq true
+        expect(subject.can?(:intercom_push, MediaObject)).to eq true
  
         expect(subject.can?(:create, MasterFile)).to eq true
         expect(subject.can?(:read, MasterFile)).to eq true
@@ -182,6 +186,8 @@ describe Ability, type: :model do
         expect(subject.can?(:update_managers, SpeedyAF::Proxy::Admin::Collection)).to eq true
         expect(subject.can?(:update_editors, SpeedyAF::Proxy::Admin::Collection)).to eq true
         expect(subject.can?(:update_depositors, SpeedyAF::Proxy::Admin::Collection)).to eq true
+
+        expect(subject.can?(:destroy, Admin::CollectionPresenter)).to eq true
       end
     end
   end


### PR DESCRIPTION
Part of #6160

- Administrative facets should be visible
- Manage Content should list collections
- Delete button should not appear next to collections on manage content page
- Push button should not appear on selected items page or item view page
- Apply to All Existing Items button on collection edit page should be disabled