### PR TITLE
[Docker] Don't overwrite custom controlled_vocabulary.yml when present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ USER        app
 ENV         RAILS_ENV=production
 
 RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') SHAKAPACKER_ASSET_HOST='' bundle exec rake assets:precompile
-RUN         cp config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
+RUN         cp -n config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 
 
 # Build production image


### PR DESCRIPTION
The default controlled_vocabulary.yml.example is copied to controlled_vocabulary.yml when creating the docker image.  When a customized controlled_vocabulary.yml already exists the docker image should include this instead of overwriting it with the default example file.

Resolves local production issue with missing units.