### PR TITLE
Escape solr special characters when performing section and transcript searches

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,7 @@ class ApplicationController < ActionController::Base
   rescue_from RSolr::Error::Timeout, :with => :handle_solr_connection_error
   rescue_from Blacklight::Exceptions::ECONNREFUSED, :with => :handle_solr_connection_error
   rescue_from Faraday::ConnectionFailed, :with => :handle_fedora_connection_error
+  rescue_from Blacklight::Exceptions::InvalidRequest, :with => :handle_invalid_request_error
 
   # Enable profiling
   if ActiveModel::Type::Boolean.new.cast(ENV['AVALON_PROFILING'])
@@ -279,5 +280,16 @@ class ApplicationController < ActionController::Base
       else
         render '/errors/fedora_connection', status: 503
       end
+    end
+
+    # Handle unmatched double quotes in searches
+    def handle_invalid_request_error(exception)
+      if params[:q].count('"').odd? && exception.message.include?('Cannot parse')
+        flash[:error] = "Invalid search: Odd number of quotation marks. Quotation marks must be matched in search queries."
+        return redirect_to(search_catalog_url)
+      end
+
+      # Reraise error if triggered by something besides quotes to prevent suppressing unhandled issues
+      raise Blacklight::Exceptions::InvalidRequest, exception.message
     end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -32,19 +32,19 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def limit_to_non_hidden_items(_permission_types = discovery_permissions, _ability = current_ability)
-    [policy_clauses,"(*:* NOT hidden_bsi:true)"].compact.join(" OR ")
+    [policy_clauses, "(*:* NOT hidden_bsi:true)"].compact.join(" OR ")
   end
 
   # Overridden to skip for admin users
   def add_access_controls_to_solr_params(solr_parameters)
-    if current_ability.cannot? :discover_everything, MediaObject
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << gated_discovery_filters.reject(&:blank?).join(' OR ')
-      avalon_solr_access_filters_logic.each do |filter|
-        solr_parameters[:fq] << send(filter, discovery_permissions, current_ability)
-      end
-      Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
+    return unless current_ability.cannot? :discover_everything, MediaObject
+
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << gated_discovery_filters.reject(&:blank?).join(' OR ')
+    avalon_solr_access_filters_logic.each do |filter|
+      solr_parameters[:fq] << send(filter, discovery_permissions, current_ability)
     end
+    Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
   end
 
   def search_section_transcripts(solr_parameters)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -53,8 +53,6 @@ class SearchBuilder < Blacklight::SearchBuilder
     # In order for the multi-word query to work we need to NOT RSolr.solr_escape the query AND replace the spaces as +; this is also true for quoted phrase searches
     # We can manually escape solr special characters that cause issues.
     query = solr_parameters[:q].gsub(/([(){}\[\]\^\*?:])/, "\\\\\1").tr(' ', '+')
