### PR TITLE
New Ramp build with CSS scoping for svg

### DIFF
--- a/app/assets/stylesheets/avalon/_facets.scss
+++ b/app/assets/stylesheets/avalon/_facets.scss
@@ -124,7 +124,6 @@ div[id*='facet-panel-'] {
 
     svg {
       scale: 1.5;
-      vertical-align: middle;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.21.1",
-    "@samvera/ramp": "https://github.com/samvera-labs/ramp.git#6f64fda",
+    "@samvera/ramp": "https://github.com/samvera-labs/ramp.git#691015e",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,9 +1677,9 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@samvera/ramp@https://github.com/samvera-labs/ramp.git#6f64fda":
+"@samvera/ramp@https://github.com/samvera-labs/ramp.git#691015e":
   version "4.0.0"
-  resolved "https://github.com/samvera-labs/ramp.git#6f64fda288f6606d4080b3c4ec2a8e52fbd0c5af"
+  resolved "https://github.com/samvera-labs/ramp.git#691015e4d3436d8a0cc3fd05c5f58c46571c3773"
   dependencies:
     "@rollup/plugin-json" "^6.0.1"
     "@silvermine/videojs-quality-selector" "^1.3.1"


### PR DESCRIPTION
Related issue: #6339 

Bring the CSS scoping in Ramp and remove the `vertical-align` CSS put in place for facet remove icon to override the leaking CSS from Ramp.