### PR TITLE
Fix typeahead dropdown CSS to make it not transparent

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -107,7 +107,8 @@ div.alert-danger {
 
 .info-text-gray {
   font-style: italic;
-  color: #6c757d; /* Bootstrap secondary color with 4.5:1 contrast ratio */
+  color: #6c757d;
+  /* Bootstrap secondary color with 4.5:1 contrast ratio */
 }
 
 .nowrap {
@@ -123,7 +124,7 @@ div.alert-danger {
   display: flex;
   flex-wrap: wrap;
 
-  > [class*='col-'] {
+  >[class*='col-'] {
     flex-grow: 1;
   }
 }
@@ -348,12 +349,12 @@ span.constraints-label {
 }
 
 .role-popover-help {
-  & + .popover .arrow {
+  &+.popover .arrow {
     left: 10%;
   }
 }
 
-.btn-confirmation + .popover .popover-content {
+.btn-confirmation+.popover .popover-content {
   white-space: nowrap;
 }
 
@@ -413,7 +414,7 @@ a[data-trigger='submit'] {
   font-weight: 700 !important;
 }
 
-.tab-content > .tab-pane {
+.tab-content>.tab-pane {
   padding: 10px;
   border-bottom: 1px solid #ddd;
   border-left: 1px solid #ddd;
@@ -661,12 +662,12 @@ div.structure_edit {
       background-color: $state-danger-bg;
     }
 
-    .attribute_container > textarea {
+    .attribute_container>textarea {
       resize: both;
     }
 
-    .attribute_container > a,
-    .attribute_container > label {
+    .attribute_container>a,
+    .attribute_container>label {
       vertical-align: top;
     }
   }
@@ -761,11 +762,9 @@ h5.card-title {
     font-weight: bold;
   }
 
-  .clip_start_time {
-  }
+  .clip_start_time {}
 
-  .clip_end_time {
-  }
+  .clip_end_time {}
 
   .clip_position {
     text-align: center;
@@ -795,6 +794,32 @@ h5.card-title {
   flex-grow: 2;
 }
 
+.twitter-typeahead .tt-menu {
+  float: left;
+  width: 100%;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  color: #212529;
+  text-align: left;
+  list-style: none;
+  background-color: white;
+  background-clip: padding-box;
+  border: 1px solid rgba(51, 51, 51, 0.15);
+  border-radius: 0.25rem;
+
+  .tt-suggestion.tt-selectable {
+    padding: 0.25rem 0.5rem;
+
+    &:hover {
+      cursor: pointer;
+      background-color: #e9ecef;
+      color: #16181b;
+    }
+  }
+}
+
 /**
  * Associated Files - Edit - Manage Files
  */
@@ -821,7 +846,7 @@ h5.card-title {
     padding-bottom: 10px;
     justify-content: space-between;
 
-    > span {
+    >span {
       padding: 0 5px;
     }
 
@@ -949,7 +974,8 @@ h5.card-title {
       .visible-inline {
         display: none;
 
-        .icon-success, .icon-error {
+        .icon-success,
+        .icon-error {
           font-size: 1.2rem;
         }
       }
@@ -959,7 +985,7 @@ h5.card-title {
       }
     }
 
-    div.supplemental-file-data.is-editing:not(.edit-item) + div.supplemental-file-data {
+    div.supplemental-file-data.is-editing:not(.edit-item)+div.supplemental-file-data {
       margin-top: 2.5rem;
     }
 
@@ -985,7 +1011,8 @@ h5.card-title {
       height: 25px;
     }
 
-    &.captions, &.transcripts {
+    &.captions,
+    &.transcripts {
       div.supplemental-file-data.is-editing:last-child {
         margin-bottom: 1.75rem;
       }


### PR DESCRIPTION
Related issue: #6405 

Issue: the CSS for styling the background and hover actions for `twitter-typeahead` dropdown and its items got removed in the Blacklight upgrade.

For language field, a 500 error is shown when using the field. The error in the network tab is as follows;
```
NoMethodError in ObjectsController#autocomplete

undefined method 'map' for class LanguageTerm
Extracted source (around line #81):

#79 
#80     def autocomplete(query, _id = nil)
*81 ["      map = query.present? ? self", ".map", ".select{ |k,v| /\#{query}/i.match(v[:text]) if v } : self.map\n"]#82       map.to_a.uniq.map{ |e| {id: e[1][:code], display: e[1][:text] }}.sort{ |x,y| x[:display]<=>y[:display] }
#83     end
#84 
```
This issue is fixed in #6416 