### PR TITLE
Fix playlist page after bringing in Ramp structure changes

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -82,9 +82,11 @@ const Ramp = ({
      */
     descriptionCheck = setInterval(prepInitialDescription, 100);
 
-    // Clear interval upon component unmounting
-    return () => clearInterval(interval);
-    return () => clearInterval(descriptionCheck);
+    // Clear intervals upon component unmounting
+    return () => {
+      clearInterval(interval);
+      clearInterval(descriptionCheck);
+    };
   }, []);
 
   /**
@@ -96,7 +98,7 @@ const Ramp = ({
     if (player && player.player != undefined && !player.player.isDisposed()) {
       let playerInst = player.player;
       playerInst.ready(() => {
-        let activeElement = document.getElementsByClassName('ramp--structured-nav__list-item active');
+        let activeElement = document.getElementsByClassName('ramp--structured-nav__tree-item active');
         if (activeElement != undefined && activeElement?.length > 0) {
           setActiveItemTitle(activeElement[0]?.dataset.label);
           setActiveItemSummary(activeElement[0]?.dataset.summary);

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -299,31 +299,13 @@
     max-height: 33.5px;
     align-items: center;
 
+    .slider {
+      height: 30px;
+      width: 55px;
+    }
     .ramp--auto-advance-label {
       font-weight: bold;
       padding: 0px;
-    }
-
-    .ramp--auto-advance-toggle {
-      width: 2.5rem;
-      height: 1.45rem;
-
-      .slider:before {
-        height: 1.1rem;
-        width: 1rem;
-        left: 0.16rem;
-        bottom: 0.16rem;
-      }
-
-      input:checked+.slider:before {
-        -webkit-transform: translateX(1.1rem);
-        -ms-transform: translateX(1.1rem);
-        transform: translateX(1.1rem);
-      }
-    }
-
-    label.ramp--auto-advance-toggle {
-      margin-bottom: 0px;
     }
   }
 
@@ -343,7 +325,7 @@
       display: flex;
       flex-direction: column-reverse;
       cursor: pointer;
-      
+
       &:last-child {
         border-bottom: none;
       }


### PR DESCRIPTION
This PR is fix the following broken styling and JS in playlist page with latest Ramp changes;
- some broken styling due to the changes to the `AutoAdvanceToggle` component
- change class name for active playlist item for populating the playlist item title below the player