### PR TITLE
Make default ffmpeg path config match location in avalon container

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ encoding:
 mediainfo:
   path: '/usr/bin/mediainfo --urlencode' # Fixes mediainfo v20.03 bug with S3 presigned URL
 ffmpeg:
-  path: '/usr/local/bin/ffmpeg'
+  path: '/usr/bin/ffmpeg'
 ffprobe:
   path: '/usr/bin/ffprobe'
 email:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,6 @@ services:
       - AWS_REGION=us-east-1
       - SETTINGS__ACTIVE_STORAGE__BUCKET=supplementalfiles
       - SETTINGS__ACTIVE_STORAGE__SERVICE=generic_s3
-      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - SETTINGS__MINIO__ENDPOINT=http://minio:9000
       - SETTINGS__MINIO__PUBLIC_HOST=http://localhost:9000
       - SETTINGS__MINIO__ACCESS=minio


### PR DESCRIPTION
This is mostly historical since the settings.yml predates the Avalon docker-compose.  We could probably change this since I think a majority of Avalon installs are running with our docker containers now.

Found by @dsteelma-umd in slack.