### PR TITLE
Work towards not fetching sections data on item show view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,8 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'rails_same_site_cookie'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'samvera-persona', '~> 0.6'
-gem 'speedy-af', '~> 0.4.0'
+#gem 'speedy-af', '~> 0.4.0'
+gem 'speedy-af', git: 'https://github.com/samvera-labs/speedy_af.git', branch: 'filter_reflections'
 
 # Authentication & Authorization
 gem 'devise', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,15 @@ GIT
       rails
 
 GIT
+  remote: https://github.com/samvera-labs/speedy_af.git
+  revision: 23fffc5f4b13850aba4c73138fcd86a2bf965daa
+  branch: filter_reflections
+  specs:
+    speedy-af (0.4.0)
+      active-fedora (>= 11.0.0)
+      activesupport (> 5.2)
+
+GIT
   remote: https://github.com/samvera/active_fedora.git
   revision: 7f91e09e630f7e3c1eb3d355e5a016ae8af44778
   ref: 7f91e09e630f7e3c1eb3d355e5a016ae8af44778
@@ -395,7 +404,7 @@ GEM
       faraday
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     fastimage (2.4.0)
     fcrepo_wrapper (0.9.0)
@@ -542,7 +551,7 @@ GEM
       nokogiri (~> 1.0)
       rexml
     marcel (1.0.4)
-    matrix (0.4.2)
+    matrix (0.4.3)
     memory_profiler (1.1.0)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -612,7 +621,7 @@ GEM
       ruby-saml (~> 1.18)
     orm_adapter (0.5.0)
     os (1.1.4)
-    ostruct (0.6.1)
+    ostruct (0.6.2)
     package_json (0.1.0)
     parallel (1.27.0)
     paranoia (3.0.1)
@@ -704,10 +713,12 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    rdf (3.3.2)
+    rdf (3.3.3)
       bcp47_spec (~> 0.2)
       bigdecimal (~> 3.1, >= 3.1.5)
       link_header (~> 0.0, >= 0.0.8)
+      logger (~> 1.5)
+      ostruct (~> 0.6)
     rdf-isomorphic (3.3.0)
       rdf (~> 3.3)
     rdf-ldp (0.1.0)
@@ -888,9 +899,6 @@ GEM
       nokogiri
       stomp
       xml-simple
-    speedy-af (0.4.0)
-      active-fedora (>= 11.0.0)
-      activesupport (> 5.2)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -1101,7 +1109,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.9)
   simplecov
   solr_wrapper (>= 0.16)
-  speedy-af (~> 0.4.0)
+  speedy-af!
   sprockets (~> 3.7.2)
   sprockets-es6
   sqlite3

--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -134,7 +134,6 @@ class SupplementalFilesController < ApplicationController
 
   def destroy
     find_supplemental_file
-
     @object.supplemental_files -= [@supplemental_file]
     raise Avalon::SaveError, "An error occurred when deleting the supplemental file: #{@object.errors[:supplemental_files_json]}" unless @object.save
     # FIXME: also wrap this in a transaction

