### PR TITLE
Fix timeliner container height for wider viewports

### DIFF
--- a/app/assets/stylesheets/avalon/_timeliner.scss
+++ b/app/assets/stylesheets/avalon/_timeliner.scss
@@ -32,7 +32,7 @@
 .timeliner-contianer {
   left: 0;
   right: 0;
-  position: inherit;
+  position: absolute;
 }
 
 /* Timeliner copy modal */

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<div class="ratio ratio-16x9 timeliner-contianer" id="content" style="max-width: 100%;">
+<div class="ratio ratio-16x9 timeliner-contianer" id="content" style="max-width: 100%;max-height: 90%;">
     <iframe src="<%= @timeliner_iframe_url %>" aria-label='timeline display'></iframe>
 </div>
 


### PR DESCRIPTION
A bug was introduced with the [previous fix](https://github.com/avalonmediasystem/avalon/pull/6504) made to keep the timeline from overflowing into the footer where, the navigation bar was getting hidden in larger viewports. This PR fixes this bug.