### PR TITLE
Test docker environment shouldn't overwrite development environment when running tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,23 +25,19 @@ services:
     volumes: []
 
   fedora: &fedora
-    image: fcrepo/fcrepo:6.4.0
-    depends_on:
-      - db
+    image: fcrepo/fcrepo:6.5-tomcat9
     environment:
       - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false -Dfcrepo.aws.access-key=minio -Dfcrepo.aws.secret-key=minio123 -Dfcrepo.storage=ocfl-s3 -Dfcrepo.ocfl.s3.bucket=fcrepo -Dfcrepo.s3.endpoint=http://minio:9000 -Dfcrepo.aws.region=us-east-1
     networks:
-      external:
       internal:
-    ports:
-      - '8080:8080'
     ulimits:
       nofile:
         soft: "65536"
         hard: "65536"
   fedora-test:
     <<: *fedora
-    volumes: []
+    environment:
+      - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
 
   solr: &solr
     image: solr:9
@@ -105,9 +101,8 @@ services:
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=postgres://postgres:password@db/avalon
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
-      - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fcrepo/rest
-      - FEDORA_BASE_PATH=/test
+      - FEDORA_BASE_PATH=/dev
       - RAILS_ENV=development
       - RAILS_ADDITIONAL_HOSTS=avalon
       - SETTINGS__REDIS__HOST=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     volumes: []
 
   fedora: &fedora
-    image: fcrepo/fcrepo:6.5-tomcat9
+    image: fcrepo/fcrepo:6.4.0
+    depends_on:
+      - createbuckets
     environment:
       - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false -Dfcrepo.aws.access-key=minio -Dfcrepo.aws.secret-key=minio123 -Dfcrepo.storage=ocfl-s3 -Dfcrepo.ocfl.s3.bucket=fcrepo -Dfcrepo.s3.endpoint=http://minio:9000 -Dfcrepo.aws.region=us-east-1
     networks:
@@ -36,6 +38,7 @@ services:
         hard: "65536"
   fedora-test:
     <<: *fedora
+    depends_on: []
     environment:
       - CATALINA_OPTS=-Dfcrepo.autoversioning.enabled=false
 


### PR DESCRIPTION
Completes #6181 

Make fedora-test service usable by test independent of the fedora service (networking and storage)
Test environment doesn't use minio or streaming so do not depend on them and separate test services do not need to be created for them.

Also included in this PR is a bump to the fedora image to handle a tomcat security upgrade.