--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -30,7 +30,7 @@ import './Ramp.scss';
 
 const Ramp = ({
   urls,
-  sections_count,
+  has_sections,
   title,
   share,
   timeline,
@@ -87,7 +87,7 @@ const Ramp = ({
             </React.Fragment>
             )
             : (<React.Fragment>
-              {sections_count > 0 &&
+              {has_sections &&
                 <React.Fragment>
                   <MediaPlayer enableFileDownload={false} enablePlaybackRate={true} />
                   <div className="ramp--rails-title">
@@ -179,7 +179,7 @@ const Ramp = ({
             <Tab eventKey="details" title="Details" >
               <MetadataDisplay showHeading={false} displayTitle={false} />
             </Tab>
-            {(cdl.can_stream && sections_count != 0 && has_transcripts) &&
+            {(cdl.can_stream && has_sections && has_transcripts) &&
               <Tab eventKey="transcripts" title="Transcripts" className="ramp--transcripts_tab">
                 <Transcript
                   playerID="iiif-media-player"

--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -136,6 +136,7 @@ module BulkActionJobs
         media_object = MediaObject.find(id)
         supplemental_files = media_object.supplemental_files
         DeleteChildFiles.perform_now(supplemental_files, nil)
+        media_object.supplemental_files = []
 
         if media_object.destroy
           successes += [media_object]

--- a/app/models/concerns/supplemental_file_read_behavior.rb
+++ b/app/models/concerns/supplemental_file_read_behavior.rb
@@ -29,11 +29,7 @@ module SupplementalFileReadBehavior
     # encountered in a live environment but came up in automated
     # testing. Adding a rescue on fail to locate allows us to skip
     # these out of sync files.
-    @supplemental_files ||= begin
-                              GlobalID::Locator.locate_many(JSON.parse(supplemental_files_json))
-                            rescue ActiveRecord::RecordNotFound
-                              nil
-                            end.compact
+    @supplemental_files ||= GlobalID::Locator.locate_many(JSON.parse(supplemental_files_json), ignore_missing: true)
     return [] if @supplemental_files.blank?
 
     case tag

--- a/app/models/concerns/supplemental_file_read_behavior.rb
+++ b/app/models/concerns/supplemental_file_read_behavior.rb
@@ -1,0 +1,48 @@
+# Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+# frozen_string_literal: true
+module SupplementalFileReadBehavior
+  extend ActiveSupport::Concern
+
+  def reload
+    @supplemental_files = nil
+    super
+  end
+
+  # @return [SupplementalFile]
+  def supplemental_files(tag: '*')
+    return [] if supplemental_files_json.blank?
+    # If the supplemental_files_json becomes out of sync with the
+    # database after a delete, this check could fail. Have not
+    # encountered in a live environment but came up in automated
+    # testing. Adding a rescue on fail to locate allows us to skip
+    # these out of sync files.
+    @supplemental_files ||= begin
+                              GlobalID::Locator.locate_many(JSON.parse(supplemental_files_json))
+                            rescue ActiveRecord::RecordNotFound
+                              nil
+                            end.compact
+    return [] if @supplemental_files.blank?
+
+    case tag
+    when '*'
+      @supplemental_files
+    when nil
+      @supplemental_files.select { |file| file.tags.empty? }
+    else
+      @supplemental_files.select { |file| Array(tag).all? { |t| file.tags.include?(t) } }
+    end
+  end
+end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -24,7 +24,8 @@ class MediaObject < ActiveFedora::Base
   include MigrationTarget
   include SpeedyAF::OrderedAggregationIndex
   include MediaObjectIntercom
-  include SupplementalFileBehavior
+  include SupplementalFileReadBehavior
+  include SupplementalFileWriteBehavior
   include MediaObjectBehavior
   require 'avalon/controlled_vocabulary'
 

--- a/app/models/stream_token.rb
+++ b/app/models/stream_token.rb
@@ -61,10 +61,10 @@ class StreamToken < ActiveRecord::Base
       attrs[:id] = existing_token_hash[attrs[:token]] if existing_token_hash[attrs[:token]].present?
     end
 
-    result = token_attributes.present? ? StreamToken.upsert_all(token_attributes) : []
+    token_attributes.present? ? StreamToken.upsert_all(token_attributes) : []
 
     # Fetch StreamToken fresh so they can be put into session and returned
-    tokens = StreamToken.where(id: result.to_a.pluck("id"))
+    tokens = StreamToken.where(id: token_attributes.pluck(:id))
     session[:hash_tokens] += tokens.pluck(:token)
     session[:hash_tokens].uniq! # Avoid duplicate entry
     tokens.to_a

--- a/app/presenters/speedy_af/proxy/master_file.rb
+++ b/app/presenters/speedy_af/proxy/master_file.rb
@@ -52,20 +52,6 @@ class SpeedyAF::Proxy::MasterFile < SpeedyAF::Base
     mf_title.blank? ? nil : mf_title
   end
 
-  # @return [SupplementalFile]
-  def supplemental_files(tag: '*')
-    return [] if supplemental_files_json.blank?
-    files = JSON.parse(supplemental_files_json).collect { |file_gid| GlobalID::Locator.locate(file_gid) }
-    case tag
-    when '*'
-      files
-    when nil
-      files.select { |file| file.tags.empty? }
-    else
-      files.select { |file| Array(tag).all? { |t| file.tags.include?(t) } }
-    end
-  end
-
   def captions
     return nil unless has_captions?
     load_subresource_content(:captions) rescue nil

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -66,20 +66,6 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     [id]
   end
 
-  # @return [SupplementalFile]
-  def supplemental_files(tag: '*')
-    return [] if supplemental_files_json.blank?
-    files = JSON.parse(supplemental_files_json).collect { |file_gid| GlobalID::Locator.locate(file_gid) }
-    case tag
-    when '*'
-      files
-    when nil
-      files.select { |file| file.tags.empty? }
-    else
-      files.select { |file| Array(tag).all? { |t| file.tags.include?(t) } }
-    end
-  end
-
   def sections
     return [] unless section_ids.present?
     query = "id:" + section_ids.join(" id:")

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -71,7 +71,7 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     query = "id:" + section_ids.join(" id:")
     @sections ||= SpeedyAF::Proxy::MasterFile.where(query,
                                                     order: -> { section_ids },
-                                                    load_reflections: true)
+                                                    load_reflections: [:derivatives, :structuralMetadata, :media_object])
   end
 
   def collection

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -42,7 +42,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= react_component("MediaObjectRamp",
       {
         urls: { base_url: request.protocol + request.host_with_port, fullpath_url: request.fullpath },
-        sections_count: @media_object.sections.size,
+        has_sections: @media_object.section_ids.present?,
         title: { content: render('title') },
         share: { canShare: (will_partial_list_render? :share), content: lending_enabled?(@media_object) ? (render('share') if can_stream) : render('share') },
         timeline: { canCreate: (current_ability.can? :create, Timeline), content: lending_enabled?(@media_object) ? (render('timeline') if can_stream) : render('timeline') },

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -22,6 +22,7 @@ Rails.application.config.to_prepare do
                       }
       include MasterFileIntercom
       include MasterFileBehavior
+      include SupplementalFileReadBehavior
       include Rails.application.routes.url_helpers
     end
 
@@ -66,6 +67,7 @@ Rails.application.config.to_prepare do
       include VirtualGroups
       include MediaObjectIntercom
       include MediaObjectBehavior
+      include SupplementalFileReadBehavior
       include Rails.application.routes.url_helpers
     end
 

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -508,7 +508,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
             if object.is_a?(MasterFile)
               expect{
                 put :update, params: { class_id => object.id, id: supplemental_file.id, supplemental_file:valid_update_attributes, format: :html}, session: valid_session
-              }.to change { object.media_object.to_solr(include_child_fields: true)['has_transcripts_bsi'] }.from(true).to(false)
+              }.to change { object.reload.media_object.to_solr(include_child_fields: true)['has_transcripts_bsi'] }.from(true).to(false)
             end
           end
         end
@@ -654,7 +654,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
         if object.is_a?(MasterFile)
           expect{
             delete :destroy, params: { class_id => object.id, id: supplemental_file.id, format: :html}, session: valid_session
-          }.to change { object.media_object.to_solr(include_child_fields: true)['has_transcripts_bsi'] }.from(true).to(false)
+          }.to change { object.reload.media_object.to_solr(include_child_fields: true)['has_transcripts_bsi'] }.from(true).to(false)
         end
       end
     end


### PR DESCRIPTION
In this PR:
- Change ramp component prop to boolean and switch to using `section_ids`
- DRY up `supplemental_files(tags)` method and optimize it by using `locate_many` and memoization
- Use branch of speedy-af that adds allowlists for loading reflections
- Fix stream token bulk creation code (possibly difference in upsert return values between mysql and postgres)

These last two changes speed up many sectioned items considerably on mco-staging.  For a 244 section item the page request takes ~2s and the manifest ~8s (down from ~14s and ~30s on MCO).

I'm happy to split this out into separate PRs if any of the commits need more work/review.

Part of #5543 