### PR TITLE
Refactor to reduce solr requests needed to render playlist edit page

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -247,7 +247,7 @@ class PlaylistsController < ApplicationController
     authorize! :read, @playlist
 
     # Fetch all master files related to the playlist items in a single SpeedyAF::Base.where
-    master_file_ids = @playlist.items.collect { |item| item.clip.master_file_id }
+    master_file_ids = @playlist.clips.collect(&:master_file_id)
     master_files = []
     master_files = SpeedyAF::Proxy::MasterFile.where("id:#{master_file_ids.join(' id:')}", load_reflections: true) if master_file_ids.present?
     media_objects = master_files.collect(&:media_object).uniq(&:id)

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -99,6 +99,14 @@ class Playlist < ActiveRecord::Base
     access_token == token && visibility == Playlist::PRIVATE_WITH_TOKEN
   end
 
+  def clips_with_section_proxies
+    cached_clips = clips.to_a
+    section_ids = cached_clips.collect(&:master_file_id).uniq
+    sections = SpeedyAF::Proxy::MasterFile.where("id:#{section_ids.join(' id:')}")
+    cached_clips.map {|c| c.master_file = sections.find { |mf| mf.id == c.master_file_id }}
+    cached_clips
+  end
+
   class << self
     # Find the i18n default playlist name
     def default_folder_name

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -77,7 +77,9 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= form_for(@playlist, html: { id: 'playlist_sort_form', class: 'playlist_actions' }) do |fs| %>
     <div class="dd" data-playlist_id="<%= @playlist.id %>">
       <ol id="items" class="dd-list" style="list-style: none">
+        <% clips = @playlist.clips_with_section_proxies %>
         <% @playlist.items.each_with_index do |i, index| %>
+          <% clip = clips[index] %>
         <li class="container dd-item" data-id="<%= i.id %>">
           <div class="row">
             <div class="col-sm-2">
@@ -85,12 +87,12 @@ Unless required by applicable law or agreed to in writing, software distributed
               <%= text_field_tag "playlist[items_attributes[#{index}[position]]]", i.position, class: 'form-control position-input', form: 'playlist_sort_form' %>
               <%= hidden_field_tag "playlist[items_attributes[#{index}[id]]]", i.id, form: 'playlist_sort_form' %>
             </div>
-            <% if can? :read, i.clip.master_file %>
+            <% if can? :read, clip.master_file %>
               <div class="col-sm-8 title" style="margin-top:5px">
-                <%= link_to i.clip.title, i.clip.mediafragment_uri, id: "playlist_item_title_label_#{i.id}" %>
+                <%= link_to clip.title, clip.mediafragment_uri, id: "playlist_item_title_label_#{i.id}" %>
               </div>
               <div class="col-sm-2 text-right" style="margin-top:5px">
-                <button id="playlist_item_edit_button" class="btn btn-sm fa fa-edit" <%= i.clip.master_file.nil? ? 'disabled' : '' %>
+                <button id="playlist_item_edit_button" class="btn btn-sm fa fa-edit" <%= clip.master_file.nil? ? 'disabled' : '' %>
                   data-toggle="collapse" href="#playlist_item_edit_<%= i.id %>" aria-expanded="false" type="button">
                 </button>
                 <label>
@@ -100,12 +102,12 @@ Unless required by applicable law or agreed to in writing, software distributed
               </div>
             <% else %>
               <div class="col-sm-9 title" style="margin-top:5px">
-                <% if i.clip.master_file.nil? %>
+                <% if clip.master_file.nil? %>
                   <i class="fa fa-times-circle" title="The source for this item has been deleted"></i>
                   <span class="playlist_item_denied">[deleted item]</span>
                 <% else %>
                   <i class="fa fa-lock" title="You don't have permission to view this item"></i>
-                  <span class="playlist_item_denied">[inaccessible item] <%= i.clip.master_file.media_object.id %></span>
+                  <span class="playlist_item_denied">[inaccessible item] <%= clip.master_file.media_object_id %></span>
                 <% end %>
               </div>
               <div class="col-sm-1 form-check text-right">


### PR DESCRIPTION
While looking at #6268 I noticed the large number of solr requests being made to render the playlist edit page when there are many playlist items.  This PR shouldn't break anything and reduce the solr calls to 1 when rendering the form.