### PR TITLE
Remove 'x' character in link for removing user

### DIFF
--- a/app/views/modules/_access_object.html.erb
+++ b/app/views/modules/_access_object.html.erb
@@ -83,7 +83,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <td class='access_list_dates'></td>
           <% if !input_disabled %>
           <td class='access_list_remove'>
-            <%= link_to "×",
+            <%= link_to "",
                 polymorphic_path(object, "remove_#{access_object}".to_sym => member_object, step: @active_step, donot_advance: true),
                 method: "put",
                 class: "btn btn-sm btn-close remove" %>
@@ -109,7 +109,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           </td>
           <% if !input_disabled %>
           <td class='access_list_remove'>
-            <%= link_to "×",
+            <%= link_to "",
                 polymorphic_path(object, "remove_lease".to_sym => lease_object, step: @active_step, donot_advance: true),
                 method: "put",
                 class: "btn btn-sm btn-close remove" %>


### PR DESCRIPTION
There are duplicated `x`s to remove a user in collection page's access control section, and this PR removes the `x` character that is set in the `link_to` tag. It seems `btn-close` class in the latest Bootstrap adds an SVG to the element. 

Reason for removing `x` character instead of the SVG in `btn-close` Bootstrap class: the `x` character is very small, so the SVG that's coming from `btn-close` seems to be the better UX choice.

Before: 
<img width="1061" height="117" alt="Screenshot 2025-07-14 at 10-37-26 Test Audio Collection - Collections - Avalon Media System" src="https://github.com/user-attachments/assets/0bff032d-51b8-45e7-bdb6-d41d783f4dc6" />

After:
<img width="1061" height="117" alt="Screenshot 2025-07-14 at 10-37-43 Test Audio Collection - Collections - Avalon Media System" src="https://github.com/user-attachments/assets/3fe977d6-0117-4708-9ef3-a75bd9005399" />

I checked other places that uses this Bootstrap class and did not see any issues with them.
