### PR TITLE
Fix timings when creating timelines with section and subheading scopes

### DIFF
--- a/app/assets/javascripts/ramp_utils.js
+++ b/app/assets/javascripts/ramp_utils.js
@@ -121,7 +121,7 @@ function getTimelineScopes() {
     let tracks = parent.find('li a');
     trackCount = tracks.length;
     // Only assign begin/end when structure item is a subsection, not a top level section
-    if (next.length > 0) {
+    if (next.length >= 0) {
       begin = parseFloat(tracks[0].hash.split('#t=').reverse()[0].split(',')[0]) || 0;
       end = parseFloat(tracks[trackCount - 1].hash.split('#t=').reverse()[0].split(',')[1]) || '';
     }
@@ -139,7 +139,7 @@ function getTimelineScopes() {
   if (currentStructureItem !== currentSection) {
     scopes.push({
       label: currentSection[0].dataset.label,
-      times: { begin: 0, end: activeItem.times.end },
+      times: { begin: 0, end: parseFloat(currentSection[0].dataset.mediafrag.split('#t=').reverse()[0].split(',')[1]) || '' },
       tags: ['current-section']
     });
   }


### PR DESCRIPTION
Fixes #6271 

Besides fixing subheading scopes it appears that this also fixes an issue with section scope.  I don't think this will affect Add to Playlist scopes because they don't actually really use the begin/end values in the scopes returned by this function.

This change will need thorough testing with structures of different kinds: section with no structure, structure with only spans, structure with multiple spans under a heading, nested headings, etc.