### PR TITLE
Fix Blacklight JSON responses

### DIFF
--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,7 +1,7 @@
 require 'blacklight'
 
 Rails.application.config.to_prepare do
-  module Blacklight::UrlHelperBehavior
+  Blacklight::SearchState.class_eval do
     def url_for_document doc, options = {}
       SpeedyAF::Base.for(doc.to_h.with_indifferent_access)
     end


### PR DESCRIPTION
Blacklight 8 changed where `url_for_document` is implemented so the call to `polymorphic_url` was returning a url helper name (`show_solr_document_url`) that didn't exist.  Fixing Avalon's override of `url_for_document` causes the correct url helper to be returned (`media_object_url`).

Resolves #6359 