### PR TITLE
Allow configuring streaming auth callback referer header

### DIFF
--- a/lib/avalon/m3u8_reader.rb
+++ b/lib/avalon/m3u8_reader.rb
@@ -24,7 +24,7 @@ module Avalon
         new(io.read, recursive: recursive)
       elsif io.is_a?(String)
         if io =~ /^https?:/
-          URI.open(io, "Referer" => Rails.application.routes.url_helpers.root_url) { |resp| new(resp, Addressable::URI.parse(io), recursive: recursive) }
+          URI.open(io, "Referer" => Settings.streaming.auth_referer || Rails.application.routes.url_helpers.root_url) { |resp| new(resp, Addressable::URI.parse(io), recursive: recursive) }
         elsif io =~ /\.m3u8?$/i
           new(File.read(io), io, recursive: recursive)
         else


### PR DESCRIPTION
When setting up Wowza in a local dev environment I needed to pass a referer other than rails root in order for wowza to contact avalon.  This could also be useful for other infrastructure setups where the streaming server could make auth calls to avalon on an internal address instead of the public address.