### PR TITLE
Fix layout in playlist show page after Bootstrap upgrade

### DIFF
--- a/app/javascript/components/PlaylistRamp.jsx
+++ b/app/javascript/components/PlaylistRamp.jsx
@@ -187,9 +187,8 @@ const PlaylistRamp = ({
           <MediaPlayer enableFileDownload={false} enablePlaybackRate={true} />
           {playlist_item_ids?.length > 0 && (
             <Card
-              className={`ramp--playlist-accordion ${
-                IS_MOBILE ? 'mobile-view' : ''
-              }`}
+              className={`ramp--playlist-accordion ${IS_MOBILE ? 'mobile-view' : ''
+                }`}
             >
               <Card.Header>
                 <h4>{activeItemTitle}</h4>
@@ -219,9 +218,8 @@ const PlaylistRamp = ({
         <Col
           sm={12}
           md={4}
-          className={`ramp--playlist-items-column ${
-            IS_MOBILE ? 'mobile-view' : ''
-          }`}
+          className={`ramp--playlist-items-column ${IS_MOBILE ? 'mobile-view' : ''
+            }`}
         >
           <Row>
             <Col sm={6}>
@@ -230,7 +228,7 @@ const PlaylistRamp = ({
             <Col sm={6}>
               {share.canShare && (
                 <button
-                  className="btn btn-outline text-nowrap float-right"
+                  className="btn btn-outline text-nowrap float-end"
                   type="button"
                   data-bs-toggle="collapse"
                   data-bs-target="#shareList"

--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -319,7 +319,7 @@
 
   .ramp--auto-advance {
     height: fit-content;
-    max-height: 33.5px;
+    max-height: 34.5px;
     align-items: center;
 
     .slider {

--- a/app/views/playlists/_action_buttons.html.erb
+++ b/app/views/playlists/_action_buttons.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="col-sm-6">
     <% if current_ability.can? :edit, @playlist %>
     <div id="edit-playlist-button" data-testid="playlist-edit-playlist-btn">
-      <%= link_to edit_playlist_path(@playlist), class: "btn btn-primary btn-block text-nowrap" do %>
+      <%= link_to edit_playlist_path(@playlist), class: "btn btn-primary btn-block text-nowrap w-100 " do %>
       <i class="fa fa-edit" aria-hidden="true"></i> Edit Playlist
       <% end %>
     </div>
@@ -26,7 +26,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
   <div class="col-sm-6">
     <% if current_ability.can? :duplicate, @playlist %>
-    <%= button_tag(type: 'button', data: { playlist: @playlist, testid: 'playlist-copy-playlist-btn' }, class: 'copy-playlist-button btn btn-outline btn-block text-nowrap') do %>
+    <%= button_tag(type: 'button', data: { playlist: @playlist, testid: 'playlist-copy-playlist-btn' }, class: 'copy-playlist-button btn btn-outline btn-block text-nowrap w-100') do %>
     <i class="fa fa-clone" aria-hidden="true"></i> Copy Playlist
     <% end %>
     <% end %>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% @page_title = t('media_objects.show.title', :media_object_title => @playlist.title, :application_name => application_name) %>
 
 <div class="playlist-view-wrapper row">
-  <div class="page-title-wrapper playlist-title-wrapper row">
+  <div class="page-title-wrapper playlist-title-wrapper row px-0">
     <div class=" playlist-title col-sm-8 ps-0">
       <%= icon_only_visibility @playlist.visibility %>
       <h1 class="page-title" data-testid="playlist-title"><%= @playlist.title %></h1>


### PR DESCRIPTION
Before:
<img width="1140" height="754" alt="Screenshot 2025-07-29 at 11-32-00 Markers Test Playlist - Avalon Media System" src="https://github.com/user-attachments/assets/2a9b8b26-aff5-45e1-9972-cceec1d0b956" />

After:

<img width="1140" height="754" alt="Screenshot 2025-07-29 at 11-32-47 Markers Test Playlist - Avalon Media System" src="https://github.com/user-attachments/assets/8eb7393f-5547-4338-853c-e3241d66f59d" />
