### PR TITLE
Restore rails-ujs needed for automatically sending CSRF tokens on AJAX requets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,6 +27,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require rails-ujs
 
 // Required by Blacklight
 //= require popper


### PR DESCRIPTION
Fixes #6470 and #6471.

While the CSRF error reported in #6471 is fixed by restoring `rails-ujs` I am seeing an error in the browser console which is preventing the successfully changed label from being displayed on the page without a reload.