### PR TITLE
Re-enable confirmation messages on delete buttons

### DIFF
--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -82,7 +82,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                         master_file_path(section.id),
                         title: 'Delete',
                         class: 'btn btn-sm btn-outline btn-confirmation',
-                          data: { placement: 'left' },
+                          data: { placement: 'left', confirm: 'Are you sure?' },
                           method: :delete %>
                     </span>
                     <span>

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -77,7 +77,7 @@ Unless required by applicable law or agreed to in writing, software distributed
               <button type="button" class="btn btn-primary btn-struct me-1" value="Advanced Edit" data-bs-toggle="modal"
                 data-bs-target="#advanced_edit_structure_<%= index %>" data-testid="media-object-struct-adv-edit-btn-<%= index %>" >Advanced Edit</button>
               <% if section.structuralMetadata.content.present? %>
-                <%= link_to 'Remove', structure_master_file_path(section.id), method: :delete, class: 'btn btn-danger btn-struct btn-confirmation', data: {placement: 'top'} %>
+                <%= link_to 'Remove', structure_master_file_path(section.id), method: :delete, class: 'btn btn-danger btn-struct btn-confirmation', data: { placement: 'top', confirm: 'Are you sure?' } %>
               <% end %>
             </div>
             <% end %>

--- a/app/views/media_objects/_supplemental_files_list.html.erb
+++ b/app/views/media_objects/_supplemental_files_list.html.erb
@@ -102,7 +102,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <%= button_tag name: 'edit_label', class:'btn btn-outline btn-sm edit_label display-item', type: 'button' do %>
           <i class="fa fa-edit" title="Edit"></i> <span class="sm-hidden">Edit</span>
         <% end %>
-        <%= link_to(object_supplemental_file_path(section, file), title: 'Remove', method: :delete, class: "btn btn-danger btn-sm file-remove btn-confirmation") do %>
+        <%= link_to(object_supplemental_file_path(section, file), title: 'Remove', method: :delete, class: "btn btn-danger btn-sm file-remove btn-confirmation", data: { confirm: "Are you sure?" }) do %>
           <i class="fa fa-trash" title="Delete"></i> <span class="sm-hidden">Delete</span>
         <% end %>
         </div>

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -69,7 +69,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
         <% end # playlists.present?%>
         <%= f.submit "Delete Selected", id: 'delete_selected_playlist_items', class: 'btn btn-danger btn-confirmation btn-sm',
-          form:"edit_playlist_#{@playlist.id}", data: { placement: 'bottom', testid: 'playlist-delete-selected-btn' }, disabled:'disabled', sanitize: false %>
+          form:"edit_playlist_#{@playlist.id}", data: { placement: 'bottom', testid: 'playlist-delete-selected-btn', confirm: 'Are you sure?' }, disabled:'disabled', sanitize: false %>
       </div>
     </div>
     <% end #form_for update_multiple %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -17,7 +17,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div>
     <%= link_to "View Playlist", @playlist, { class: 'btn btn-primary'} %>
     <% if can?(:destroy, @playlist) %>
-    <%= link_to "Delete Playlist", @playlist, method: :delete, class: 'btn btn-link btn-confirmation', data: {placement: 'bottom', testid:'playlist-delete-playlist-form'} %>
+    <%= link_to "Delete Playlist", @playlist, method: :delete, class: 'btn btn-link btn-confirmation', data: { placement: 'bottom', testid:'playlist-delete-playlist-form', confirm: 'Are you sure?' } %>
     <% end %>
   </div>
 

--- a/app/views/timelines/_show_timeline_details.html.erb
+++ b/app/views/timelines/_show_timeline_details.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <div class="col-sm-12">
       <%= link_to "View Timeline", @timeline, { class: 'btn btn-primary' } %>
       <% if can?(:destroy, @timeline) %>
-        <%= link_to "Delete Timeline", @timeline, method: :delete, class: 'btn btn-link btn-confirmation', data: {placement: 'bottom'} %>
+        <%= link_to "Delete Timeline", @timeline, method: :delete, class: 'btn btn-link btn-confirmation', data: {placement: 'bottom', confirm: 'Are you sure?' } %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Related issue: #6444

Bootstrap 5 changed how popovers are enabled and triggered for display. As part of the rework for our confirmation popovers, we changed them from triggering on click to triggering on a rails confirmation event. During the upgrade some of the delete buttons were missed and so the rails confirmation was not added to those buttons.