### PR TITLE
Fix width of typeahead fields on resource description page

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -791,6 +791,8 @@ h5.card-title {
 .twitter-typeahead {
   z-index: auto !important;
   background-color: $white;
+  display: inline-flex !important;
+  flex-grow: 2;
 }
 
 /**


### PR DESCRIPTION
Related issue: #6347 