### PR TITLE
Remove col-md breakpoint for tabs in items page

### DIFF
--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -72,15 +72,15 @@ const Ramp = ({
       startCanvasId={startCanvasId}
       startCanvasTime={startCanvasTime}>
       <Row className="ramp--all-components ramp--itemview">
-        <Col sm={12} md={9} lg={8}>
+        <Col sm={12} md={12} xl={8}>
           {(cdl.enabled && !cdl.can_stream)
             ? (<React.Fragment>
-                <div dangerouslySetInnerHTML={{ __html: cdl.embed }} />
-                <div className="ramp--rails-title">
-                  {<div className="object-title" dangerouslySetInnerHTML={{ __html: title.content }} />}
-                </div>
-              </React.Fragment>
-              )
+              <div dangerouslySetInnerHTML={{ __html: cdl.embed }} />
+              <div className="ramp--rails-title">
+                {<div className="object-title" dangerouslySetInnerHTML={{ __html: title.content }} />}
+              </div>
+            </React.Fragment>
+            )
             : (<React.Fragment>
               {sections_count > 0 &&
                 <React.Fragment>
@@ -101,7 +101,6 @@ const Ramp = ({
                           aria-controls="timelineModal"
                           disabled={true}
                           data-testid="media-object-create-timeline-btn"
-                        
                         >
                           Create Timeline
                         </button>
@@ -163,7 +162,7 @@ const Ramp = ({
             )
           }
         </Col>
-        <Col sm={12} md={3} lg={4} className="ramp--tabs-panel">
+        <Col sm={12} md={12} xl={4} className="ramp--tabs-panel">
           {cdl.enabled && <div dangerouslySetInnerHTML={{ __html: cdl.destroy }} />}
           <Tabs>
             <Tab eventKey="details" title="Details" >


### PR DESCRIPTION
Related issue: https://github.iu.edu/AvalonIU/Avalon/issues/362

The column display of the tabs panel and the media player uses Bootstrap's `col-*` classes to set the width of the columns for different viewports and these classes are called breakpoints. The breakpoint `md` class that was used in this grid display was setting the column width of the tabs panel to a smaller value which doesn't give much space for transcript cue display.
This specifically happens between viewport width between 768px and 1200px. In this viewport width range `col-md-3` and `col-lg-4` classes are applied for the `ramp--tabs-panel` column for viewport widths 768px -> 992px  and 992px -> 1200px respectively.

I checked the behavior of Aviary's annotations component for different viewports and from their CSS it seems they only display it side-by-side with the player for `xl` viewport widths (>1200px). Even though YouTube doesn't specify classes that conforms with Bootstrap's breakpoint classes they wrap the transcript display below the player once it reaches ~1000px viewport width.

Therefore, I replaced the `lg` breakpoint class with `xl` and set `md` class to span the full width of the tabs panel column.