### PR TITLE
Fix date helper to handle "unknown/unknown"

### DIFF
--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -27,7 +27,10 @@ module Blacklight::LocalBlacklightHelper
   end
 
   def humanized_date_index_display args
-    Date.edtf(args[:document][args[:field]]).humanize
+    field = args[:document][args[:field]]
+    return "unknown" if field == "unknown/unknown"
+
+    Date.edtf(field).humanize
   end
 
   def description_index_display args


### PR DESCRIPTION
Related issue: #6430

In the original implementation of the view helper for human readable dates an assumption was made about "unknown/unknown" being edtf compliant. This was not the case, so the edtf-humanize gem errored in an environment containing that value. Adding a guard clause to handle that case takes care of the issue.