### PR TITLE
Bring avalon-workflow into avalon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,6 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', '~> 0.6'
 gem 'speedy-af', '~> 0.4.0'
 
-# Avalon Components
-gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r8.0'
-
 # Authentication & Authorization
 gem 'devise', '~> 4.8'
 gem 'devise_invitable', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,13 +15,6 @@ GIT
       about_page
 
 GIT
-  remote: https://github.com/avalonmediasystem/avalon-workflow.git
-  revision: 503f5fd195359ca73e7facf79843381c611cfa0b
-  tag: avalon-r8.0
-  specs:
-    avalon-workflow (0.0.3)
-
-GIT
   remote: https://github.com/avalonmediasystem/browse-everything.git
   revision: 3d03380a73b2bf97cb94ea987f725d15bc71af12
   branch: v1.5-avalon
@@ -1001,7 +994,6 @@ DEPENDENCIES
   api-pagination
   audio_waveform-ruby (~> 1.0.7)
   avalon-about!
-  avalon-workflow!
   aws-activejob-sqs
   aws-partitions
   aws-sdk-cloudfront

--- a/app/controllers/concerns/workflow_controller_behavior.rb
+++ b/app/controllers/concerns/workflow_controller_behavior.rb
@@ -1,0 +1,127 @@
+# --- BEGIN LICENSE_HEADER BLOCK ---
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module WorkflowControllerBehavior
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :update_active_step, only: [:edit, :update]
+  end
+
+  def update_active_step
+    #FIXME make this follow ||= pattern
+    @active_step = params[:step] || model_object.workflow.last_completed_step.first
+    @active_step = HYDRANT_STEPS.first.step if @active_step.blank?
+  end
+
+  def inject_workflow_steps
+    @workflow_steps = HYDRANT_STEPS
+  end
+
+  def edit
+    context = perform_step_action :before_step
+
+    custom_edit #yield to custom_edit in the controller
+
+    prev_step = HYDRANT_STEPS.previous(@active_step)
+    unless prev_step.nil? || model_object.workflow.completed?(prev_step.step)
+      redirect_to edit_polymorphic_path(model_object)
+      return
+    end
+  end
+
+  def custom_edit
+  end
+
+  def update
+    context = perform_step_action :execute
+
+    # yield to custom_update in the controller
+    custom_update
+
+
+    # if object has updated attributes and or the step has changed
+    if model_object.save
+      if params[:save_and_continue].present?
+        model_object.workflow.update_status(@active_step)        
+        if HYDRANT_STEPS.has_next?(@active_step)
+          @active_step = HYDRANT_STEPS.next(@active_step).step
+        elsif model_object.workflow.published?
+          @active_step = 'published'
+        end
+        model_object.workflow.save!
+      end
+    end
+
+    respond_to do |format|
+      format.html do 
+        flashes = { error: context[:error], notice: context[:notice]}
+        if model_object.errors.present?
+          flash.now[:error] = 'There are errors with your submission. Please correct them before continuing.'
+
+          # Refresh the context before rendering edit
+          context = HYDRANT_STEPS.get_step(@active_step).send(:before_step, context)
+          context_to_instance_variables context
+          custom_edit #yield to custom_edit in the controller
+
+          render :edit
+        elsif model_object.workflow.published? && model_object.workflow.current?(@active_step)
+          redirect_to(polymorphic_path(model_object), flash: flashes)
+        else
+          redirect_to(get_redirect_path(@active_step, model_object), flash: flashes)
+        end
+      end
+    end
+
+  end
+
+  def custom_update
+  end
+
+  def model_object
+    @model_object ||= ActiveFedora::Base.find(params[:id], cast: true)
+  end
+
+  def build_context
+    params.merge!({model_variable_name.to_sym => model_object, user: user_key})
+  end
+
+  def model_variable_name
+    controller_name.classify.downcase
+  end
+
+  def perform_step_action action
+    context = HYDRANT_STEPS.get_step(@active_step).send(action, build_context)
+    context_to_instance_variables context
+    context
+  end
+
+  protected
+
+  def context_to_instance_variables context
+    #copy everything out of context and into instance variables
+    context.each {|k,v| self.instance_variable_set("@#{k}", v)}
+  end 
+
+  def get_redirect_path(target, obj)
+    unless HYDRANT_STEPS.last?(params[:step]) && @active_step == "published"
+      redirect_path = edit_polymorphic_path(obj, step: target)
+    else
+      redirect_path = polymorphic_path(obj)
+    end
+
+    redirect_path
+  end
+end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -17,7 +17,7 @@ require 'avalon/intercom'
 
 class MediaObjectsController < ApplicationController
   include Rails::Pagination
