### PR TITLE
Fix a11y issue for focusable elements in VideoJS modals

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -470,3 +470,9 @@
 .vjs-svg-icon>svg {
   vertical-align: baseline;
 }
+
+// Remove focusable elements from DOM in VideoJS modals when modal is closed
+.vjs-theme-ramp>.vjs-modal-dialog[aria-hidden=true] select,
+.vjs-theme-ramp>.vjs-modal-dialog[aria-hidden=true] button {
+  display: none;
+}


### PR DESCRIPTION
Related issue: #6427 

These errors were coming from the `button` and `select` fields within the VideoJS error and caption settings modals. However I was not seeing these a11y errors on Ramp demo site.

Changes in this PR gets applied to both media object and playlist show pages.