### PR TITLE
Search result titles include duration and fallback to object id when title isn't present

### DIFF
--- a/app/components/index_header_media_object_component.rb
+++ b/app/components/index_header_media_object_component.rb
@@ -1,7 +1,10 @@
 class IndexHeaderMediaObjectComponent < Blacklight::DocumentTitleComponent
+  include TimeFormattingHelper
+
   def initialize(title = nil, document: nil, presenter: nil, as: :h3, counter: nil, classes: 'index_title document-title-heading col', link_to_document: true, document_component: nil, actions: true)
     super
     @classes += @actions.present? ? " col-sm-9 col-lg-10" : " col-md-12"
+    @title = search_result_label(presenter.document)
   end
 
   # Override to add test-id
@@ -11,5 +14,24 @@ class IndexHeaderMediaObjectComponent < Blacklight::DocumentTitleComponent
     else
       content_tag('span', @title.presence || content.presence || presenter.heading, itemprop: 'name')
     end
+  end
+
+  private
+
+  def search_result_label document
+    if document['title_tesi'].present?
+      label = truncate(document['title_tesi'], length: 100)
+    else
+      label = document[:id]
+    end
+
+    if document['duration_ssi'].present?
+      duration = document['duration_ssi']
+      if duration.respond_to?(:to_i) && duration.to_i > 0
+        label += " (#{milliseconds_to_formatted_time(duration.to_i, false)})"
+      end
+    end
+
+    label
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,23 +107,6 @@ module ApplicationHelper
     value = value == "true" ? 'Yes' : 'No'
   end
 
-  def search_result_label item
-    if item['title_tesi'].present?
-      label = truncate(item['title_tesi'], length: 100)
-    else
-      label = item[:id]
-    end
-
-    if item['duration_ssi'].present?
-      duration = item['duration_ssi']
-      if duration.respond_to?(:to_i) && duration.to_i > 0
-        label += " (#{milliseconds_to_formatted_time(duration.to_i, false)})"
-      end
-    end
-
-    label
-  end
-
   def stream_label_for(resource)
     if resource.title.present?
       resource.title
@@ -137,41 +120,6 @@ module ApplicationHelper
   #Taken from Hydra::Controller::ControllerBehavior
   def user_key
     current_user.user_key if current_user
-  end
-
-  # We are converting FFprobe's duration output to milliseconds for
-  # uniformity with existing metadata and consequently leaving these
-  # conversion methods in place for now.
-  def milliseconds_to_formatted_time(milliseconds, include_fractions = true)
-    total_seconds = milliseconds / 1000
-    hours = total_seconds / (60 * 60)
-    minutes = (total_seconds / 60) % 60
-    seconds = total_seconds % 60
-    fractional_seconds = milliseconds.to_s[-3, 3].to_i
-    fractional_seconds = (include_fractions && fractional_seconds.positive? ? ".#{fractional_seconds}" : '')
-
-    output = ''
-    if hours > 0
-      output += "#{hours}:"
-    end
-
-    output += "#{minutes.to_s.rjust(2,'0')}:#{seconds.to_s.rjust(2,'0')}#{fractional_seconds}"
-    output
-  end
-
-  # display millisecond times in HH:MM:SS.sss format
-  # @param [Float] milliseconds the time to convert
-  # @return [String] time in HH:MM:SS.sss
-  def pretty_time(milliseconds)
-    milliseconds = Float(milliseconds).to_int # will raise TypeError or ArgumentError if unparsable as a Float
-    return "00:00:00.000" if milliseconds <= 0
-
-    total_seconds = milliseconds / 1000.0
-    hours = (total_seconds / (60 * 60)).to_i.to_s.rjust(2, "0")
-    minutes = ((total_seconds / 60) % 60).to_i.to_s.rjust(2, "0")
-    seconds = (total_seconds % 60).to_i.to_s.rjust(2, "0")
-    frac_seconds = (milliseconds % 1000).to_s.rjust(3, "0")[0..2]
-    hours + ":" + minutes + ":" + seconds + "." + frac_seconds
   end
 
   FLOAT_PATTERN = Regexp.new(/^\d+([.]\d*)?$/).freeze