-  include Avalon::Workflow::WorkflowControllerBehavior
+  include WorkflowControllerBehavior
   include Avalon::Controller::ControllerBehavior
   include ConditionalPartials
   include NoidValidator

--- a/app/models/access_control_step.rb
+++ b/app/models/access_control_step.rb
@@ -12,7 +12,7 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-class AccessControlStep < Avalon::Workflow::BasicStep
+class AccessControlStep < BasicStep
   def initialize(step = 'access-control',
                  title = "Access Control",
                  summary = "Who can access the item",

--- a/app/models/basic_step.rb
+++ b/app/models/basic_step.rb
@@ -1,0 +1,65 @@
+# --- BEGIN LICENSE_HEADER BLOCK ---
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+# basic_step.rb
+#
+# This template lays out the API for implementing your own custom steps. As a
+# class it should never be used since its own implementations are trivial at
+# best (unless you need a NoOp operation)
+#
+# Workflow state is designed to be chained so that multiple operations can be
+# performed in sequence. Make sure that your own steps return the modified
+# application context for use by methods down the line
+class BasicStep
+  attr_accessor :step, :title, :summary, :template
+
+  def initialize(step = nil, title = nil, summary = nil, template = nil)
+    self.step = step
+    self.title = title
+    self.summary = summary
+    self.template = template
+  end
+
+  # before_step will execute to set the context for an operation.
+  # If you need to load options for forms, verify MD5 checksums, or
+  # other similar functions this is the place to perform those
+  # calls 
+  #
+  # This method is analogous to the processing that would take place
+  # within the edit step of a controller to set up the view and
+  # environment for users
+  def before_step context
+    context
+  end
+
+  # after_step does the same except that it will fire once a step's
+  # perform method has finished. Example implementations here might
+  # include moving files, cleaning up and validating metadata, or
+  # rewinding the current step if it should not advance
+  def after_step context
+    context
+  end
+
+  # execute should take care of the actual events that need to happen
+  # when an operation is triggered. The context object which is passed
+  # should provide all the necessary information for the step. Any
+  # changes should be pushed out through the context object.
+  #
+  # If a step has certain dependencies beyond the basic Hydra options
+  # they should be expressed locally (ie at the top of that step).
+  def execute context
+    context
+  end
+end

--- a/app/models/concerns/workflow_model_mixin.rb
+++ b/app/models/concerns/workflow_model_mixin.rb
@@ -1,0 +1,22 @@
+# --- BEGIN LICENSE_HEADER BLOCK ---
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module WorkflowModelMixin
+  def self.included(klazz)
+    klazz.has_subresource 'workflow', class_name: 'WorkflowDatastream' do |f|
+      f.original_name = "workflow.xml"
+    end
+  end
+end

--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -14,7 +14,7 @@
 
 require 'avalon/dropbox'
 
-class FileUploadStep < Avalon::Workflow::BasicStep
+class FileUploadStep < BasicStep
   def initialize(step = 'file-upload',
                  title = "Manage files",
                  summary = "Associated bitstreams",

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -18,7 +18,7 @@ class MediaObject < ActiveFedora::Base
   include VirtualGroups
   include ActiveFedora::Associations
   include MediaObjectMods
-  include Avalon::Workflow::WorkflowModelMixin
+  include WorkflowModelMixin
   include Permalink
   include Identifier
   include MigrationTarget

--- a/app/models/resource_description_step.rb
+++ b/app/models/resource_description_step.rb
@@ -12,7 +12,7 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-class ResourceDescriptionStep < Avalon::Workflow::BasicStep
+class ResourceDescriptionStep < BasicStep
   def initialize(step = 'resource-description', title = "Resource description", summary = "Metadata about the item", template = 'resource_description')
     super
   end

--- a/app/models/structure_step.rb
+++ b/app/models/structure_step.rb
@@ -12,16 +12,16 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
-  class StructureStep < Avalon::Workflow::BasicStep
-    def initialize(step = 'structure', title = "Structure", summary = "Organization of resources", template = 'structure')
-      super
-    end
-
-    def execute context
-      media_object = context[:media_object]
-      if context[:master_file_ids].present?
-        media_object.section_ids = context[:master_file_ids]
-      end
-      context
-    end
+class StructureStep < BasicStep
+  def initialize(step = 'structure', title = "Structure", summary = "Organization of resources", template = 'structure')
+    super
   end
+
+  def execute context
+    media_object = context[:media_object]
+    if context[:master_file_ids].present?
+      media_object.section_ids = context[:master_file_ids]
+    end
+    context
+  end
+end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,0 +1,109 @@
+# --- BEGIN LICENSE_HEADER BLOCK ---
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class Workflow
+  @_states = []
+  @_states_order = []
+  
+  def initialize(*steps)
+    @_states = {}
+    @_states_order = []
+  
+    steps.each do |step|
+      @_states[step.step.to_s] = step
+      @_states_order.push(step.step)
+    end
+    @_states.freeze
+    @_states_order.freeze
+  end
+  
+  def get_step(name)
+    @_states[name]
+  end
+
+  def first?(step)
+    step == @_states_order.first
+  end
+  
+  def first
+    @_states[@_states_order.first]
+  end
+  
+  def last
+    @_states[@_states_order.last]
+  end
+  
+  def last?(step)
+    step == @_states_order.last
+  end
+
+  def has_next?(step)
+    not self.next(step).nil?
+  end
+  
+  def next(step)
+    offset = get_key_index(step)
+    next_step = nil
+    
+    unless last?(step) or offset.nil?
+      offset = offset + 1
+      next_step = @_states[@_states_order[offset]]
+    end
+    
+    # Return the next step
+    next_step
+  end
+  
+  def previous(step)
+    offset = get_key_index(step)
+    previous_step = nil
+    
+    unless first?(step) or offset.nil?
+      offset = offset - 1
+      previous_step = @_states[@_states_order[offset]]
+    end
+    
+    # Return the next step
+    previous_step
+  end
+  
+  def index(step)
+    index = get_key_index(step)
+    unless index.nil?
+      index + 1
+    else
+      nil
+    end
+  end
+  
+  def exists?(step)
+    @_states.key?(step)
+  end
+  
+  # Override so it returns a array of just the steps
+  def to_a
+    @_states.values
+  end
+  
+  def template(step)
+    target_step = @_states[step]
+    target_step.template
+  end
+        
+  protected
+  def get_key_index(step)
+    @_states_order.index(step)
+  end
+end

--- a/app/models/workflow_datastream.rb
+++ b/app/models/workflow_datastream.rb
@@ -1,0 +1,178 @@
+# --- BEGIN LICENSE_HEADER BLOCK ---
+# Copyright 2011-2013, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed 
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class WorkflowDatastream < ActiveFedora::OmDatastream
+  before_save :reset_values
+
+  set_terminology do |t|
+    t.root(path: 'workflow')
+    
+    t.last_completed_step(path: 'last_completed_step')
+    t.published(path: 'published')
+    t.origin(path: 'origin')
+  end
+
+  def published?
+    published.first.eql? true.to_s
+  end
+
+  def published= publication_status
+     update_values({[{:published=>"0"}]=>{"0"=>publication_status.to_s}})
+  end
+
+  def last_completed_step= active_step
+    active_step = active_step.first if active_step.is_a? Array
+    unless HYDRANT_STEPS.exists? active_step
+      Rails.logger.warn "Unrecognized step : #{active_step}"
+    end
+    
+    # Set it anyways for now. Need to come up with a more robust warning
+    # system down the road
+    update_values({[{:last_completed_step=>"0"}]=>{"0"=>active_step}})
+  end 
+  
+  def origin= source
+    unless ['batch', 'web', 'console'].include? source
+      Rails.logger.warn "Unrecognized origin : #{source}"
+      update_values({[{:origin=>"0"}]=>{"0"=>"unknown"}})
+    else
+      update_values({[{:origin=>"0"}]=>{"0"=>source}})
+    end
+  end
+
+      # Return true if the step is current or prior to the parameter passed in
+      # Defaults to false if the step is not recognized
+      def completed?(step_name)
+        status_flag = published? || false
+        unless published?
+          step_index = HYDRANT_STEPS.index(step_name)
+          current_index = HYDRANT_STEPS.index(step_name)
+          last_index = HYDRANT_STEPS.index(last_completed_step.first)
+          unless (current_index.nil? or last_index.nil?)
+            status_flag = (last_index >= current_index)
+          end
+        end
+        status_flag
+      end
+
+      # Current can be true if the last_completed_step is defined as the
+      # step prior to the current one. If the step given is the first and
+      # the value of last_completed_step is blank then it is also true
+      #
+      # Otherwise assume the result should be false because you are on a
+      # different step
+      def current?(step_name)
+        current = case
+                  when HYDRANT_STEPS.first?(step_name)
+                    last_completed_step.first.empty?
+                  when HYDRANT_STEPS.exists?(step_name)
+                    previous_step = HYDRANT_STEPS.previous(step_name)
+                    (last_completed_step.first == previous_step.step)
+                  else
+                    false
+                  end
+
+        current
+      end
+      
+      def active?(step_name)
+        completed?(step_name) or current?(step_name)
+      end
+
+      # Advance should recognize that a step is invalid and respond by 
+      # defaulting to the first known step. If you are already on the last
+      # step then don't advance any further. There's a potential for silently
+      # failing here but this is a first pass only
+      def advance
+	lcs = (last_completed_step.is_a? Array) ? last_completed_step.first : last_completed_step
+
+	if (lcs.blank? or not HYDRANT_STEPS.exists?(lcs))
+	  Rails.logger.warn "<< Step #{lcs} invalid, defaulting to first step >>"
+	  self.last_completed_step = HYDRANT_STEPS.first.step
+	elsif (not HYDRANT_STEPS.last?(lcs))
+	  next_step = HYDRANT_STEPS.next(lcs).step
+	  Rails.logger.debug "<< Advancing to the next step - #{next_step} >>"
+          self.last_completed_step = next_step 
+        end
+      end
+
+      def publish
+        self.last_completed_step = HYDRANT_STEPS.last.step 
+        self.published = true.to_s
+      end
+      
+  def update_status(active_step=nil)
+      Rails.logger.debug "<< UPDATE_INGEST_STATUS >>"
+      active_step = active_step || last_completed_step.first
+      Rails.logger.debug "<< COMPLETED : #{completed?(active_step)} >>"
+
+      if current?(active_step) and not published?
+        advance
+      end
+
+      if HYDRANT_STEPS.last? active_step and completed? active_step
+        publish
+      end
+      Rails.logger.debug "<< PUBLISHED : #{published?} >>"
+  end
+
+  def self.xml_template
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.workflow do
+        xml.last_completed_step '' 
+        xml.published false.to_s
+        xml.origin 'unknown' 
+      end
+    end
+    
+    builder.doc
+  end
+
+  def to_solr(solr_doc=Hash.new, opts = {})
+    super(solr_doc, opts)
+
+    solr_value = case last_completed_step.first
+    when blank?
+      'New'
+    when 'preview'
+      'Completed'
+    else
+      'In progress'
+    end
+    # Compatible with both Solrizer 2.x and 3.x
+    mapper = Solrizer.respond_to?(:default_field_mapper) ? Solrizer.default_field_mapper : Solrizer::FieldMapper::Default.new
+
+    solr_doc.merge!(mapper.solr_name('workflow_status',:facetable) => solr_value)
+    published_value = published? ? 'Published' : 'Unpublished'
+    solr_doc.merge!(mapper.solr_name('workflow_published',:facetable) => published_value)
+  end
+
+      protected
+      def reset_values
+        Rails.logger.debug "<< BEFORE_SAVE (IngestStatus) >>"
+        Rails.logger.debug "<< last_completed_step => #{last_completed_step} >>"
+        
+        if published.nil?
+          Rails.logger.debug "<< Default published flag = false >>"
+          published = false
+        end
+        
+        if last_completed_step.nil?
+          Rails.logger.debug "<< Default step = #{HYDRANT_STEPS.first.step} >>"
+          last_completed_step = HYDRANT_STEPS.first.step
+        end
+      end
+
+end

--- a/config/initializers/workflow_steps.rb
+++ b/config/initializers/workflow_steps.rb
@@ -1,6 +1,6 @@
 Rails.application.config.to_prepare do
-  HYDRANT_STEPS = Avalon::Workflow::Workflow.new(FileUploadStep.new,
-                                                 ResourceDescriptionStep.new,
-                                                 StructureStep.new,
-                                                 AccessControlStep.new)
+  HYDRANT_STEPS = Workflow.new(FileUploadStep.new,
+                               ResourceDescriptionStep.new,
+                               StructureStep.new,
+                               AccessControlStep.new)
 end

--- a/lib/avalon/batch/ingest.rb
+++ b/lib/avalon/batch/ingest.rb
@@ -13,7 +13,6 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 require 'iconv'
-require 'avalon/workflow/workflow_controller_behavior'
 require 'avalon/controller/controller_behavior'
 require 'avalon/dropbox'
 


### PR DESCRIPTION
The `avalon-workflow` gem was created at the beginning of avalon but hasn't proven to be useful as a separate project so this PR folds it back into the main avalon repo for ease of development.