### PR TITLE
Provide download path for side-loaded mp3 derivatives with nginx streaming

### DIFF
--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -48,7 +48,7 @@ module Avalon
                    when :generic, :adobe
                      url.gsub(/(?:#{Regexp.escape(http_base)}\/)(?:audio-only\/)?(.*)(?:\.m3u8)/, '\1')
                    when :nginx
-                     url.gsub(/(?:#{Regexp.escape(Settings.streaming.http_base)}\/)(.*)(?:\/index\.m3u8)/, '\1')
+                     url.gsub(/(?:#{Regexp.escape(Settings.streaming.http_base)}\/)(.*(mp4|mp3))(?:\/index\.m3u8|$)/, '\1')
                    when :wowza
                      # Wowza HLS urls include the extension between the base and relative path.
                      # "http_base/extension:path/filename.extension/playlist.m3u8"

--- a/spec/models/derivative_spec.rb
+++ b/spec/models/derivative_spec.rb
@@ -153,6 +153,15 @@ describe Derivative do
         allow(Settings.streaming).to receive(:server).and_return(:nginx)
         expect(subject.download_path).to eq "file://6f69c008-06a4-4bad-bb60-26297f0b4c06/35bddaa0-fbb4-404f-ab76-58f22921529c/warning.mp4"
       end
+
+      context "with mp3 derivative" do
+        let(:hls_url) { "http://localhost:3000/streams/6f69c008-06a4-4bad-bb60-26297f0b4c06/35bddaa0-fbb4-404f-ab76-58f22921529c/warning.mp3" }
+
+        it "provides a file path" do
+          allow(Settings.streaming).to receive(:server).and_return(:nginx)
+          expect(subject.download_path).to eq "file://6f69c008-06a4-4bad-bb60-26297f0b4c06/35bddaa0-fbb4-404f-ab76-58f22921529c/warning.mp3"
+        end
+      end
     end
 
     describe "s3" do


### PR DESCRIPTION
Related to #6279 

This was overlooked when implementing the mp3 derivative streaming support.  There may be other places in the code that still assume HLS streaming and which might break when tried with side-loaded mp3s.