### PR TITLE
Move blacklight helper overrides into CatalogController 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,6 +25,10 @@ class CatalogController < ApplicationController
   before_action :enforce_show_permissions, only: :show
   before_action :load_home_page_collections, only: :index, if: proc { helpers.current_page? root_path }
 
+  helper_method :main_content_classes
+  helper_method :sidebar_classes
+  helper_method :render_document_class
+
   configure_blacklight do |config|
     config.show.route = { controller: "media_objects" }
 
@@ -230,4 +234,36 @@ class CatalogController < ApplicationController
         @featured_collection = ::Admin::CollectionPresenter.new(collection) if collection
       end
     end
+
+    # Override of blacklight helper to add row class
+    def render_document_class(document)
+      # HACK I'm not sure why CatalogController needs to reference these helpers through helpers, but BookmarksController doesn't
+      types = if respond_to? :document_presenter
+                document_presenter(document).display_type
+              else
+                helpers.document_presenter(document).display_type
+              end
+      return if types.blank?
+
+      classes = Array(types).compact.map do |t|
+        if respond_to? :document_class_prefix
+          "#{document_class_prefix}#{t.try(:parameterize) || t}"
+        else
+          "#{helpers.document_class_prefix}#{t.try(:parameterize) || t}"
+        end
+      end
+      classes << "row"
+      classes.join(' ')
+    end
+
+    # Override of blacklight for classes used for main content of Blacklight page
+    def main_content_classes
+      'col-sm-12 col-md-8'
+    end
+
+    # Override of blacklight for classes used for sidebar content of Blacklight page
+    def sidebar_classes
+      'page-sidebar col-sm-12 col-md-4'
+    end
+
 end

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -63,35 +63,4 @@ module Blacklight::LocalBlacklightHelper
     result = t('blacklight.search.filters.none') if result.empty?
     result
   end
-
-  # Override of blacklight helper to add row class
-  def render_document_class(document)
-    # HACK I'm not sure why CatalogController needs to reference these helpers through helpers, but BookmarksController doesn't
-    types = if respond_to? :document_presenter
-              document_presenter(document).display_type
-            else
-              helpers.document_presenter(document).display_type
-            end
-    return if types.blank?
-
-    classes = Array(types).compact.map do |t|
-      if respond_to? :document_class_prefix
-        "#{document_class_prefix}#{t.try(:parameterize) || t}"
-      else
-        "#{helpers.document_class_prefix}#{t.try(:parameterize) || t}"
-      end
-    end
-    classes << "row"
-    classes.join(' ')
-  end
-
-  # Override of blacklight for classes used for main content of Blacklight page
-  def main_content_classes
-    'col-sm-12 col-md-8'
-  end
-
-  # Override of blacklight for classes used for sidebar content of Blacklight page
-  def sidebar_classes
-    'page-sidebar col-sm-12 col-md-4'
-  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,8 +165,76 @@ services:
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
     ports: []
 
+  staging: &staging
+    container_name: avalon
+    image: ghcr.io/avalonmediasystem/avalon:staging
+    build:
+      context: .
+      target: prod
+    command: bash -c "bundle exec rake db:migrate && bundle exec rails server -b 0.0.0.0"
+    depends_on:
+      - db
+      - fedora
+      - solr
+      - redis
+      - hls
+      - minio
+    environment:
+      - APP_NAME=avalon
+      - BUNDLE_FLAGS=--with production postgres --without development test
+      - ENCODE_WORK_DIR=/tmp
+      - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
+      - DATABASE_URL=postgres://postgres:password@db/avalon
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fcrepo/rest
+      - FEDORA_BASE_PATH=/dev
+      - RAILS_ENV=production
+      - RAILS_ADDITIONAL_HOSTS=avalon
+      - SETTINGS__REDIS__URL=redis://redis:6379/0
+      - SECRET_KEY_BASE=abcd
+      - SOLR_URL=http://solr:8983/solr/avalon
+      - AWS_REGION=us-east-1
+      - RAILS_SERVE_STATIC_FILES=true
+      - SETTINGS__ACTIVE_STORAGE__BUCKET=supplementalfiles
+      - SETTINGS__ACTIVE_STORAGE__SERVICE=generic_s3
+      - SETTINGS__DOMAIN=http://localhost/
+      - SETTINGS__MINIO__ENDPOINT=http://minio:9000
+      - SETTINGS__MINIO__PUBLIC_HOST=http://localhost:9000
+      - SETTINGS__MINIO__ACCESS=minio
+      - SETTINGS__MINIO__SECRET=minio123
+      - SETTINGS__ENCODING__MASTERFILE_BUCKET=masterfiles
+      - SETTINGS__ENCODING__DERIVATIVE_BUCKET=derivatives
+      - SETTINGS__DROPBOX__PATH=s3://masterfiles/dropbox/
+      - SETTINGS__DROPBOX__UPLOAD_URI=s3://masterfiles/dropbox/
+      - SETTINGS__MASTER_FILE_MANAGEMENT__PATH=s3://preserves/
+      - SETTINGS__MASTER_FILE_MANAGEMENT__STRATEGY=move
+      - SETTINGS__STREAMING__CONTENT_PATH=/
+      - SETTINGS__STREAMING__STREAM_DEFAULT_QUALITY=medium
+      - SETTINGS__STREAMING__HTTP_BASE=http://localhost:8880/avalon
+      - SETTINGS__STREAMING__SERVER=nginx
+      - SETTINGS__STREAMING__STREAM_TOKEN_TTL=20
+      - SYSTEM_GROUPS=administrator,group_manager,manager
+      - PIDFILE=tmp/pids/server.pid
+      - PUMA_STATE_PATH=tmp/puma.state
+      - AVALON_PROFILING=true
+    volumes:
+      - .:/home/app/avalon
+    ports:
+      - '80:3000'
+    networks:
+      internal:
+      external:
+    stdin_open: true
+    tty: true
+
   worker:
     <<: *avalon
+    command: dumb-init -- bash -c "bundle install && bundle exec sidekiq -C config/sidekiq.yml"
+    ports: []
+
+  worker-staging:
+    <<: *staging
+    container_name: worker
     command: dumb-init -- bash -c "bundle install && bundle exec sidekiq -C config/sidekiq.yml"
     ports: []
 


### PR DESCRIPTION
This allows them to take precedence over the ones supplied by Blacklight which fixes the layout for search results.  

This PR also includes new `staging` and `worker-staging` services in the `docker-compose.yml` that use the same dependency services (fedora, solr, redis, db, HLS streaming, minio) as the `avalon` service but with `RAILS_ENV=production`.  This allows for testing issues which only come up in the production environment.