--- a/app/helpers/time_formatting_helper.rb
+++ b/app/helpers/time_formatting_helper.rb
@@ -1,0 +1,50 @@
+# Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+#   
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module TimeFormattingHelper
+  # We are converting FFprobe's duration output to milliseconds for
+  # uniformity with existing metadata and consequently leaving these
+  # conversion methods in place for now.
+  def milliseconds_to_formatted_time(milliseconds, include_fractions = true)
+    total_seconds = milliseconds / 1000
+    hours = total_seconds / (60 * 60)
+    minutes = (total_seconds / 60) % 60
+    seconds = total_seconds % 60
+    fractional_seconds = milliseconds.to_s[-3, 3].to_i
+    fractional_seconds = (include_fractions && fractional_seconds.positive? ? ".#{fractional_seconds}" : '')
+
+    output = ''
+    if hours > 0
+      output += "#{hours}:"
+    end
+
+    output += "#{minutes.to_s.rjust(2,'0')}:#{seconds.to_s.rjust(2,'0')}#{fractional_seconds}"
+    output
+  end
+
+  # display millisecond times in HH:MM:SS.sss format
+  # @param [Float] milliseconds the time to convert
+  # @return [String] time in HH:MM:SS.sss
+  def pretty_time(milliseconds)
+    milliseconds = Float(milliseconds).to_int # will raise TypeError or ArgumentError if unparsable as a Float
+    return "00:00:00.000" if milliseconds <= 0
+
+    total_seconds = milliseconds / 1000.0
+    hours = (total_seconds / (60 * 60)).to_i.to_s.rjust(2, "0")
+    minutes = ((total_seconds / 60) % 60).to_i.to_s.rjust(2, "0")
+    seconds = (total_seconds % 60).to_i.to_s.rjust(2, "0")
+    frac_seconds = (milliseconds % 1000).to_s.rjust(3, "0")[0..2]
+    hours + ":" + minutes + ":" + seconds + "." + frac_seconds
+  end
+end

--- a/spec/components/index_header_media_object_component_spec.rb
+++ b/spec/components/index_header_media_object_component_spec.rb
@@ -1,0 +1,50 @@
+# Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+RSpec.describe IndexHeaderMediaObjectComponent, type: :component do
+  let(:component) { described_class.new(presenter: presenter, **attr) }
+
+  let(:presented_document) { SolrDocument.new(id: 'abcd1234', title_tesi: 'Title', duration_ssi: '361000') }
+
+  let(:presenter) { vc_test_controller.view_context.document_presenter(presented_document) }
+
+  before do
+    with_controller_class(CatalogController) do
+      allow(vc_test_controller).to receive_messages(current_user: nil)
+      render_inline described_class.new(presenter: presenter)
+    end
+  end
+
+  it 'renders title with duration' do
+    expect(page).to have_content 'Title (06:01)'
+  end
+
+  context 'without title' do
+    let(:presented_document) { SolrDocument.new(id: 'abcd1234', duration_ssi: '361100') }
+
+    it 'renders id with duration' do
+      expect(page).to have_content 'abcd1234 (06:01)'
+    end
+  end
+
+  context 'without duration' do
+    let(:presented_document) { SolrDocument.new(id: 'abcd1234', title_tesi: 'Title') }
+
+    it 'renders title without duration' do
+      expect(page).to have_content 'Title'
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -72,21 +72,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#search_result_label" do
-    it "should not include a duration string if it would be 0" do
-      mo_solr_doc = {"title_tesi" => "my_title"}
-      expect(helper.search_result_label(mo_solr_doc)).not_to include("(00:00)")
-    end
-    it "should return formatted title if duration is present" do
-      mo_solr_doc = {"title_tesi" => "my_title", "duration_ssi" => "1000"}
-      expect(helper.search_result_label(mo_solr_doc)).to eq("my_title (00:01)")
-    end
-    it "should return id when no title" do
-      mo_solr_doc = { id: "avalon:123" }
-      expect(helper.search_result_label(mo_solr_doc)).to eq("avalon:123")
-    end
-  end
-
   describe "#titleize" do
     it "titleizes a string" do
       expect(helper.titleize("lower case phrase")).to eq "Lower Case Phrase"
@@ -108,17 +93,6 @@ describe ApplicationHelper do
     end
     it "shouldn't truncate if not needed" do
       expect(helper.truncate_center("This string is short", 20)).to eq "This string is short"
-    end
-  end
-
-  describe "#milliseconds_to_formatted_time" do
-    it "should return correct values" do
-      expect(helper.milliseconds_to_formatted_time(0)).to eq("00:00")
-      expect(helper.milliseconds_to_formatted_time(1000)).to eq("00:01")
-      expect(helper.milliseconds_to_formatted_time(60000)).to eq("01:00")
-      expect(helper.milliseconds_to_formatted_time(3600000)).to eq("1:00:00")
-      expect(helper.milliseconds_to_formatted_time(1123)).to eq("00:01.123")
-      expect(helper.milliseconds_to_formatted_time(1123, false)).to eq("00:01")
     end
   end
 
@@ -179,37 +153,6 @@ describe ApplicationHelper do
 
     it "should return 'No' for 'false'" do
       expect(helper.display_has_caption_or_transcript("false")).to eq("No")
