### PR TITLE
Make .keep file when creating s3 dropbox directory

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -329,7 +329,7 @@ class Admin::Collection < ActiveFedora::Base
         obj = FileLocator::S3File.new(base_uri.join(n).to_s + '/').object
         obj.exists?
       end
-      absolute_path = base_uri.join(name).to_s + '/'
+      absolute_path = base_uri.join(name).to_s + '/.keep'
       obj = FileLocator::S3File.new(absolute_path).object
       Aws::S3::Client.new.put_object(bucket: obj.bucket_name, key: obj.key)
       self.dropbox_directory_name = name


### PR DESCRIPTION
Putting a placeholder file in the dropbox directory will keep it around if the last file is processed and removed from it.  Minio (and possibly s3) treat the directory as a prefix and not a first-order object and will automatically remove it when the prefix isn't used anymore.

Resolves #6267 

Note: I haven't been able to fully test this yet since my local machine is having some problems with the dev environment.  I did see that the `.keep` file was created with a new collection and on avalon-dev I saw that a `.keep` file will preserve a directory but I wasn't able to verify it works end-to-end.