### PR TITLE
Bring in patch for closing blacklight modals via escape key while preserving scrolling

### DIFF
--- a/app/assets/javascripts/blacklight/modal_patch.js
+++ b/app/assets/javascripts/blacklight/modal_patch.js
@@ -1,0 +1,11 @@
+// Patch fix of https://github.com/projectblacklight/blacklight/pull/3694
+// TODO: Remove this when on a version of blacklight that includes that PR
+$(document).ready(function () {
+    // Make sure user-agent dismissal of html 'dialog', etc `esc` key, triggers
+    // our hide logic, including events and scroll restoration.
+    document.getElementById('blacklight-modal').addEventListener('cancel', (e) => {
+      e.preventDefault(); // 'hide' will close the modal unless cancelled
+
+      Blacklight.Modal.hide();
+    });
+});


### PR DESCRIPTION
Port of https://github.com/projectblacklight/blacklight/pull/3694
Fixes #6460 