-    # Quotes need special handling to allow phrase searches.
-    query = query.gsub(/"/, "\\\\\1") if query.count('"').odd?
     transcript_subquery = "transcript_tsim:#{query}"
     solr_parameters[:defType] = "lucene"
     solr_parameters[:q] = "({!edismax v=\"#{RSolr.solr_escape(solr_parameters[:q])}\"}) {!join to=id from=isPartOf_ssim}{!join to=id from=isPartOf_ssim}#{transcript_subquery}"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -217,6 +217,13 @@ describe CatalogController do
         expect(assigns(:response).documents.count).to eq 2
         expect(assigns(:response).documents.collect(&:id)).to eq [media_object_1.id, @media_object.id]
       end
+      it 'should not error when special characters are in the query' do
+        ['+', '-', '&', '|', '"', '(', ')', '{', '}', '[', ']', '^', '~', '*', '?', ':', '/'].each do |char|
+          expect { get 'index', params: { q: "#{char} Test Label" } }.to_not raise_error
+          expect(assigns(:response).documents.count).to eq 1
+          expect(assigns(:response).documents.collect(&:id)).to eq [@media_object.id]
+        end
+      end
     end
     describe "search transcripts" do
       before(:each) do
@@ -231,7 +238,7 @@ describe CatalogController do
       end
 
       it "should find results based upon transcripts" do
-        get 'index', params: { q: 'Example' }
+        get 'index', params: { q: 'Example captions' }
         expect(assigns(:response).documents.count).to eq 1
         expect(assigns(:response).documents.collect(&:id)).to eq [@media_object.id]
       end
@@ -247,6 +254,16 @@ describe CatalogController do
           get 'index', params: { q: '"Example quote"' }
           expect(assigns(:response).documents.count).to eq 0
           expect(assigns(:response).documents.collect(&:id)).not_to include @media_object.id
+        end
+      end
+
+      context "special characters" do
+        it 'should not error when special characters are in the query' do
+          ['+', '-', '&', '|', '"', '(', ')', '{', '}', '[', ']', '^', '~', '*', '?', ':', '/'].each do |char|
+            expect { get 'index', params: { q: "Example #{char}" } }.to_not raise_error
+            expect(assigns(:response).documents.count).to eq 1
+            expect(assigns(:response).documents.collect(&:id)).to eq [@media_object.id]
+          end
         end
       end
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -21,22 +21,22 @@ describe CatalogController do
     describe "as an un-authenticated user" do
       it "should show results for items that are public and published" do
         mo = FactoryBot.create(:published_media_object, visibility: 'public')
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(1)
         expect(assigns(:response).documents.map(&:id)).to eq([mo.id])
       end
       it "should not show results for items that are not public" do
-        mo = FactoryBot.create(:published_media_object, visibility: 'restricted')
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:published_media_object, visibility: 'restricted')
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
       end
       it "should not show results for items that are not published" do
-        mo = FactoryBot.create(:media_object, visibility: 'public')
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:media_object, visibility: 'public')
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
@@ -48,34 +48,34 @@ describe CatalogController do
       end
       it "should show results for items that are published and available to registered users" do
         mo = FactoryBot.create(:published_media_object, visibility: 'restricted')
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(1)
         expect(assigns(:response).documents.map(&:id)).to eq([mo.id])
       end
       it "should not show results for items that are not public or available to registered users" do
-        mo = FactoryBot.create(:published_media_object, visibility: 'private')
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:published_media_object, visibility: 'private')
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
       end
       it "should not show results for items that are not published" do
-        mo = FactoryBot.create(:media_object, visibility: 'public')
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:media_object, visibility: 'public')
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
       end
     end
     describe "as a manager" do
-      let!(:collection) {FactoryBot.create(:collection)}
-      let!(:manager) {login_user(collection.managers.first)}
+      let!(:collection) { FactoryBot.create(:collection) }
+      let!(:manager) { login_user(collection.managers.first) }
 
       it "should show results for items that are unpublished, private, and belong to one of my collections" do
         mo = FactoryBot.create(:media_object, visibility: 'private', collection: collection)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(1)
@@ -83,7 +83,7 @@ describe CatalogController do
       end
       it "should show results for items that are hidden and belong to one of my collections" do
         mo = FactoryBot.create(:media_object, hidden: true, visibility: 'private', collection: collection)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(1)
@@ -92,33 +92,33 @@ describe CatalogController do
       it "should show results for items that are not hidden and do not belong to one of my collections along with hidden items that belong to my collections" do
         mo = FactoryBot.create(:media_object, hidden: true, visibility: 'private', collection: collection)
         mo2 = FactoryBot.create(:fully_searchable_media_object)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(2)
         expect(assigns(:response).documents.map(&:id)).to match_array([mo.id, mo2.id])
       end
       it "should not show results for items that do not belong to one of my collections" do
-        mo = FactoryBot.create(:media_object, visibility: 'private')
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:media_object, visibility: 'private')
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
       end
       it "should not show results for hidden items that do not belong to one of my collections" do
