### PR TITLE
Move clean up of expired StreamTokens into background job run by sidekiq cron

### DIFF
--- a/app/jobs/cleanup_stream_token_job.rb
+++ b/app/jobs/cleanup_stream_token_job.rb
@@ -1,0 +1,20 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+# frozen_string_literal: true
+class CleanupStreamTokenJob < ActiveJob::Base
+  def perform
+    StreamToken.delete_expired
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -21,6 +21,7 @@ Rails.application.config.to_prepare do
     Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification of Existing Batches - every 15min', cron: '*/15 * * * *', class: 'IngestBatchStatusEmailJobs::IngestFinished')
     Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification for Stalled Batches - every 1day', cron: '0 1 * * *', class: 'IngestBatchStatusEmailJobs::StalledJob')
     Sidekiq::Cron::Job.create(name: 'Clean out user sessions older than 7 days - every 6hour', cron: '0 */6 * * *', class: 'CleanupSessionJob')
+    Sidekiq::Cron::Job.create(name: 'Clean out expired stream tokens - every 5min', cron: '*/5 * * * *', class: 'CleanupStreamTokenJob')
   rescue Redis::CannotConnectError => e
     Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"
   end

--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -70,6 +70,11 @@ namespace :avalon do
     orphans.destroy_all
   end
 
+  desc 'clean out expired stream tokens'
+  task stream_token_cleanup: :environment do
+    CleanupStreamTokenJob.perform_now
+  end
+
   namespace :services do
     services = ["jetty", "felix", "delayed_job"]
     desc "Start Avalon's dependent services"

--- a/spec/jobs/cleanup_stream_token_job_spec.rb
+++ b/spec/jobs/cleanup_stream_token_job_spec.rb
@@ -1,0 +1,37 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe CleanupStreamTokenJob do
+  let(:session) { { session_id: '00112233445566778899aabbccddeeff' } }
+  let!(:valid_token) { StreamToken.find_or_create_session_token(session, 1.to_s) }
+  let!(:expired_token1) { StreamToken.find_or_create_session_token(session, 2.to_s) }
+  let!(:expired_token2) { StreamToken.find_or_create_session_token(session, 3.to_s) }
+
+  describe 'perform' do
+    it 'deletes all expired tokens' do
+      expect(StreamToken.count).to eq 3
+      [expired_token1, expired_token2].each do |token|
+        stream_token = StreamToken.find_by_token(token)
+        stream_token.update_attribute :expires, Time.now.utc
+      end
+      CleanupStreamTokenJob.perform_now
+      expect(StreamToken.count).to eq 1
+      expect(StreamToken.find_by_token(expired_token1)).to be_nil
+      expect(StreamToken.find_by_token(expired_token2)).to be_nil
+      expect(StreamToken.find_by_token(valid_token)).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This work was originally done in an attempt to deal with a production slowdown due to the database being overloaded and table write locks being hard to acquire.  By moving the deletion out into a background job we reduce the number of database write calls to one every few minutes instead of one every request which could potentially be hundreds in the same time frame.