### PR TITLE
Fix skip to main content link visibility and href

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,4 +216,15 @@ module ApplicationHelper
       media_object_supplemental_files_path(object.id)
     end
   end
+
+  # Set href for 'Skip to main content' to 
+  # - media-player on playlist/:id and media_objects/ pages
+  # - <main> container on other pages
+  def skip_to_content_href
+    if (params[:controller] == 'media_objects') || (params[:controller] == 'playlists' && params[:id].present?)
+      "#iiif-media-player"
+    else
+      "#main-content"
+    end
+  end
 end

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -40,14 +40,14 @@ Unless required by applicable law or agreed to in writing, software distributed
 <body data-mountpoint="<%=main_app.root_path%>" <%= request.fullpath.include?('login_popup') ? 'onunload=closePopup()' : nil %> >
   <div class="page-container">
     <div class="content-wrapper">
-      <a id="skip-to-content" class="visually-hidden visually-hidden-focusable" href="#iiif-media-player">Skip to main content</a>
+      <a id="skip-to-content" class="visually-hidden-focusable" href="<%= skip_to_content_href %>">Skip to main content</a>
       <%= render partial: 'shared/modal' %>
       <% if defined?(Samvera::Persona) %>
       <%= render partial: 'modules/become_message' %>
       <% end %>
       <%= render 'modules/header' %>
       <%= render :partial => 'modules/global_navigation' %>
-      <main role="main" class="<%= "homepage-main" if current_page?(main_app.root_path) %>">
+      <main id="main-content" role="main" class="<%= "homepage-main" if current_page?(main_app.root_path) %>">
 
         <!-- Homepage -->
         <% if current_page?(main_app.root_path) %>


### PR DESCRIPTION
Related issue: #6456 

Changes in the PR:
- removed the `visually-hidden` class from the `Skip to main content` link
- once the link was visible on focus, I tested its functionality and noticed that, it takes the user to `#iiif-media-player` on all pages. So, I added a helper to set the `href` of the `Skip to main content` link based on the page.
  - on media object and playlist show pages set it to `#iiif-media-player`
  - on other pages set it to `#main-content` which is the newly added id of the `<main>` container shared by all the pages in Avalon
