### PR TITLE
Supplemental file links in ramp render inline and not force download

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -85,11 +85,11 @@ class SupplementalFilesController < ApplicationController
       format.html { 
         # Redirect or proxy the content
         if Settings.supplemental_files.proxy
-          send_data @supplemental_file.file.download, filename: @supplemental_file.file.filename.to_s, type: @supplemental_file.file.content_type, disposition: 'attachment'
+          send_data @supplemental_file.file.download, filename: @supplemental_file.download_filename, type: @supplemental_file.file.content_type, disposition: "inline; filename=#{@supplemental_file.download_filename}"
         else
           # Rails 7.0 adds a config option to protect against "open redirects". We override
           # that here in case the active storage db is not local.
-          redirect_to rails_blob_path(@supplemental_file.file, disposition: "attachment"), allow_other_host: true
+          redirect_to rails_blob_path(@supplemental_file.file, disposition: "inline; filename=#{@supplemental_file.download_filename}"), allow_other_host: true
         end
       }
       format.json { render json: @supplemental_file.as_json }
@@ -152,7 +152,7 @@ class SupplementalFilesController < ApplicationController
     file_content = @supplemental_file.file.download
     content = @supplemental_file.file.content_type == 'text/srt' ? SupplementalFile.convert_from_srt(file_content) : file_content
 
-    send_data content, filename: @supplemental_file.file.filename.to_s, type: 'text/vtt', disposition: 'attachment'
+    send_data content, filename: @supplemental_file.download_filename, type: 'text/vtt', disposition: "inline; filename=#{@supplemental_file.download_filename}"
   end
 
   private

--- a/app/models/supplemental_file.rb
+++ b/app/models/supplemental_file.rb
@@ -138,6 +138,12 @@ class SupplementalFile < ApplicationRecord
     chunked_transcript.map(&:strip).map { |cue| cue.gsub("\n", " ").squeeze(' ') }.compact
   end
 
+  def download_filename
+    filename = file.filename.to_s
+
+    machine_generated? ? "#{File.basename(filename, File.extname(filename))} (machine generated)#{File.extname(filename)}" : filename
+  end
+
   private
 
   def validate_file_type

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.21.1",
-    "@samvera/ramp": "https://github.com/samvera-labs/ramp.git#691015e",
+    "@samvera/ramp": "https://github.com/samvera-labs/ramp.git#browser-determined-download",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "buffer": "^6.0.3",

--- a/spec/models/supplemental_file_spec.rb
+++ b/spec/models/supplemental_file_spec.rb
@@ -333,4 +333,18 @@ describe SupplementalFile do
       end
     end
   end
+
+  describe '#download_filename' do
+    let(:file) { FactoryBot.create(:supplemental_file, :with_transcript_file, tags: ['transcript']) }
+    it 'returns the filename' do
+      expect(file.download_filename).to eq "captions.vtt"
+    end
+
+    context 'with machine generated file' do
+      let(:file) { FactoryBot.create(:supplemental_file, :with_transcript_file, tags: ['transcript', 'machine_generated']) }
+      it 'returns the filename with "(machine generated)" inserted' do
+        expect(file.download_filename).to eq "captions (machine generated).vtt"
+      end
+    end
+  end
 end

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -142,7 +142,7 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
 
     it "returns the supplemental file content" do
       get :show, params: { class_id => object.id, id: supplemental_file.id }, session: valid_session
-      expect(response).to redirect_to Rails.application.routes.url_helpers.rails_blob_path(supplemental_file.file, disposition: "attachment")
+      expect(response).to redirect_to Rails.application.routes.url_helpers.rails_blob_path(supplemental_file.file, disposition: "inline; filename=#{supplemental_file.download_filename}")
     end
 
     context '.json' do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,11 @@
   resolved "https://registry.yarnpkg.com/@iiif/vocabulary/-/vocabulary-1.0.26.tgz#557fab623100ca860daeddf6e4de46a8f94aaf86"
   integrity sha512-yOsMDg5C90iMfD5HSydoTDzmOM/ki5zGiu4DbHpzRueM7D+12IcDHeai2A8QvEroS8HCJl5M1Edbju5rOlPIpg==
 
+"@iiif/vocabulary@^1.0.28":
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/@iiif/vocabulary/-/vocabulary-1.0.28.tgz#04069f9636a17c6bb0eecc6ee59cb32a8d382439"
+  integrity sha512-+6D5FYv5fHvYpJHZKOoX0FYsU/w+cOLKcIrL2lFKkrCoD2LfMf5JzdxvgrAqdcBbwIa3AGJwWaHhXPhYbS40iQ==
+
 "@jest/schemas@^29.6.0":
   version "29.6.0"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.0.tgz#0f4cb2c8e3dca80c135507ba5635a4fd755b0040"
@@ -1677,9 +1682,9 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@samvera/ramp@https://github.com/samvera-labs/ramp.git#691015e":
+"@samvera/ramp@https://github.com/samvera-labs/ramp.git#browser-determined-download":
   version "4.0.0"
-  resolved "https://github.com/samvera-labs/ramp.git#691015e4d3436d8a0cc3fd05c5f58c46571c3773"
+  resolved "https://github.com/samvera-labs/ramp.git#fd6e8ef9c217f2812252427113821b1d2a51f2c2"
   dependencies:
     "@rollup/plugin-json" "^6.0.1"
     "@silvermine/videojs-quality-selector" "^1.3.1"
@@ -5706,12 +5711,12 @@ mammoth@^1.4.19:
     xmlbuilder "^10.0.0"
 
 manifesto.js@^4.1.0:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/manifesto.js/-/manifesto.js-4.2.21.tgz#a62e9c7673467f7dd832a4fe27fe1c97a7b62d6c"
-  integrity sha512-C14J8zMSXlQaQjKR7KpIYEAXWquS2DtdxL8cFj1P2kc/ZJ5nWWmDUrthysVoQlRIzks5HtUNf5bStOwzhzarag==
+  version "4.2.22"
+  resolved "https://registry.yarnpkg.com/manifesto.js/-/manifesto.js-4.2.22.tgz#39f251ea2711e9df088655077bf2776895bd84dd"
+  integrity sha512-Rl7nKFzJ7kiotWCrFkqTnY6xfdGr7KtaHo+QovRXe4WGizoH1QaF6kHodNPIOsi2L5LCgX/RVoNqOryLKEuNrg==
   dependencies:
     "@edsilv/http-status-codes" "^1.0.3"
-    "@iiif/vocabulary" "^1.0.26"
+    "@iiif/vocabulary" "^1.0.28"
     isomorphic-unfetch "^3.0.0"
     lodash "^4.17.21"
 


### PR DESCRIPTION
Resolves #6399 

Change content disposition header from `attachment` (which forces download) to `inline` (which allows browser to display or download if filetype isn't supported).  This required a change in ramp to skip special handling of links because it was creating an anchor tag and setting the `download` attribute which if present browsers will download instead of respecting the inline content disposition.

### Testing guidance

1. Upload supplemental files of different types to both item and section
1. Test that downloads work correctly with correct filename on item view page
1. Upload captions and transcripts (both machine generated and not)
1. Test that captions and transcripts work correctly in ramp
1. Test that transcript download works correctly and renames file if machine generated