### PR TITLE
Ensure activeTrack is set for "add current track" playlist save action

### DIFF
--- a/app/assets/javascripts/player_listeners.js
+++ b/app/assets/javascripts/player_listeners.js
@@ -303,6 +303,9 @@ function addToPlaylistListeners(sectionIds, mediaObjectId) {
     e.preventDefault();
     let playlistId = $('#post_playlist_id').val();
     if ($('#playlistitem_scope_track')[0].checked) {
+      if (activeTrack === undefined) {
+        activeTrack = getActiveItem(false);
+      }
       let starttime = createTimestamp(activeTrack.times.begin, true);
       let endtime = createTimestamp(activeTrack.times.end, true);
       addPlaylistItem(playlistId, streamId, starttime, endtime);


### PR DESCRIPTION
Related issue: #6235

On MacOS devices the "Add current track" option in the add to playlist menu was not successfully adding the track in certain circumstances. This arose from `activeTrack` being undefined in the listener on the save button. It is still unclear why this value was not available as expected on MacOS and was fine on other desktop environments, but adding a fallback to set the `activeTrack` when it is undefined resolves the issue.