### PR TITLE
Fix layout of collection details display

### DIFF
--- a/app/assets/stylesheets/avalon/_collections.scss
+++ b/app/assets/stylesheets/avalon/_collections.scss
@@ -24,6 +24,7 @@
 
   .collection-details-wrapper {
     justify-content: space-between;
+    flex-direction: row-reverse;
   }
 
   .document-thumbnail img {


### PR DESCRIPTION
| Before (in 8.1 RC 1) | After fix (identical to the layout in Avalon 8) |
|---|---|
| <img width="1337" height="1175" alt="Screenshot 2025-08-18 at 13-59-39 Video Collection - Collections - Avalon Media System" src="https://github.com/user-attachments/assets/a45ff1ee-2309-43c2-820f-90eb91e3c7b2" /> | <img width="1337" height="1175" alt="Screenshot 2025-08-18 at 13-58-43 Video Collection - Collections - Avalon Media System" src="https://github.com/user-attachments/assets/bf1bef4e-f4dc-4a0f-8dbb-1a6364d66177" /> |
