### PR TITLE
Fix playlist item details -> cancel button

### DIFF
--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -54,10 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <div class="mb-3">
     <%= f.submit id: 'submit-playlist-form', class: 'btn btn-primary', value: t("playlist.#{params[:action]}.action"), 'data-testid': 'playlist-submit-form' %>
-      <% if params[:action] == "edit" || params[:action] == "update" %>
-      <button id="playlist_edit_cancel" class="btn btn-outline" data-toggle="collapse"
-        data-target="#playlist_edit_div, #playlist_view_div">Cancel</button>
-      <% end %>
+    <a id="playlist_edit_cancel" role="button" class="btn btn-outline" data-bs-toggle="collapse" data-bs-target="#playlist_edit_div, #playlist_view_div">Cancel</a>
   </div>
   <% end # form_for playlist_form%>
 </div>


### PR DESCRIPTION
When accessibility fixes were done to the playlist details edit page, the `Cancel` button was changed to use `<button>` element instead of `<a>` to support the related `aria-*` attributes. But this caused the form to submit with incorrect values for `tags` field (submitted a string instead of an array) when `Cancel` button is pressed. 

And this is causing any array-related operation on `@playlist.tags` in the back-end to fail because `String` class doesn't support these methods.

This PR changes it back to use `<a>` with the `role="button"` attribute, which fixes the accessibility issue without breaking the functionality.