### PR TITLE
Remove code climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,15 +106,6 @@ jobs:
             curl -H "Content-type:application/octet-stream" --data-binary @solr_conf.zip "http://solr:SolrRocks@127.0.0.1:<< parameters.solr_port >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
             curl "http://solr:SolrRocks@127.0.0.1:<< parameters.solr_port >>/solr/admin/collections?action=CREATE&name=hydra-test&numShards=1&collection.configName=solrconfig"
 
-      - run:
-          command: |
-            if [[ $(command -v cc-test-reporter) == "" ]]; then
-              curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-              chmod +x ./cc-test-reporter
-            fi
-      - run:
-          command: ./cc-test-reporter before-build
-
       # Pull in the parallel_rspec step and modify it to ensure that test results get stored
       # - samvera/parallel_rspec
       - run: mkdir /tmp/test-results
@@ -129,39 +120,6 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-      - run:
-          command: ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
-
-      - persist_to_workspace:
-          root: coverage
-          paths:
-            - codeclimate.*.json
-
-  upload-coverage:
-    parameters:
-      parallelism:
-        type: integer
-        default: 4
-    docker:
-      # Primary container image where all steps run.
-      - image: avalonmediasystem/avalon:develop
-
-    working_directory: /home/app/avalon
-
-    steps:
-      - attach_workspace:
-          at: /home/app/avalon
-
-      - run:
-          name: Install Code Climate Test Reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-
-      - deploy:
-          # CC_TEST_REPORTER_ID set within the circleci web interface
-          command: ./cc-test-reporter sum-coverage --output - --parts << parameters.parallelism >> codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
-
 workflows:
   version: 2
   build_test_report:
@@ -170,7 +128,3 @@ workflows:
           ruby_ver: '3.4'
           name: 'Ruby3-4'
           parallelism: 4
-      - upload-coverage:
-          parallelism: 4
-          requires:
-            - Ruby3-4

--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'codeclimate-test-reporter'
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,8 +310,6 @@ GEM
     cgi (0.5.0)
     childprocess (3.0.0)
     cloudfront-signer (3.0.2)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -1028,7 +1026,6 @@ DEPENDENCIES
   capistrano-yarn
   capybara
   cloudfront-signer
-  codeclimate-test-reporter
   coffee-rails (~> 5.0)
   config
   csv

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,6 @@ ENV['RAILS_ENV'] = 'test'
 
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'
-  require 'codeclimate-test-reporter'
 
   SimpleCov.start('rails') do
     add_filter '/spec'


### PR DESCRIPTION
Code Climate has been shut down and moved with new version of service.  See https://codeclimate.com/blog/code-climate-quality-is-now-qlty-software

We haven't really been using this in any meaningful capacity for a while so I opted to remove than port.