### PR TITLE
Fix tab focus and tab order in playlist details edit page

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1240,6 +1240,12 @@ td {
   &:hover {
     background-color: $lightgray;
   }
+
+  // Override Bootstrap 5's default styling to remove button border on focus-visible
+  &:focus-visible {
+    border: 1px solid $btn-outline-border-color;
+    box-shadow: 0 0 0 0.2rem rgba($btn-outline-border-color, 0.25);
+  }
 }
 
 .ramp--rails-content {

--- a/app/assets/stylesheets/avalon/_playlists.scss
+++ b/app/assets/stylesheets/avalon/_playlists.scss
@@ -46,7 +46,7 @@
 
 .playlist-action-button-row.col-sm-4 {
   padding-left: 0.75rem;
-  padding-right:0px;
+  padding-right: 0px;
 }
 
 .playlist-autoplay-wrapper {
@@ -183,4 +183,10 @@
 #playlist_title:invalid {
   border-color: $danger;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px $danger;
+}
+
+/* Add focus ring to edit details icon for playlist and playlist items */
+.edit-details-icon-btn:focus-visible {
+  outline: none;
+  box-shadow: rgba(74, 110, 114, 0.5) 0px 0px 0px 3.5px; // Use Bootstrap's focus ring color
 }

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -92,7 +92,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <%= link_to clip.title, clip.mediafragment_uri, id: "playlist_item_title_label_#{i.id}" %>
               </div>
               <div class="col-sm-2 text-right" style="margin-top:5px">
-                <button id="playlist_item_edit_button" class="btn btn-sm" <%= clip.master_file.nil? ? 'disabled' : '' %>
+                <button id="playlist_item_edit_button" class="btn btn-sm edit-details-icon-btn" <%= clip.master_file.nil? ? 'disabled' : '' %>
                   data-bs-toggle="collapse" href="#playlist_item_edit_<%= i.id %>" aria-expanded="false" type="button" aria-label="Edit playlist item <%= index + 1 %>">
                   <i class="fa fa-edit"></i>
                 </button>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -54,7 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <div class="mb-3">
     <%= f.submit id: 'submit-playlist-form', class: 'btn btn-primary', value: t("playlist.#{params[:action]}.action"), 'data-testid': 'playlist-submit-form' %>
-    <a id="playlist_edit_cancel" role="button" class="btn btn-outline" data-bs-toggle="collapse" data-bs-target="#playlist_edit_div, #playlist_view_div">Cancel</a>
+    <a id="playlist_edit_cancel" role="button" class="btn btn-outline" data-bs-toggle="collapse" href="#playlist_edit_div, #playlist_view_div">Cancel</a>
   </div>
   <% end # form_for playlist_form%>
 </div>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -23,8 +23,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <div class="playlist-details-headline-wrapper">
     <h2 class="headline" style="display:inline-block"><%= t("playlist.details") %></h2>
-    <button id="playlist_edit_button" type="button" class="btn btn-lg" data-bs-toggle="collapse" 
-      data-bs-target="#playlist_edit_div, #playlist_view_div" aria-expanded="false" 
+    <button id="playlist_edit_button" class="ms-2 btn btn-lg edit-details-icon-btn" data-bs-toggle="collapse" data-bs-target="#playlist_edit_div, #playlist_view_div" aria-expanded="false" 
       aria-label="Edit playlist details" data-testid="playlist-edit-icon-btn">
       <i class="fa fa-edit"></i>
     </button>


### PR DESCRIPTION
Related issue: #6356

Changes:
- switched `data-bs-target` to `href` in `<a>` tag for `Cancel` button in playlist edit details form. Adding `href` adds the button to the tab order of the page
- added `:focus-visible` pseudo-class to `.btn-outline` Bootstrap class to keep the outline visible when using keyboard focus. - **This change is applied to all the buttons in Avalon using `.btn-outline` class**
- add `:focus-visible` pseudo-class to the edit-icon button for both playlist and playlist-item details edit forms to make it visibly focused upon keyboard `Tab` focus