### PR TITLE
Fix unsupported ARIA by adding role attr. to share-tabs

### DIFF
--- a/app/views/media_objects/_share.html.erb
+++ b/app/views/media_objects/_share.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 
 <div id="share-list">
-  <nav class="nav nav-tabs share-tabs">
+  <nav class="nav nav-tabs share-tabs" role="tablist">
     <%= render_conditional_partials :share, section:'share-tabs' %>
   </nav>
 

--- a/app/views/media_objects/_share_resource.html.erb
+++ b/app/views/media_objects/_share_resource.html.erb
@@ -37,5 +37,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     </form>
   </div>
 <% elsif section=='share-tabs' %>
-  <a href="#link-tab" data-toggle="tab" class="nav-item nav-link active">Share this resource</a>
+  <a href="#link-tab" data-toggle="tab" role="tab" class="nav-item nav-link active">Share this resource</a>
 <% end %>


### PR DESCRIPTION
Accessibility fixes around unsupported ARIA attributes in the share tabs in item view page.
Related: https://github.com/avalonmediasystem/avalon/pull/6380