### PR TITLE
Make finders case insensistive to match validators

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,8 +43,8 @@ class User < ActiveRecord::Base
   before_destroy :remove_bookmarks
 
   def username_email_uniqueness
-    errors.add(:email, :taken, value: email) if User.find_by_username(email) && User.find_by_username(email).id != id
-    errors.add(:username, :taken, valud: username) if User.find_by_email(username) && User.find_by_email(username).id != id
+    errors.add(:email, :taken, value: email) if User.find_and_verify_by_username(email) && User.find_and_verify_by_username(email).id != id
+    errors.add(:username, :taken, value: username) if User.find_and_verify_by_email(username) && User.find_and_verify_by_email(username).id != id
   end
 
   # Method added by Blacklight; Blacklight uses #to_s on your
@@ -71,7 +71,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_and_verify_by_username(username)
-    user = User.find_by(username: username)
+    user = User.find_by("lower(username) = ?", username&.downcase)
     if user&.deleted_at
       raise Avalon::DeletedUserId
     end
@@ -79,7 +79,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_and_verify_by_email(email)
-    user = User.find_by(email: email)
+    user = User.find_by("lower(email) = ?", email&.downcase)
     if user&.deleted_at
       raise Avalon::DeletedUserId
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -92,8 +92,20 @@ describe User do
     end
 
     it "should find undeleted users by email" do
-      found_user = User.find_or_create_by_username_or_email(user.username, nil)
+      found_user = User.find_or_create_by_username_or_email(nil, user.email)
       expect(found_user).to eq(user)
+    end
+
+    context 'case insensitive' do
+      it "should find undeleted users by usernames" do
+        found_user = User.find_or_create_by_username_or_email(user.username.upcase, nil)
+        expect(found_user).to eq(user)
+      end
+
+      it "should find undeleted users by email" do
+        found_user = User.find_or_create_by_username_or_email(nil, user.email.upcase)
+        expect(found_user).to eq(user)
+      end
     end
   end
 


### PR DESCRIPTION
I was investigating this honeybadger report (https://app.honeybadger.io/projects/54117/faults/103019048) and noticed that the username/email returned by the auth service was uppercase but a prior user account in Avalon had been made with the username/email lowercase.  This led to an error when using `find_or_create_by_username_or_email` because the user wasn't found but creating failed due to the case insensitive validations on username and email.  Making the special finders used by `find_or_create_by_username_or_email` to do case insensitive queries should fix this problem.