### PR TITLE
Remove poster button should have white text for contrast and consistency

### DIFF
--- a/app/assets/stylesheets/avalon/_buttons.scss
+++ b/app/assets/stylesheets/avalon/_buttons.scss
@@ -28,7 +28,8 @@ button.btn-close {
 
 .btn-danger,
 .btn-danger:hover,
-.btn-danger:visited {
+.btn-danger:visited,
+.btn-danger:disabled {
   color: $white;
 }
 


### PR DESCRIPTION
Before:
<img width="480" height="300" alt="Screenshot from 2025-08-20 09-33-10" src="https://github.com/user-attachments/assets/00b36f7b-a53b-4fb2-ab37-509b8bd3399c" />

After:
<img width="480" height="300" alt="image" src="https://github.com/user-attachments/assets/d07e37b7-ba5c-4142-a705-51740f342e2d" />