-        mo = FactoryBot.create(:media_object, hidden: true, visibility: 'private', read_users: [manager.user_key])
-        get 'index', params: { :q => "" }
+        FactoryBot.create(:media_object, hidden: true, visibility: 'private', read_users: [manager.user_key])
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(0)
       end
     end
     describe "as an administrator" do
-      let!(:administrator) {login_as(:administrator)}
+      let!(:administrator) { login_as(:administrator) }
 
       it "should show results for all items" do
         mo = FactoryBot.create(:media_object, visibility: 'private')
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eq 1
@@ -131,7 +131,7 @@ describe CatalogController do
       it "should show results for items visible to the lti virtual group" do
         mo = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
         perform_enqueued_jobs(only: MediaObjectIndexingJob)
-        get 'index', params: { :q => "read_access_virtual_group_ssim:#{lti_group}" }
+        get 'index', params: { q: "read_access_virtual_group_ssim:#{lti_group}" }
         expect(response).to be_successful
         expect(response).to render_template('catalog/index')
         expect(assigns(:response).documents.count).to eql(1)
@@ -147,30 +147,30 @@ describe CatalogController do
         perform_enqueued_jobs(only: MediaObjectIndexingJob)
       end
       it "should show no results when no items are visible to the user's IP address" do
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(assigns(:response).documents.count).to eq 0
       end
       it "should show results for items visible to the the user's IP address" do
         allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return(@ip_address1)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(assigns(:response).documents.count).to eq 1
         expect(assigns(:response).documents.map(&:id)).to include @mo.id
       end
       it "should show results for items visible to the the user's IPv4 subnet" do
         ip_address2 = Faker::Internet.ip_v4_address
         allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return(ip_address2)
-        mo2 = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [ip_address2+'/30'])
+        mo2 = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [ip_address2 + '/30'])
         perform_enqueued_jobs(only: MediaObjectIndexingJob)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(assigns(:response).documents.count).to be >= 1
         expect(assigns(:response).documents.map(&:id)).to include mo2.id
       end
       it "should show results for items visible to the the user's IPv6 subnet" do
         ip_address3 = Faker::Internet.ip_v6_address
         allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return(ip_address3)
-        mo3 = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [ip_address3+'/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00'])
+        mo3 = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [ip_address3 + '/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00'])
         perform_enqueued_jobs(only: MediaObjectIndexingJob)
-        get 'index', params: { :q => "" }
+        get 'index', params: { q: "" }
         expect(assigns(:response).documents.count).to be >= 1
         expect(assigns(:response).documents.map(&:id)).to include mo3.id
       end
@@ -178,15 +178,15 @@ describe CatalogController do
 
     describe "search fields" do
       let(:media_object) { FactoryBot.create(:fully_searchable_media_object) }
-      ["title_tesi", "alternative_title_ssim", "creator_ssim", "contributor_ssim", "unit_ssim", "collection_ssim", "abstract_ssi", "publisher_ssim", "topical_subject_ssim", "geographic_subject_ssim", "temporal_subject_ssim", "genre_ssim", "physical_description_ssim", "language_ssim", "date_sim", "notes_sim", "table_of_contents_ssim", "other_identifier_sim", "series_ssim", "bibliographic_id_ssi" ].each do |field|
+      ["title_tesi", "alternative_title_ssim", "creator_ssim", "contributor_ssim", "unit_ssim", "collection_ssim", "abstract_ssi", "publisher_ssim", "topical_subject_ssim", "geographic_subject_ssim", "temporal_subject_ssim", "genre_ssim", "physical_description_ssim", "language_ssim", "date_sim", "notes_sim", "table_of_contents_ssim", "other_identifier_sim", "series_ssim", "bibliographic_id_ssi"].each do |field|
         it "should find results based upon #{field}" do
           query = Array(media_object.to_solr[field]).first
-          #split on ' ' and only search on the first word of a multiword field value
+          # split on ' ' and only search on the first word of a multiword field value
           query = query.split(' ').first
