### PR TITLE
Ensure tags is array before attempting string join

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -99,7 +99,7 @@ class PlaylistsController < ApplicationController
           view_context.human_friendly_visibility(playlist.visibility),
           "<span title='#{playlist.created_at.utc.iso8601}'>#{view_context.time_ago_in_words(playlist.created_at)} ago</span>",
           "<span title='#{playlist.updated_at.utc.iso8601}'>#{view_context.time_ago_in_words(playlist.updated_at)} ago</span>",
-          playlist.tags.join(', '),
+          Array(playlist.tags).join(', '),
           "#{copy_button} #{edit_button} #{delete_button}"
         ]
       end


### PR DESCRIPTION
On avalon-dev there was a playlist with tags `""` instead of `[]` which caused the playlist index page to hit a 500 when AJAX requesting it.  I changed that one item on avalon-dev but this PR should have resolved it too.

Part of #6470 