### PR TITLE
Move share links into JS so it doesn't need the /stream endpoint

### DIFF
--- a/app/assets/javascripts/player_listeners.js
+++ b/app/assets/javascripts/player_listeners.js
@@ -33,7 +33,7 @@ let isPlaying = false;
  * @param {String} mediaObjectId 
  * @param {Array<String>} sectionIds array of ordered masterfile ids in the mediaobject
  */
-function addActionButtonListeners(player, mediaObjectId, sectionIds) {
+function addActionButtonListeners(player, mediaObjectId, sectionIds, sectionShareInfos) {
   if (player && player.player != undefined) {
     let currentIndex = parseInt(player.dataset.canvasindex);
     /* Ensure we only add player listeners once */
@@ -77,7 +77,7 @@ function addActionButtonListeners(player, mediaObjectId, sectionIds) {
         let timelineBtn = document.getElementById('timelineBtn');
 
         if (addToPlaylistBtn.disabled && thumbnailBtn.disabled && timelineBtn.disabled) {
-          buildActionButtons(player, mediaObjectId, sectionIds);
+          buildActionButtons(player, mediaObjectId, sectionIds, sectionShareInfos);
         }
       });
     }
@@ -101,7 +101,7 @@ function addActionButtonListeners(player, mediaObjectId, sectionIds) {
     if (currentIndex != canvasIndex && !player.player.canvasIsEmpty) {
       if (isMobile || player?.player.readyState() >= 2) {
         canvasIndex = currentIndex;
-        buildActionButtons(player, mediaObjectId, sectionIds);
+        buildActionButtons(player, mediaObjectId, sectionIds, sectionShareInfos);
         firstLoad = false;
       }
     }
@@ -111,7 +111,7 @@ function addActionButtonListeners(player, mediaObjectId, sectionIds) {
     */
     if (currentIndex != canvasIndex && player.player.canvasIsEmpty) {
       canvasIndex = currentIndex;
-      setUpShareLinks(mediaObjectId, sectionIds);
+      setUpShareLinks(mediaObjectId, sectionIds, sectionShareInfos);
       resetAllActionButtons();
     }
 
@@ -155,8 +155,8 @@ function resetAllActionButtons() {
  * @param {String} mediaObjectId 
  * @param {Array<String>} sectionIds array of ordered masterfile ids in the mediaobject
  */
-function buildActionButtons(player, mediaObjectId, sectionIds) {
-  setUpShareLinks(mediaObjectId, sectionIds);
+function buildActionButtons(player, mediaObjectId, sectionIds, sectionShareInfos) {
+  setUpShareLinks(mediaObjectId, sectionIds, sectionShareInfos);
   setUpAddToPlaylist(player, sectionIds, mediaObjectId);
   setUpCreateThumbnail(player, sectionIds);
   setUpCreateTimeline(player);
@@ -168,25 +168,15 @@ function buildActionButtons(player, mediaObjectId, sectionIds) {
  * @param {String} mediaObjectId 
  * @param {Array<String>} sectionIds array of ordered masterfile id in the mediaobject
  */
-function setUpShareLinks(mediaObjectId, sectionIds) {
+function setUpShareLinks(mediaObjectId, sectionIds, sectionShareInfos) {
   const sectionId = sectionIds[canvasIndex];
-  $.ajax({
-    url: '/media_objects/' + mediaObjectId + '/section/' + sectionId + '/stream',
-    type: 'GET',
-    success: function (data) {
-      const { lti_share_link, link_back_url, embed_code } = data;
-      $('#share-link-section')
-        .val(link_back_url)
-        .attr('placeholder', link_back_url);
-      $('#ltilink-section')
-        .val(lti_share_link)
-        .attr('placeholder', lti_share_link);
-      $('#embed-part').val(embed_code);
-    },
-    error: function (err) {
-      console.log(err);
-    }
-  });
+  const sectionShareInfo = sectionShareInfos[canvasIndex];
+  const { lti_share_link, link_back_url, embed_code } = sectionShareInfo;
+
+  $('#share-link-section').val(link_back_url).attr('placeholder', link_back_url);
+  $('#ltilink-section').val(lti_share_link).attr('placeholder', lti_share_link);
+  $('#embed-part').val(embed_code);
+
   shareListeners();
 }
 

--- a/app/models/concerns/master_file_behavior.rb
+++ b/app/models/concerns/master_file_behavior.rb
@@ -199,4 +199,34 @@ module MasterFileBehavior
   def rdf_type
     is_video? ? 'dctypes:MovingImage' : 'dctypes:Sound'
   end
+
+  def share_info
+    {
+      lti_share_link: lti_share_url,
+      link_back_url: share_link,
+      embed_code: embed_code(EMBED_SIZE[:medium], {urlappend: '/embed'})
+    }
+  end
+
+  protected
+
+  def share_link(only_path: false)
+    if permalink.present?
+      permalink
+    else
+      if only_path
+        Rails.application.routes.url_helpers.id_section_media_object_path(self.media_object_id, self.id)
+      else
+        Rails.application.routes.url_helpers.id_section_media_object_url(self.media_object_id, self.id)
+      end
+    end
+  end
+
+  def lti_share_url
+    if Avalon::Authentication.lti_configured?
+      Rails.application.routes.url_helpers.user_omniauth_callback_lti_url(target_id: self.id)
+    else
+      I18n.t('share.empty_lti_share_url')
+    end
+  end
 end

--- a/app/models/concerns/media_object_behavior.rb
+++ b/app/models/concerns/media_object_behavior.rb
@@ -83,4 +83,8 @@ module MediaObjectBehavior
     checkouts = Checkout.active_for_media_object(id)
     checkouts.select{ |ch| ch.user_id == user_id  }.first
   end
+
+  def section_share_infos
+    @share_infos ||= sections.collect { |section| section.share_info }
+  end
 end

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -62,6 +62,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     $(document).ready(function () {
       const mediaObjectId = <%= @media_object.id.to_json.html_safe %>;
       const sectionIds = <%= @media_object.section_ids.to_json.html_safe %>;
+      const sectionShareInfos = <%= @media_object.section_share_infos.to_json.html_safe %>;
       const transcriptSections = <%= @media_object.sections_with_files(tag: 'transcript').to_json.html_safe %>;
 
       // Enable action buttons after derivative is loaded
@@ -69,7 +70,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       function initActionButtons() {
         let player = document.getElementById('iiif-media-player');
         if (player) {
-          addActionButtonListeners(player, mediaObjectId, sectionIds);
+          addActionButtonListeners(player, mediaObjectId, sectionIds, sectionShareInfos);
         }
       } 
 

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -999,4 +999,34 @@ describe MasterFile do
       expect(MediaObjectIndexingJob).to have_been_enqueued.with(master_file.media_object.id)
     end
   end
+
+  describe '#share_info' do
+    let(:master_file) { FactoryBot.create(:master_file, :with_media_object) }
+    subject(:share_info) { master_file.share_info }
+
+    it 'is a hash of sharing urls and embed code' do
+      expect(share_info[:lti_share_link]).to eq "http://test.host/users/auth/lti/callback?target_id=#{master_file.id}"
+      expect(share_info[:link_back_url]).to eq "http://test.host/media_objects/#{master_file.media_object.id}/section/#{master_file.id}"
+      expect(share_info[:embed_code]).to include "http://test.host/master_files/#{master_file.id}/embed"
+    end
+
+    context 'with permalinks' do
+      let(:master_file) { FactoryBot.create(:master_file, :with_media_object, permalink: 'https://permalink.host/path/id') }
+
+      it 'uses permalinks' do
+        expect(share_info[:link_back_url]).to eq 'https://permalink.host/path/id'
+        expect(share_info[:embed_code]).to include "https://permalink.host/path/id?urlappend=%2Fembed"
+      end
+    end
+
+    context 'with LTI disabled' do
+      before do
+        allow(Avalon::Authentication).to receive(:lti_configured?).and_return(false)
+      end
+
+      it 'displays an notice for the lti_share_link' do
+        expect(share_info[:lti_share_link]).to eq I18n.t('share.empty_lti_share_url')
+      end
+    end
+  end
 end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -1309,4 +1309,12 @@ describe MediaObject do
       end
     end
   end
+
+  describe '#section_share_infos' do
+    let(:media_object) { FactoryBot.create(:media_object, :with_master_file) }
+
+    it 'is an array of hashes' do
+      expect(media_object.section_share_infos).to contain_exactly({lti_share_link: be_a(String), link_back_url: be_a(String), embed_code: be_a(String)})
+    end
+  end
 end


### PR DESCRIPTION
Part of #5543 and #5502

These changes remove the slow calls to `/stream` that happen on item view page load and section switches.  The share information is embedded in the page in the JS on page render which should be _much faster_ than calling `/stream`.
