### PR TITLE
Fix supplemental file path helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,20 +204,16 @@ module ApplicationHelper
   def object_supplemental_file_path(object, file)
     if object.is_a?(MasterFile) || object.try(:model) == MasterFile
       master_file_supplemental_file_path(master_file_id: object.id, id: file.id)
-    elsif object.is_a? MediaObject || object.try(:model) == MediaObject
+    elsif object.is_a?(MediaObject) || object.try(:model) == MediaObject
       media_object_supplemental_file_path(media_object_id: object.id, id: file.id)
-    else
-      nil
     end
   end
 
   def object_supplemental_files_path(object)
     if object.is_a?(MasterFile) || object.try(:model) == MasterFile
       master_file_supplemental_files_path(object.id)
-    elsif object.is_a? MediaObject || object.try(:model) == MediaObject
+    elsif object.is_a?(MediaObject) || object.try(:model) == MediaObject
       media_object_supplemental_files_path(object.id)
-    else
-      nil
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -188,5 +188,56 @@ describe ApplicationHelper do
         )
       end
     end
+
+    context 'SpeedyAF(MediaObject)' do
+      let(:presenter) { SpeedyAF::Proxy::MediaObject.find(media_object.id) }
+
+      it 'returns media_object_supplemental_file_path' do
+        expect(helper.object_supplemental_file_path(presenter, supplemental_file)).to eq(
+          "/media_objects/#{media_object.id}/supplemental_files/#{supplemental_file.id}"
+        )
+      end
+    end
+  end
+
+  describe "#object_supplemental_files_path" do
+    let(:master_file) { FactoryBot.create(:master_file) }
+    let(:media_object) { FactoryBot.create(:media_object) }
+
+    context 'MasterFile' do
+      it 'returns masterfile_supplemental_files_path' do
+        expect(helper.object_supplemental_files_path(master_file)).to eq(
+          "/master_files/#{master_file.id}/supplemental_files"
+        )
+      end
+    end
+
+    context 'SpeedyAF(MasterFile)' do
+      let(:presenter) { SpeedyAF::Proxy::MasterFile.find(master_file.id) }
+
+      it 'returns masterfile_supplemental_files_path' do
+        expect(helper.object_supplemental_files_path(presenter)).to eq(
+          "/master_files/#{master_file.id}/supplemental_files"
+        )
+      end
+    end
+
+    context 'MediaObject' do
+      it 'returns mediaobject_supplemental_files_path' do
+        expect(helper.object_supplemental_files_path(media_object)).to eq(
+          "/media_objects/#{media_object.id}/supplemental_files"
+        )
+      end
+    end
+
+    context 'SpeedyAF(MediaObject)' do
+      let(:presenter) { SpeedyAF::Proxy::MediaObject.find(media_object.id) }
+
+      it 'returns media_object_supplemental_files_path' do
+        expect(helper.object_supplemental_files_path(presenter)).to eq(
+          "/media_objects/#{media_object.id}/supplemental_files"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Related issue: #6436

A lack of parantheses in the conditional statements determining object type for supplemental file path generation caused valid SpeedyAF::Proxy::MediaObject objects to fail the check and fallback to nil. Added in the missing parantheses and added additional tests to hopefully catch any future issues.