### PR TITLE
Force mimetype to application/x-mpegurl when the hls_url is an m3u8

### DIFF
--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -42,6 +42,11 @@ module MasterFileBehavior
                  mimetype: d.mime_type,
                  format: d.format }
       flash << common.merge(url: d.streaming_url(false))
+
+      hls_url = d.streaming_url(true)
+      # Quick fix for old items with mimetypes to deal with issue due to mp3 progressive download code in IIIFCanvasPresenter
+      common[:mimetype] = 'application/x-mpegURL' if File.extname(hls_url) == ".m3u8"
+
       hls << common.merge(url: d.streaming_url(true))
     end
     if hls.length > 1
@@ -90,6 +95,11 @@ module MasterFileBehavior
                  bitrate: d.bitrate,
                  mimetype: d.mime_type,
                  format: d.format }
+
+      hls_url = d.streaming_url(true)
+      # Quick fix for old items with mimetypes to deal with issue due to mp3 progressive download code in IIIFCanvasPresenter
+      common[:mimetype] = 'application/x-mpegURL' if File.extname(hls_url) == ".m3u8"
+
       hls << common.merge(url: d.streaming_url(true))
     end
     if hls.length > 1

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -818,18 +818,18 @@ describe MasterFile do
     let(:master_file) { FactoryBot.create(:master_file) }
     let(:streams) do
       [{:format=>"video",
-        :mimetype=>nil,
+        :mimetype=>"application/x-mpegURL",
         :quality=>"auto",
         :url=>"http://test.host/master_files/#{master_file.id}/auto.m3u8"},
       {:bitrate=>4163842,
         :format=>"video",
-        :mimetype=>nil,
+        :mimetype=>"application/x-mpegURL",
         :quality=>"high",
         :url=>
          "http://localhost:3000/streams/6f69c008-06a4-4bad-bb60-26297f0b4c06/35bddaa0-fbb4-404f-ab76-58f22921529c/warning.mp4.m3u8"},
       {:bitrate=>4163842,
         :format=>"video",
-        :mimetype=>nil,
+        :mimetype=>"application/x-mpegURL",
         :quality=>"medium",
         :url=>
          "http://localhost:3000/streams/6f69c008-06a4-4bad-bb60-26297f0b4c06/35bddaa0-fbb4-404f-ab76-58f22921529c/warning.mp4.m3u8"}]


### PR DESCRIPTION
Fix for #6214 

As part of enabling MP3 streaming a check was added to IIIFCanvasPresenter for the m3u8 mimetype.  That mimetype is the default when a derivative doesn't have one set which I believe is true for all files transcoded using ffmpeg.  Older transcodes (possibly dating back to matterhorn) do have a mimetype and that causes issues in the front end when it comes through.  This PR forces the m3u8 mimetype when the HLS url being passed to the presenter has an m3u8 extension.