### PR TITLE
Update "ffmpeg" location in "config/settings.yml", replace overrides

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ encoding:
 mediainfo:
   path: '/usr/bin/mediainfo --urlencode' # Fixes mediainfo v20.03 bug with S3 presigned URL
 ffmpeg:
-  path: '/usr/local/bin/ffmpeg'
+  path: '/usr/bin/ffmpeg'
 ffprobe:
   path: '/usr/bin/ffprobe'
 email:
@@ -126,7 +126,7 @@ derivative:
 # Maximum size for uploaded files in bytes (default is disabled)
 #max_upload_size: 2147483648 # Use :none or comment out to disable limit
 # Rack Multipart creates temporary files when processing multipart form data with a large payload.
-# If the default system /tmp directory is storage constrained, you can define an alternative here. 
+# If the default system /tmp directory is storage constrained, you can define an alternative here.
 # Leave commented out to use the system default.
 # tempfile:
 #   location: '/tmp'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,6 @@ services:
       - AWS_REGION=us-east-1
       - SETTINGS__ACTIVE_STORAGE__BUCKET=supplementalfiles
       - SETTINGS__ACTIVE_STORAGE__SERVICE=generic_s3
-      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - SETTINGS__MINIO__ENDPOINT=http://minio:9000
       - SETTINGS__MINIO__PUBLIC_HOST=http://localhost:9000
       - SETTINGS__MINIO__ACCESS=minio
@@ -157,7 +156,6 @@ services:
       - redis-test
     environment:
       - DATABASE_URL=postgresql://postgres:password@db-test/avalon
-      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - SETTINGS__REDIS__HOST=redis-test
       - SETTINGS__REDIS__PORT=6379
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora-test:8080/fcrepo/rest

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -121,7 +121,6 @@ services:
       - AWS_REGION=us-east-1
       - SETTINGS__ACTIVE_STORAGE__BUCKET=supplementalfiles
       - SETTINGS__ACTIVE_STORAGE__SERVICE=generic_s3
-      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - SETTINGS__MINIO__ENDPOINT=http://minio:9000
       - SETTINGS__MINIO__PUBLIC_HOST=http://localhost:9000
       - SETTINGS__MINIO__ACCESS=minio
@@ -161,7 +160,6 @@ services:
       - redis-test
     environment:
       - DATABASE_URL=postgresql://postgres:password@db-test/avalon
-      - SETTINGS__FFMPEG__PATH=/usr/bin/ffmpeg
       - SETTINGS__REDIS__HOST=redis-test
       - SETTINGS__REDIS__PORT=6379
       - FEDORA_URL=http://fedora-test:8080/fedora/rest


### PR DESCRIPTION
Since at least Avalon v6.0, the “ffmpeg” binary has been in the “/usr/bin/” directory, however the "config/settings.yml" file still sets the path to "/usr/local/bin/ffmpeg".

Assuming this was just an historical oversight, updated the "config/settings.yml" with the correct location, and removed the "SETTINGS__FFMPEG__PATH" overrides in the "docker-compose.yml" and "podman-compose.yml" files, as they should no longer be needed.

This change simplifies the configuration settings, and makes the stock "settings.yml" file more correct, and usable in more situations (such as when running Avalon in Kubernetes where the docker-compose.yml" and "podman-compose.yml" files are not used).