### PR TITLE
Add display_title to media object section_labels so it will be searchable if only filename

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -287,7 +287,9 @@ class MediaObject < ActiveFedora::Base
   end
 
   def section_labels
-    all_labels = sections.collect{ |section| section.structural_metadata_labels << section.title}
+    # Need to add both title and display_title to avoid a regression because it is possible to have a title different than
+    # the section's structrualMetadata.section_title which is preferred in display_title
+    all_labels = sections.collect { |section| (section.structural_metadata_labels << section.title << section.display_title).uniq }
     all_labels.flatten.uniq.compact
   end
 

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -820,11 +820,13 @@ describe MediaObject do
   describe '#section_labels' do
     before do
       mf = FactoryBot.create(:master_file, :with_structure, title: 'Test Label', media_object: media_object)
+      mf2 = FactoryBot.create(:master_file, media_object: media_object)
       media_object.reload
     end
     it 'should return correct list of labels' do
       expect(media_object.section_labels.first).to eq 'CD 1'
       expect(media_object.section_labels).to include 'Test Label'
+      expect(media_object.section_labels).to include 'video.mp4'
     end
   end
 


### PR DESCRIPTION
Resolves #6440 

This change would fix newly created items but a partial reindex would be needed to fix items that already exist with this issue.