### PR TITLE
Provide more user friendly errors when playlist/timeline is missing

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -364,4 +364,12 @@ class PlaylistsController < ApplicationController
       item.position = nil
     end
   end
+
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    if request.format == :json
+      render json: { errors: ["#{params[:id]} could not be found"] }, status: :not_found
+    elsif request.format == :html
+      render '/errors/unknown_pid', status: :not_found
+    end
+  end
 end

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -381,4 +381,12 @@ class TimelinesController < ApplicationController
       new_params[:tags] = JSON.parse(new_params[:tags]) if new_params[:tags].present?
       new_params
     end
+
+    rescue_from ActiveRecord::RecordNotFound do |exception|
+      if request.format == :json
+        render json: { errors: ["#{params[:id]} could not be found"] }, status: :not_found
+      elsif request.format == :html
+        render '/errors/unknown_pid', status: :not_found
+      end
+    end
 end

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -150,6 +150,21 @@ RSpec.describe PlaylistsController, type: :controller do
     end
     # TODO: write tests for public/private playists
 
+    context 'deleted/missing playlist' do
+      it 'provides missing item error page' do
+        get :show, params: { id: 'missing' }, session: valid_session
+        expect(response.status).to eq 404
+        expect(response).to render_template("errors/unknown_pid")
+      end
+
+      it 'provides json error response' do
+        get :show, params: { id: 'missing' }, session: valid_session, format: :json
+        expect(response.status).to eq 404
+        result = JSON.parse(response.body)
+        expect(result).to eq({ "errors" => ["missing could not be found"] })
+      end
+    end
+
     context 'read from solr' do
       render_views
 

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -388,6 +388,21 @@ RSpec.describe TimelinesController, type: :controller do
         expect(response_json["manifest"]).to eq timeline.manifest
       end
     end
+
+    context 'deleted/missing timeline' do
+      it 'provides missing item error page' do
+        get :show, params: { id: 'missing' }, session: valid_session
+        expect(response.status).to eq 404
+        expect(response).to render_template("errors/unknown_pid")
+      end
+
+      it 'provides json error response' do
+        get :show, params: { id: 'missing' }, session: valid_session, format: :json
+        expect(response.status).to eq 404
+        result = JSON.parse(response.body)
+        expect(result).to eq({ "errors" => ["missing could not be found"] })
+      end
+    end
   end
 
   describe "GET #new" do


### PR DESCRIPTION
Related issue: #6527

This commit adds a rescue to the playlist and timelines controllers in order to provide better error pages for when a user tries to access a deleted or otherwise missing playlist/timeline. For simplicity, this work reuses the 'errors/unknown_pid' partial but it may eventually be worthwhile to differentiate between the different contexts.