-          #The following line is to check that the test is using a valid solr field name
-          #since an incorrect one will lead to an empty query resulting in a false positive below
+          # The following line is to check that the test is using a valid solr field name
+          # since an incorrect one will lead to an empty query resulting in a false positive below
           expect(query).not_to be_empty
-          get 'index', params: { :q => query }
+          get 'index', params: { q: query }
           expect(assigns(:response).documents.count).to eq 1
           expect(assigns(:response).documents.map(&:id)). to eq [media_object.id]
         end
@@ -274,15 +274,15 @@ describe CatalogController do
       let!(:m3) { FactoryBot.create(:published_media_object, title: 'Doo', date_issued: '1980', creator: ['Wilma'], visibility: 'public') }
 
       it "should sort correctly by title" do
-        get :index, params: { :sort => 'title_ssort asc, date_issued_ssi desc' }
+        get :index, params: { sort: 'title_ssort asc, date_issued_ssi desc' }
         expect(assigns(:response).documents.map(&:id)).to eq [m2.id, m3.id, m1.id]
       end
       it "should sort correctly by date" do
-        get :index, params: { :sort => 'date_issued_ssi desc, title_ssort asc' }
+        get :index, params: { sort: 'date_issued_ssi desc, title_ssort asc' }
         expect(assigns(:response).documents.map(&:id)).to eq [m3.id, m2.id, m1.id]
       end
       it "should sort correctly by creator" do
-        get :index, params: { :sort => 'creator_ssort asc, title_ssort asc' }
+        get :index, params: { sort: 'creator_ssort asc, title_ssort asc' }
         expect(assigns(:response).documents.map(&:id)).to eq [m2.id, m1.id, m3.id]
       end
     end
@@ -296,7 +296,7 @@ describe CatalogController do
       ["avalon_resource_type_ssim", "creator_ssim", "date_sim", "genre_ssim", "series_ssim", "collection_ssim", "unit_ssim", "language_ssim", "has_captions_bsi", "has_transcripts_bsi",
        "workflow_published_sim", "avalon_uploader_ssi", "read_access_group_ssim", "read_access_virtual_group_ssim", "date_digitized_ssim", "date_ingested_ssim", "subject_ssim", "rights_statement_ssi"].each do |field|
         it "should facet results on #{field}" do
-          query = Array(media_object.to_solr(include_child_fields:true)[field]).first
+          query = Array(media_object.to_solr(include_child_fields: true)[field]).first
           # The following line is to check that the test is using a valid solr field name
           # since an incorrect one will lead to an empty query resulting in a false positive below
           expect(query.to_s).not_to be_empty
@@ -370,7 +370,7 @@ describe CatalogController do
         end
         context "when there are transcripts present" do
           let!(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_file, :with_transcript_tag, parent_id: private_media_object.id) }
-          
+
           before do
             private_media_object.supplemental_files = [transcript]
             private_media_object.save
@@ -387,7 +387,7 @@ describe CatalogController do
       end
       context "without api key" do
         it "should only show visible results" do
-          get 'index', params: {  q: "other_identifier_sim:/GR[0-9]{8}/", sort: "timestamp+desc", rows: 100, page: 1, format: 'atom' }
+          get 'index', params: { q: "other_identifier_sim:/GR[0-9]{8}/", sort: "timestamp+desc", rows: 100, page: 1, format: 'atom' }
           expect(response).to be_successful
           expect(response.content_type).to eq "application/atom+xml; charset=utf-8"
           expect(response).to render_template('catalog/index')
@@ -458,7 +458,7 @@ describe CatalogController do
 
         it 'does not load featured collection' do
           expect(controller).not_to receive(:load_home_page_collections)
-          get 'index', params: { :q => "" }
+          get 'index', params: { q: "" }
           expect(assigns(:featured_collection)).not_to be_present
         end
       end


### PR DESCRIPTION
Related issue: #6348

This PR also includes some formatting fixes for the affected files.