-    end
-  end
-
-  describe "#pretty_time" do
-    it 'returns a formatted time' do
-      expect(helper.pretty_time(0)).to eq '00:00:00.000'
-      expect(helper.pretty_time(1)).to eq '00:00:00.001'
-      expect(helper.pretty_time(9)).to eq '00:00:00.009'
-      expect(helper.pretty_time(10)).to eq '00:00:00.010'
-      expect(helper.pretty_time(101)).to eq '00:00:00.101'
-      expect(helper.pretty_time(1010)).to eq '00:00:01.010'
-      expect(helper.pretty_time(10101)).to eq '00:00:10.101'
-      expect(helper.pretty_time(101010)).to eq '00:01:41.010'
-      expect(helper.pretty_time(1010101)).to eq '00:16:50.101'
-      expect(helper.pretty_time(10101010)).to eq '02:48:21.010'
-      expect(helper.pretty_time(0.0)).to eq '00:00:00.000'
-      expect(helper.pretty_time(0.1)).to eq '00:00:00.000'
-      expect(helper.pretty_time(1.1)).to eq '00:00:00.001'
-      expect(helper.pretty_time(-1000)).to eq '00:00:00.000'
-      expect(helper.pretty_time('0')).to eq '00:00:00.000'
-      expect(helper.pretty_time('1')).to eq '00:00:00.001'
-      expect(helper.pretty_time('10101010')).to eq '02:48:21.010'
-      expect(helper.pretty_time('-1000')).to eq '00:00:00.000'
-      expect(helper.pretty_time('0.0')).to eq '00:00:00.000'
-      expect(helper.pretty_time('0.1')).to eq '00:00:00.000'
-      expect(helper.pretty_time('1.1')).to eq '00:00:00.001'
-    end
-
-    it 'returns an exception when not a number' do
-      expect { helper.pretty_time(nil) }.to raise_error(TypeError)
-      expect { helper.pretty_time('foo') }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/helpers/time_formatting_helper_spec.rb
+++ b/spec/helpers/time_formatting_helper_spec.rb
@@ -1,0 +1,59 @@
+# Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe TimeFormattingHelper do
+    describe "#milliseconds_to_formatted_time" do
+    it "should return correct values" do
+      expect(helper.milliseconds_to_formatted_time(0)).to eq("00:00")
+      expect(helper.milliseconds_to_formatted_time(1000)).to eq("00:01")
+      expect(helper.milliseconds_to_formatted_time(60000)).to eq("01:00")
+      expect(helper.milliseconds_to_formatted_time(3600000)).to eq("1:00:00")
+      expect(helper.milliseconds_to_formatted_time(1123)).to eq("00:01.123")
+      expect(helper.milliseconds_to_formatted_time(1123, false)).to eq("00:01")
+    end
+  end
+
+  describe "#pretty_time" do
+    it 'returns a formatted time' do
+      expect(helper.pretty_time(0)).to eq '00:00:00.000'
+      expect(helper.pretty_time(1)).to eq '00:00:00.001'
+      expect(helper.pretty_time(9)).to eq '00:00:00.009'
+      expect(helper.pretty_time(10)).to eq '00:00:00.010'
+      expect(helper.pretty_time(101)).to eq '00:00:00.101'
+      expect(helper.pretty_time(1010)).to eq '00:00:01.010'
+      expect(helper.pretty_time(10101)).to eq '00:00:10.101'
+      expect(helper.pretty_time(101010)).to eq '00:01:41.010'
+      expect(helper.pretty_time(1010101)).to eq '00:16:50.101'
+      expect(helper.pretty_time(10101010)).to eq '02:48:21.010'
+      expect(helper.pretty_time(0.0)).to eq '00:00:00.000'
+      expect(helper.pretty_time(0.1)).to eq '00:00:00.000'
+      expect(helper.pretty_time(1.1)).to eq '00:00:00.001'
+      expect(helper.pretty_time(-1000)).to eq '00:00:00.000'
+      expect(helper.pretty_time('0')).to eq '00:00:00.000'
+      expect(helper.pretty_time('1')).to eq '00:00:00.001'
+      expect(helper.pretty_time('10101010')).to eq '02:48:21.010'
+      expect(helper.pretty_time('-1000')).to eq '00:00:00.000'
+      expect(helper.pretty_time('0.0')).to eq '00:00:00.000'
+      expect(helper.pretty_time('0.1')).to eq '00:00:00.000'
+      expect(helper.pretty_time('1.1')).to eq '00:00:00.001'
+    end
+
+    it 'returns an exception when not a number' do
+      expect { helper.pretty_time(nil) }.to raise_error(TypeError)
+      expect { helper.pretty_time('foo') }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,8 @@ require 'noid/rails/rspec'
 require "email_spec"
 require "email_spec/rspec"
 require 'webdrivers'
+require "view_component/test_helpers"
+require "view_component/system_test_helpers"
 # require 'equivalent-xml/rspec_matchers'
 # require 'fakefs/safe'
 # require 'fileutils'
@@ -192,6 +194,8 @@ RSpec.configure do |config|
   config.include FixtureMacros, type: :controller
   config.include OptionalExample
   config.include Features::SessionHelpers, type: :feature
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponent::SystemTestHelpers, type: :component
 end
 
 FactoryBot::SyntaxRunner.class_eval do


### PR DESCRIPTION
The commit restores the pre-BL8 title behavior by moving the search_result_label helper into the component and splitting some time formatting helpers into their own helper file to make a more minimal include into the component.  Also setup testing for components.

Resolves #6337 