### PR TITLE
Use `load_reflections` when instantiating Speedy::AF records in `MediaObject#add_to_playlist`

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -109,7 +109,9 @@ class MediaObjectsController < ApplicationController
 
   # POST /media_objects/avalon:1/add_to_playlist
   def add_to_playlist
-    @media_object = params[:post][:masterfile_id].present? ? SpeedyAF::Proxy::MediaObject.find(params[:id]) : SpeedyAF::Proxy::MediaObject.find(params[:id], load_reflections: true)
+    if params[:post].present?
+      @media_object = params[:post][:masterfile_id].present? ? SpeedyAF::Proxy::MediaObject.find(params[:id]) : SpeedyAF::Proxy::MediaObject.find(params[:id], load_reflections: true)
+    end
     authorize! :read, @media_object
     masterfile_id = params[:post][:masterfile_id]
     playlist_id = params[:post][:playlist_id]

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -109,9 +109,8 @@ class MediaObjectsController < ApplicationController
 
   # POST /media_objects/avalon:1/add_to_playlist
   def add_to_playlist
-    if params[:post].present?
-      @media_object = params[:post][:masterfile_id].present? ? SpeedyAF::Proxy::MediaObject.find(params[:id]) : SpeedyAF::Proxy::MediaObject.find(params[:id], load_reflections: true)
-    end
+    add_to_playlist_params = params.require(:post).permit(:masterfile_id, :playlist_id, :playlistitem_scope)
+    @media_object = add_to_playlist_params.present? ? SpeedyAF::Proxy::MediaObject.find(params[:id]) : SpeedyAF::Proxy::MediaObject.find(params[:id], load_reflections: true)
     authorize! :read, @media_object
     masterfile_id = params[:post][:masterfile_id]
     playlist_id = params[:post][:playlist_id]

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -75,7 +75,7 @@ describe MediaObjectsController, type: :controller do
           expect(get :tree, params: { id: media_object.id }).to render_template('errors/restricted_pid')
           expect(get :deliver_content, params: { id: media_object.id, file: 'descMetadata' }).to render_template('errors/restricted_pid')
           expect(delete :destroy, params: { id: media_object.id }).to render_template('errors/restricted_pid')
-          expect(post :add_to_playlist, params: { id: media_object.id }).to render_template('errors/restricted_pid')
+          expect(post :add_to_playlist, params: { id: media_object.id, post: {} }).to render_template('errors/restricted_pid')
         end
         it "json routes should return 401" do
           expect(post :create, format: 'json').to have_http_status(401)
@@ -102,7 +102,7 @@ describe MediaObjectsController, type: :controller do
           expect(put :update, params: { id: media_object.id }).to render_template('errors/restricted_pid')
           expect(get :tree, params: { id: media_object.id }).to render_template('errors/restricted_pid')
           expect(get :deliver_content, params: { id: media_object.id, file: 'descMetadata' }).to render_template('errors/restricted_pid')
-          expect(post :add_to_playlist, params: { id: media_object.id }).to render_template('errors/restricted_pid')
+          expect(post :add_to_playlist, params: { id: media_object.id, post: { masterfile_id: nil } }).to render_template('errors/restricted_pid')
         end
         it "json routes should return 401" do
           expect(post :create, format: 'json').to have_http_status(401)


### PR DESCRIPTION
Related issue: #5989 

This commit also moves the `playlist.items +=` call out of the `each` block so that it is only triggered once.