### PR TITLE
Fix unsupported ARIA by adding role attr. to tabs

### DIFF
--- a/app/views/playlists/_share.html.erb
+++ b/app/views/playlists/_share.html.erb
@@ -14,14 +14,14 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <div id="share-list" data-testid="playlist-share-list">
-    <nav class="nav nav-tabs share-tabs">
-      <%= render_conditional_partials :share, section:'share-tabs' %>
-    </nav>
+  <nav class="nav nav-tabs share-tabs" role="tablist">
+    <%= render_conditional_partials :share, section:'share-tabs' %>
+  </nav>
 
-    <div class="tab-content">
-      <%= render_conditional_partials :share, section:'tab-content' %>
-    </div>
+  <div class="tab-content">
+    <%= render_conditional_partials :share, section:'tab-content' %>
   </div>
+</div>
 
 <% content_for :page_scripts do %>
 

--- a/app/views/playlists/_share_resource.html.erb
+++ b/app/views/playlists/_share_resource.html.erb
@@ -34,5 +34,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
   </div>
 <% elsif section=='share-tabs' %>
-  <a class="nav-link nav-item active" href="#link-tab" data-toggle="tab">Share this playlist</a>
+  <a class="nav-link nav-item active" href="#link-tab" data-toggle="tab" role="tab">Share this playlist</a>
 <% end %>


### PR DESCRIPTION
Related issue: #6357 

There are other tab-panel implementations in Avalon, and SiteImprove doesn't complain about them with this error. One such implementation is the `Details`, and `Files` tab implementation in the item view page. This is implemented using components from `react-bootstrap`. And it provides required `aria-*` attributes out of the box for its components.

Since the share tab panels are implemented using similar elements in Avalon code, this PR adds `role` attributes to the playlist share tabs mimicking  the `react-bootstrap` implementation of tabs. We should probably do the same for share tabs in the item view page.