### PR TITLE
Rename id for remove item button and delete unused popover handler

### DIFF
--- a/app/views/media_objects/_remove_item.html.erb
+++ b/app/views/media_objects/_remove_item.html.erb
@@ -14,4 +14,4 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<%= link_to "Delete this item", confirm_remove_media_object_path(@media_object), id: "special_button_color", class: "btn btn-outline btn-block", data:{testid: 'media-object-delete-btn'} %>
+<%= link_to "Delete this item", confirm_remove_media_object_path(@media_object), id: "media-object-delete-btn", class: "btn btn-outline btn-block", data:{testid: 'media-object-delete-btn'} %>


### PR DESCRIPTION
Resolves #6272 

It looks like the change in https://github.com/avalonmediasystem/avalon/commit/6bf6e371fc33816a7f751cc7430b5806e6f1c0f7 prevented the user from continuing to the confirmation page when they clicked the "Remove this item" button.  Since the behavior has been to go to a separate page instead of displaying a popover for a long time, I removed the special popover handling and renamed the id of the button to be more semantic.