### PR TITLE
Dev environment improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM        bundle as bundle-dev
 LABEL       stage=build
 LABEL       project=avalon
 RUN         bundle config set --local without 'production' \
-         && bundle config set --local with 'aws development test postgres profiling' \
+         && bundle config set --local with 'aws development test postgres' \
          && bundle install
 
 
@@ -116,7 +116,7 @@ RUN         dpkg -i /chrome.deb || apt-get install -yf
 FROM        bundle as bundle-prod
 LABEL       stage=build
 LABEL       project=avalon
-RUN         bundle config set --local without 'development test profiling' \
+RUN         bundle config set --local without 'development test' \
          && bundle config set --local with 'aws production postgres' \
          && bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for building gems
-FROM        ruby:3.3-bullseye as bundle
+FROM        ruby:3.3-bookworm as bundle
 LABEL       stage=build
 LABEL       project=avalon
 RUN        apt-get update && apt-get upgrade -y build-essential && apt-get autoremove \
@@ -37,7 +37,7 @@ RUN         bundle config set --local without 'production' \
 
 
 # Download binaries in parallel
-FROM        ruby:3.3-bullseye as download
+FROM        ruby:3.3-bookworm as download
 LABEL       stage=build
 LABEL       project=avalon
 RUN         curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz | tar xvz -C /usr/bin/
@@ -50,12 +50,12 @@ RUN      apt-get -y update && apt-get install -y ffmpeg
 
 
 # Base stage for building final images
-FROM        ruby:3.3-slim-bullseye as base
+FROM        ruby:3.3-slim-bookworm as base
 LABEL       stage=build
 LABEL       project=avalon
-RUN         echo "deb     http://ftp.us.debian.org/debian/    bullseye main contrib non-free"  >  /etc/apt/sources.list.d/bullseye.list \
-         && echo "deb-src http://ftp.us.debian.org/debian/    bullseye main contrib non-free"  >> /etc/apt/sources.list.d/bullseye.list \
-         && cat /etc/apt/sources.list.d/bullseye.list \
+RUN         echo "deb     http://ftp.us.debian.org/debian/    bookworm main contrib non-free"  >  /etc/apt/sources.list.d/bookworm.list \
+         && echo "deb-src http://ftp.us.debian.org/debian/    bookworm main contrib non-free"  >> /etc/apt/sources.list.d/bookworm.list \
+         && cat /etc/apt/sources.list.d/bookworm.list \
          && mkdir -p /etc/apt/keyrings \
          && apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 ffmpeg \
          && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -122,7 +122,7 @@ RUN         bundle config set --local without 'development test' \
 
 
 # Install node modules
-FROM        node:20-bullseye-slim as node-modules
+FROM        node:20-bookworm-slim as node-modules
 LABEL       stage=build
 LABEL       project=avalon
 RUN         apt-get update && apt-get install -y --no-install-recommends git ca-certificates

--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,12 @@ gem 'with_locking'
 gem 'sequel'
 gem 'httpx'
 
+# Profiling tools - enable via AVALON_PROFILING environment variable
+gem 'rack-mini-profiler'
+gem 'flamegraph'
+gem 'stackprof'
+gem 'memory_profiler'
+
 group :development do
   gem 'capistrano', '~>3.6'
   gem 'capistrano-passenger', require: false
@@ -186,14 +192,6 @@ end
 # Install the bundle --with mysql if using mysql as the database backend
 group :mysql, optional: true do
   gem 'mysql2'
-end
-
-# Install the bundle --with profiling and enable via AVALON_PROFILING environment variable
-group :profiling, optional: true do
-  gem 'rack-mini-profiler'
-  gem 'flamegraph'
-  gem 'stackprof'
-  gem 'memory_profiler'
 end
 
 extra_gems = File.expand_path("../Gemfile.local", __FILE__)

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'sprockets', '~>3.7.2'
 gem 'sqlite3'
 # Force newer version of mail for compatibility with rails 6.0.6.1
 gem 'mail', '> 2.8.0.1'
+gem 'puma', '>= 6.4.2'
+gem 'puma-status'
 
 # Assets
 gem 'bootstrap', '4.6.2'
@@ -161,7 +163,6 @@ group :production do
   gem 'google-analytics-rails', '1.1.0'
   gem 'lograge'
   gem 'okcomputer'
-  gem 'puma', '>= 6.4.2'
 end
 
 # Install the bundle --with aws when running on Amazon Elastic Beanstalk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,6 +613,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     net-ssh (7.2.3)
+    net_http_unix (0.2.2)
     netrc (0.11.0)
     nio4r (2.7.4)
     noid (0.9.0)
@@ -667,8 +668,11 @@ GEM
       pry (>= 0.13.0)
     psych (3.3.4)
     public_suffix (6.0.1)
-    puma (6.4.3)
+    puma (6.6.0)
       nio4r (~> 2.0)
+    puma-status (1.7)
+      net_http_unix (~> 0.2)
+      parallel (~> 1)
     raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.13)
@@ -1106,6 +1110,7 @@ DEPENDENCIES
   pry-rails
   psych (< 4)
   puma (>= 6.4.2)
+  puma-status
   rack-cors
   rack-mini-profiler
   rails (~> 7.2.2)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,3 +31,6 @@ plugin :tmp_restart
 
 # Only use a pidfile when requested
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+state_path ENV["PUMA_STATE_PATH"] if ENV["PUMA_STATE_PATH"]
+activate_control_app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - minio
     environment:
       - APP_NAME=avalon
-      - BUNDLE_FLAGS=--with development postgres profiling --without production test
+      - BUNDLE_FLAGS=--with development postgres --without production test
       - ENCODE_WORK_DIR=/tmp
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=postgres://postgres:password@db/avalon
@@ -132,7 +132,7 @@ services:
       - SETTINGS__STREAMING__SERVER=nginx
       - SETTINGS__STREAMING__STREAM_TOKEN_TTL=20
       - SYSTEM_GROUPS=administrator,group_manager,manager
-      - AVALON_PROFILING=false
+      - AVALON_PROFILING=true
     volumes:
       - .:/home/app/avalon
       - npms:/home/app/avalon/node_modules
@@ -162,7 +162,7 @@ services:
       - FEDORA_BASE_PATH=/test
       - SOLR_URL=http://solr-test:8983/solr/avalon
       - RAILS_ENV=test
-      - BUNDLE_FLAGS=--with aws test postgres --without production profiling
+      - BUNDLE_FLAGS=--with aws test postgres --without production
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
     ports: []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,8 @@ services:
       - SETTINGS__STREAMING__SERVER=nginx
       - SETTINGS__STREAMING__STREAM_TOKEN_TTL=20
       - SYSTEM_GROUPS=administrator,group_manager,manager
+      - PIDFILE=tmp/pids/server.pid
+      - PUMA_STATE_PATH=tmp/puma.state
       - AVALON_PROFILING=true
     volumes:
       - .:/home/app/avalon


### PR DESCRIPTION
This PR includes two commits:
- Fix and re-enable profiling
- Switch to puma (from webrick) as the rails server
  - Configure puma to allow usage of `pumactl stats` and `puma-status tmp/puma.state`
- Update base images to Debian bookworm