### PR TITLE
Do not include legacy captions in IIIF manifests

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -160,7 +160,7 @@ class IiifCanvasPresenter
 
     def supplemental_captions_transcripts
       files = master_file.supplemental_files(tag: 'caption') + master_file.supplemental_files(tag: 'transcript')
-      files += [master_file.captions] if master_file.captions.present? && master_file.captions.persisted?
+      files += [master_file.captions] if master_file.has_captions?
       files
     end
 

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -124,11 +124,6 @@ class IiifCanvasPresenter
     end
 
     def supplementing_content_data(file)
-      unless file.is_a?(SupplementalFile)
-        url = Rails.application.routes.url_helpers.captions_master_file_url(master_file.id)
-        return IIIFManifest::V3::AnnotationContent.new(body_id: url, **supplemental_attributes(file))
-      end
-
       tags = file.tags.reject { |t| t == 'machine_generated' }.compact
       case tags
       when ['caption']
@@ -159,9 +154,7 @@ class IiifCanvasPresenter
     end
 
     def supplemental_captions_transcripts
-      files = master_file.supplemental_files(tag: 'caption') + master_file.supplemental_files(tag: 'transcript')
-      files += [master_file.captions] if master_file.has_captions?
-      files
+      master_file.supplemental_files(tag: 'caption') + master_file.supplemental_files(tag: 'transcript')
     end
 
     def simple_iiif_range(label = stream_info[:label])

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -147,17 +147,11 @@ class IiifPlaylistCanvasPresenter
     end
 
     def supplemental_captions
-      files = master_file.supplemental_files(tag: 'caption')
-      files += [master_file.captions] if master_file.captions.present? && master_file.captions.persisted?
-      files
+      master_file.supplemental_files(tag: 'caption')
     end
 
     def supplemental_captions_data(file)
-      url = if !file.is_a?(SupplementalFile)
-              Rails.application.routes.url_helpers.captions_master_file_url(master_file.id)
-            elsif file.tags.include?('caption')
-              Rails.application.routes.url_helpers.captions_master_file_supplemental_file_url(master_file.id, file.id)
-            end
+      url = Rails.application.routes.url_helpers.captions_master_file_supplemental_file_url(master_file.id, file.id)
       IIIFManifest::V3::AnnotationContent.new(body_id: url, **supplemental_attributes(file))
     end
 

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -67,6 +67,7 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
   end
 
   def captions
+    return nil unless has_captions?
     load_subresource_content(:captions) rescue nil
   end
 

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -361,12 +361,8 @@ describe IiifCanvasPresenter do
       context 'legacy master file captions' do
         let(:master_file) { FactoryBot.create(:master_file, :with_waveform, :with_captions, supplemental_files_json: supplemental_files_json, media_object: media_object, derivatives: [derivative]) }
 
-        it 'includes the master file captions' do
-          expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq true
-        end
-
-        it 'includes the original filename' do
-          expect(subject.any? { |content| content.label['none'] == [master_file.captions.original_name] }).to eq true
+        it 'does not include the master file captions' do
+          expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq false
         end
       end
 

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -187,7 +187,7 @@ describe IiifPlaylistCanvasPresenter do
 
       it "includes paths to supplemental but NOT legacy caption files" do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}\/captions/ }).to eq true
-        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).not_to eq true
+        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq false
       end
 
       it "includes 'supplementing' motivation" do
@@ -216,7 +216,7 @@ describe IiifPlaylistCanvasPresenter do
 
       it "includes paths to supplemental but NOT legacy caption files" do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}\/captions/ }).to eq true
-        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).not_to eq true
+        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq false
       end
 
       it "includes 'highlighting' motivation" do

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -182,12 +182,12 @@ describe IiifPlaylistCanvasPresenter do
 
       it "serializes captions as iiif annotations" do
         expect(subject).to all be_a(IIIFManifest::V3::AnnotationContent)
-        expect(subject.length).to eq 2
+        expect(subject.length).to eq 1
       end
 
-      it "includes paths to supplemental and legacy caption files" do
+      it "includes paths to supplemental but NOT legacy caption files" do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}\/captions/ }).to eq true
-        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq true
+        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).not_to eq true
       end
 
       it "includes 'supplementing' motivation" do
@@ -203,7 +203,7 @@ describe IiifPlaylistCanvasPresenter do
 
       it "serializes captions as iiif annotations" do
         expect(subject).to all be_a(IIIFManifest::V3::AnnotationContent)
-        expect(subject.length).to eq 3
+        expect(subject.length).to eq 2
       end
 
       it "includes marker label" do
@@ -214,9 +214,9 @@ describe IiifPlaylistCanvasPresenter do
         expect(subject.any? { |content| content.media_fragment =~ /t=#{marker.start_time}/ }).to eq true
       end
 
-      it "includes paths to supplemental and legacy caption files" do
+      it "includes paths to supplemental but NOT legacy caption files" do
         expect(subject.any? { |content| content.body_id =~ /supplemental_files\/#{caption_file.id}\/captions/ }).to eq true
-        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).to eq true
+        expect(subject.any? { |content| content.body_id =~ /master_files\/#{master_file.id}\/captions/ }).not_to eq true
       end
 
       it "includes 'highlighting' motivation" do


### PR DESCRIPTION
Part of #6246 

Including any "legacy" captions in manifests was causing a separate solr call for each section whether it had legacy captions or not.  Removing them from manifests allows us to skip those solr calls keeping the number of solr calls around 6-7 no matter the number of sections in an item.  Legacy captions should have been migrated to supplemental file captions as part of upgrading to 7.7 and they are not shown in the manage files page nor anywhere else in the UI.