### PR TITLE
Refactor MediaObjectsController#update_status method

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -400,53 +400,50 @@ class MediaObjectsController < ApplicationController
         success_ids << id
         success_count += 1
       else
-        errors += [ "#{media_object.title} (#{params[:id]}) permission denied" ]
+        errors += ["#{media_object.title} (#{params[:id]}) permission denied"]
       end
     end
     message = "#{success_count} #{'media object'.pluralize(success_count)} deleted."
     message += "These objects were not deleted:</br> #{ errors.join('<br/> ') }" if errors.count > 0
     BulkActionJobs::Delete.perform_later success_ids, nil
-    redirect_to params[:previous_view]=='/bookmarks'? '/bookmarks' : root_path, flash: { notice: message }
+    redirect_to params[:previous_view] == '/bookmarks' ? '/bookmarks' : root_path, flash: { notice: message }
   end
 
-  # Sets the published status for the object. If no argument is given then
-  # it will just toggle the state.
   def update_status
     status = params[:status]
     errors = []
     success_count = 0
-    Array(params[:id]).each do |id|
-      media_object = MediaObject.find(id)
-      if cannot? :update, media_object
-        errors += ["#{media_object&.title} (#{id}) (permission denied)."]
-      else
-        begin
-          case status
-          when 'publish'
-            unless media_object.title.present?
-              errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
-              next
-            end
-            media_object.publish!(user_key)
-            # additional save to set permalink
-            media_object.save( validate: false )
-            success_count += 1
-          when 'unpublish'
-            if can? :unpublish, media_object
-              media_object.publish!(nil, validate: false)
-              success_count += 1
-            else
-              errors += ["#{media_object&.title} (#{id}) (permission denied)."]
-            end
+    media_objects = MediaObject.find(Array(params[:id]))
+    media_objects.each do |media_object|
+      id = media_object.id
+      begin
+        case status
+        when 'publish'
+          if cannot? :update, media_object
+            errors += ["#{media_object&.title} (#{id}) (permission denied)."]
+            next
+          elsif media_object.title.blank?
+            errors += ["#{media_object&.title} (#{id}) (missing required fields)"]
+            next
           end
-        rescue ActiveFedora::RecordInvalid => e
-          errors += [e.message]
+          media_object.avalon_publisher = user_key.presence
+          media_object.save!
+          success_count += 1
+        when 'unpublish'
+          if can? :unpublish, media_object
+            media_object.publish!(nil, validate: false)
+            success_count += 1
+          else
+            errors += ["#{media_object&.title} (#{id}) (permission denied)."]
+          end
         end
+      rescue ActiveFedora::RecordInvalid => e
+        errors += [e.message]
       end
     end
     message = "#{success_count} #{'media object'.pluralize(success_count)} successfully #{status}ed." if success_count.positive?
-    message = "Unable to #{status} #{'item'.pluralize(errors.count)}: #{ errors.join('<br/> ') }" if errors.count > 0
-    redirect_back(fallback_location: root_path, flash: {notice: message.html_safe})
+    message = "Unable to #{status} #{'item'.pluralize(errors.count)}: #{errors.join('<br/> ')}" if errors.count.positive?
+    redirect_back(fallback_location: root_path, flash: { notice: message&.html_safe })
   end
 
   # Sets the published status for the object. If no argument is given then

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -227,7 +227,7 @@ class MediaObject < ActiveFedora::Base
   # omit the status which will default to unpublished. This makes the act
   # of publishing _explicit_ instead of an accidental side effect.
   def publish!(user_key, validate: true)
-    self.avalon_publisher = user_key.blank? ? nil : user_key
+    self.avalon_publisher = user_key.presence
     if validate
       save!
     else


### PR DESCRIPTION
Related issue: #6244

This commit makes three minor improvements to the `update_status` method:

1. Removes the extra save action from the publish code flow. This was originally put in place because of issues with permalink generation, but I did not run into any issues with a single save in testing.

2. Moves the initial ability check into the publish code flow, meaning that each code path is only performing one ability check.

3. Moves `MediaObject.find` out of the loop to grab all of the relevant media objects in a single query instead of making a query for each object.