### PR TITLE
Fix select-all logic after page reload and individual selection changes

### DIFF
--- a/app/assets/javascripts/select_all.js
+++ b/app/assets/javascripts/select_all.js
@@ -14,21 +14,70 @@
  * ---  END LICENSE_HEADER BLOCK  ---
 */
 
+// Global abort controller for managing select all operations
+let selectAllAbortController = null;
+let isSelectAllInProgress = false;
+
+function processCheckboxes(checkboxes, selectAllCheckbox) {
+  // If there are no checkboxes to process, re-enable immediately
+  if (checkboxes.length === 0) {
+    selectAllCheckbox.prop("disabled", false);
+    isSelectAllInProgress = false;
+  }
+
+  let completedCount = 0;
+  checkboxes.each(function (index, input) {
+    // Check if select all operation was aborted before starting each operation
+    if (selectAllAbortController.signal.aborted) {
+      return false;
+    }
+
+    // Use a timeout for better handling of async operations
+    setTimeout(() => {
+      if (!selectAllAbortController.signal.aborted) {
+        input.click();
+        completedCount++;
+        // Re-enable select all when all operations complete
+        if (completedCount === checkboxes.length) {
+          selectAllCheckbox.prop("disabled", false);
+          isSelectAllInProgress = false;
+        }
+      }
+    }, index * 100);
+  });
+}
+
 $("#bookmarks_selectall").on("click", function (e) {
+  // If a select all operation is already in progress, abort it and start a new one
+  if (isSelectAllInProgress && selectAllAbortController) {
+    selectAllAbortController.abort();
+  }
+  selectAllAbortController = new AbortController();
+  isSelectAllInProgress = true;
+
   // Disable 'Select All' to prevent collision between select
   // and deselect POST requests while the page is getting updated
   $(this).prop("disabled", true);
 
-  if (!$(this).is(':checked')) {
-    $("label.toggle-bookmark.checked input.toggle-bookmark").each(function (index, input) {
-      input.click();
-    });
-  } else {
-    $("label.toggle-bookmark:not(.checked) input.toggle-bookmark").each(function (index, input) {
-      input.click();
-    });
+  // Check if operation was aborted before starting
+  if (selectAllAbortController.signal.aborted) {
+    $(this).prop("disabled", false);
+    isSelectAllInProgress = false;
+    return;
   }
 
-  // Enable 'Select All' afer all checkboxes have been toggled
-  $(this).prop("disabled", false);
+  if (!$(this).is(':checked')) {
+    const checkedCheckboxes = $("label.toggle-bookmark input.toggle-bookmark:checked");
+    processCheckboxes(checkedCheckboxes, $(this));
+  } else {
+    const uncheckedCheckboxes = $("label.toggle-bookmark input.toggle-bookmark:not(:checked)");
+    processCheckboxes(uncheckedCheckboxes, $(this));
+  }
+});
+
+// Clean up abort controller when page unloads
+$(window).on('beforeunload', function () {
+  if (selectAllAbortController) {
+    selectAllAbortController.abort();
+  }
 });

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -59,6 +59,12 @@ module Blacklight::LocalBlacklightHelper
     result
   end
 
+  # Override of blacklight helper identify if the document is in the user's bookmarks
+  # https://github.com/projectblacklight/blacklight/blob/fe4b92fa4866f192c50f717cfa24bbf528d3c8ee/app/helpers/blacklight/document_helper_behavior.rb#L45
+  def bookmarked? document
+    current_or_guest_user.bookmarks.any? { |b| b.document_id == document.id && b.document_type.to_s == document.class.to_s }
+  end
+
   # Override of blacklight helper to add row class
   def render_document_class(document)
     # HACK I'm not sure why CatalogController needs to reference these helpers through helpers, but BookmarksController doesn't

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -59,12 +59,6 @@ module Blacklight::LocalBlacklightHelper
     result
   end
 
-  # Override of blacklight helper identify if the document is in the user's bookmarks
-  # https://github.com/projectblacklight/blacklight/blob/fe4b92fa4866f192c50f717cfa24bbf528d3c8ee/app/helpers/blacklight/document_helper_behavior.rb#L45
-  def bookmarked? document
-    current_or_guest_user.bookmarks.any? { |b| b.document_id == document.id && b.document_type.to_s == document.class.to_s }
-  end
-
   # Override of blacklight helper to add row class
   def render_document_class(document)
     # HACK I'm not sure why CatalogController needs to reference these helpers through helpers, but BookmarksController doesn't


### PR DESCRIPTION
Related issue: #6338 

Changes:
- Override Blacklight's `bookmarked?` helper method to use `current_or_guest_user.bookmarks` to mark selected items on page reload
- Change the jQuery selector to check for `<input/>`'s `checked` attribute instead of `.checked` class in the `<label />` when filtering bookmarks for select-all operation