### PR TITLE
Fix layout of collection item cards view

### DIFF
--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -138,10 +138,17 @@
       padding-right: 10px;
       flex-grow: 1;
       width: 33%;
-  
+      max-width: 33%;
+
       &:last-child {
         padding-right: 0;
       }
+    }
+  }
+
+  @media screen and (min-width: 992px) {
+    li {
+      flex: 0 0 25%;
     }
   }
 

--- a/app/javascript/components/collections/landing/SearchResults.js
+++ b/app/javascript/components/collections/landing/SearchResults.js
@@ -31,7 +31,7 @@ const SearchResults = ({ documents = [], baseUrl }) => {
   return (
     <ul className="row list-unstyled search-within-search-results">
       {documents.map((doc, index) => (
-        <li key={doc.id} className="col-sm-4 col-md-4 col-lg-3">
+        <li key={doc.id}>
           <SearchResultsCard doc={doc} index={index} baseUrl={baseUrl} />
         </li>
       ))}


### PR DESCRIPTION
Related issue: #6518 

Fix layout of collection landing page,
- make a single item card not span the entire page width and height
- change the number of cards displayed in each row at different viewports identical to MCO,
  - in larger viewports (>992px) display 4 items in a row 
  - in medium viewports (in between 992px and 576px) display 3 items in a row