### PR TITLE
Correctly filter the 'Add' in the form row

### DIFF
--- a/app/assets/javascripts/autocomplete.js.coffee
+++ b/app/assets/javascripts/autocomplete.js.coffee
@@ -15,8 +15,9 @@
 @initialize_typeahead = ($t) ->
   $validate = $t.data('validate') || false
   $t.attr('autocomplete','off')
-  # Get the closest 'Add' button related to the input text field
-  add_button = ($t.closest 'div').next().first().children()
+  # Get the closest 'Add' button in the form row
+  add_button = $t.closest('div[class="row"]')
+    .find('button').filter((i, btn) -> $(btn).text().trim() == 'Add').first()
   # Disable the 'Add' button
   add_button.prop 'disabled', true
   mySource = new Bloodhound(


### PR DESCRIPTION
Related issue: #6529 

Get the 'Add' button in the form row with typeahead form fields by filtering elements using the text on the button element instead of getting the element next to the typeahead form field. This makes it work with any form where there are additional form fields in the row.