### PR TITLE
Use new combined redis url setting

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -26,7 +26,7 @@ ActiveJob::Uniqueness.configure do |config|
   # Array of redis servers for Redlock quorum.
   # Read more at https://github.com/leandromoreira/redlock-rb#redis-client-configuration
   #
-  config.redlock_servers = ["redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}"]
+  config.redlock_servers = [Settings.redis.url || "redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}"]
 
   # Custom options for Redlock.
   # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
-redis_conn = { url: "redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}" }
+redis_url = Settings.redis.url || "redis://#{Settings.redis.host}:#{Settings.redis.port}/#{Settings.redis.db}"
+redis_conn = { url: redis_url }
 Sidekiq.configure_server do |s|
   s.redis = redis_conn
 end


### PR DESCRIPTION
The `docker-compose.yml` file switched to use `SETTINGS__REDIS__URL` from the component ENV vars in #6360.  This PR continues the approach taken there and applies it to the other two initializers that set redis connections.  This resolves sidekiq being unable to connect to redis.  (I had to rebuild my worker container for this change to work but that may have been peculiar to my environment.)