### PR TITLE
Prevent timeline overflow over the footer on page resize

### DIFF
--- a/app/assets/stylesheets/avalon/_timeliner.scss
+++ b/app/assets/stylesheets/avalon/_timeliner.scss
@@ -32,7 +32,7 @@
 .timeliner-contianer {
   left: 0;
   right: 0;
-  position: absolute;
+  position: inherit;
 }
 
 /* Timeliner copy modal */


### PR DESCRIPTION
Related issue: #6454 