### PR TITLE
Make edtf humanization configurable

### DIFF
--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -28,11 +28,7 @@ module Blacklight::LocalBlacklightHelper
 
   def humanized_date_index_display args
     field = args[:document][args[:field]]
-    return "unknown" if field == "unknown/unknown"
-
-    Date.edtf(field).humanize
-  rescue
-    nil
+    Avalon::Configuration.humanize_edtf.call(field)
   end
 
   def description_index_display args

--- a/app/models/iiif_manifest_presenter.rb
+++ b/app/models/iiif_manifest_presenter.rb
@@ -180,9 +180,7 @@ class IiifManifestPresenter
   end
 
   def display_date(date)
-    return unless date.present?
-    # `date_issued` and `date_created` return as String, so convert to Date/EDTF class before humanization
-    Date.edtf(date).humanize
+    Avalon::Configuration.humanize_edtf.call(date)
   end
 
   def iiif_metadata_fields

--- a/lib/avalon/configuration.rb
+++ b/lib/avalon/configuration.rb
@@ -94,6 +94,20 @@ module Avalon
       end
     end
 
+    attr_writer :humanize_edtf
+    def humanize_edtf
+      @humanize_edtf ||= lambda do |date|
+        begin
+          return if date.blank?
+          return "unknown" if date == "unknown/unknown"
+          # `date_issued` and `date_created` return as String, so convert to Date/EDTF class before humanization
+          Date.edtf(date).humanize
+        rescue
+          nil
+        end
+      end
+    end
+
     # To be called as Avalon::Configuration.controlled_digital_lending_enabled?
     def controlled_digital_lending_enabled?
       !!Settings.controlled_digital_lending&.enable

--- a/spec/models/iiif_manifest_presenter_spec.rb
+++ b/spec/models/iiif_manifest_presenter_spec.rb
@@ -120,6 +120,33 @@ describe IiifManifestPresenter do
         end
       end
     end
+
+    context 'date handling' do
+      let(:media_object) { FactoryBot.build(:media_object, date_issued: '2025-07-22', date_created: '2025-07-01') }
+
+      it 'returns human readable date' do
+        expect(subject['Publication date'].first).to eq 'July 22, 2025'
+        expect(subject['Creation date'].first).to eq 'July 1, 2025'
+      end
+
+      context 'unknown/unknown' do
+        let(:media_object) { FactoryBot.build(:media_object, date_issued: 'unknown/unknown', date_created: 'unknown/unknown') }
+
+        it 'returns "unknown"' do
+          expect(subject['Publication date'].first).to eq 'unknown'
+          expect(subject['Creation date'].first).to eq 'unknown'
+        end
+      end
+
+      context 'invalid date' do
+        let(:media_object) { FactoryBot.build(:media_object, date_issued: 'not_a date', date_created: false) }
+
+        it 'returns nil' do
+          expect(subject['Publication date']).to be_nil
+          expect(subject['Creation date']).to be_nil
+        end
+      end
+    end
   end
 
   context 'viewing_hint' do

--- a/spec/models/iiif_manifest_presenter_spec.rb
+++ b/spec/models/iiif_manifest_presenter_spec.rb
@@ -62,9 +62,10 @@ describe IiifManifestPresenter do
     it 'provides metadata' do
       allow_any_instance_of(IiifManifestPresenter).to receive(:lending_enabled).and_return(false)
 
-      ['Title', 'Alternative title', 'Publication date', 'Creation date', 'Main contributor', 'Summary', 'Contributor', 'Publisher', 'Genre', 'Subject', 
-       'Time period', 'Geographic Subject', 'Collection', 'Unit', 'Language', 'Rights Statement', 'Terms of Use', 'Physical Description', 'Series',
-       'Related Item', 'Notes', 'Table of Contents', 'Local Note', 'Other Identifier', 'Access Restrictions', 'Bibliographic ID'
+      [
+        'Title', 'Alternative title', 'Publication date', 'Creation date', 'Main contributor', 'Summary', 'Contributor', 'Publisher', 'Genre', 'Subject',
+        'Time period', 'Geographic Subject', 'Collection', 'Unit', 'Language', 'Rights Statement', 'Terms of Use', 'Physical Description', 'Series',
+        'Related Item', 'Notes', 'Table of Contents', 'Local Note', 'Other Identifier', 'Access Restrictions', 'Bibliographic ID'
       ].each do |field|
         expect(subject).to include(field)
       end
@@ -76,7 +77,6 @@ describe IiifManifestPresenter do
         FactoryBot.build(:fully_searchable_media_object).tap do |mo|
           mo.other_identifier += mo.other_identifier
           mo.other_identifier += [mo.bibliographic_id]
-          mo
         end
       end
 
@@ -93,9 +93,10 @@ describe IiifManifestPresenter do
       it 'provides metadata' do
         allow_any_instance_of(IiifManifestPresenter).to receive(:lending_enabled).and_return(true)
 
-        ['Title', 'Publication date', 'Creation date', 'Main contributor', 'Summary', 'Contributor', 'Publisher', 'Genre', 'Subject',
-         'Time period', 'Geographic Subject', 'Collection', 'Unit', 'Language', 'Rights Statement', 'Terms of Use', 'Physical Description', 'Series',
-         'Related Item', 'Notes', 'Table of Contents', 'Local Note', 'Other Identifier', 'Access Restrictions', 'Bibliographic ID', 'Lending Period'
+        [
+          'Title', 'Publication date', 'Creation date', 'Main contributor', 'Summary', 'Contributor', 'Publisher', 'Genre', 'Subject',
+          'Time period', 'Geographic Subject', 'Collection', 'Unit', 'Language', 'Rights Statement', 'Terms of Use', 'Physical Description', 'Series',
+          'Related Item', 'Notes', 'Table of Contents', 'Local Note', 'Other Identifier', 'Access Restrictions', 'Bibliographic ID', 'Lending Period'
         ].each do |field|
           expect(subject).to include(field)
         end
@@ -112,10 +113,10 @@ describe IiifManifestPresenter do
 
     context 'values with search links' do
       it 'includes appropriate link tags' do
-        search_url = Rails.application.routes.url_helpers.blacklight_url.gsub('/','\/')
+        search_url = Rails.application.routes.url_helpers.blacklight_url.gsub('/', '\/')
         ['Subject'].each do |field|
           subject[field].each do |value|
-            expect(value).to match /^<a href="#{search_url}\?f%5B.+%5D%5B%5D=.*">.*<\/a>$/
+            expect(value).to match(/^<a href="#{search_url}\?f%5B.+%5D%5B%5D=.*">.*<\/a>$/)
           end
         end
       end


### PR DESCRIPTION
Related issue: #6463

An issue was run into where we fixed date handling for the blacklight helper but failed to apply it to the iiif manifest generation as well. This PR moves the humanization into a lambda function in the avalon configuration. This allows a one stop place to adjust the logic and will allow other implementers to more easily adjust the humanization to their specifications.

This PR also includes some minor fixes to appease rubocop.