### PR TITLE
Empty transcript search returns blank IIIF content search response

### DIFF
--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -901,5 +901,16 @@ describe MasterFilesController do
       expect(items[0]["body"]["value"]).to eq "Just <em>before</em> <em>lunch</em> one day, a puppet show was put on at school."
       expect(items[0]["target"]).to eq "#{Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(parent_master_file.id, transcript_1.id)}#t=00:00:22.200,00:00:26.600"
     end
+
+    context 'with empty search' do
+      it 'returns an empty valid IIIF content search response' do
+        get('search', params: { id: parent_master_file.id })
+        result = JSON.parse(response.body)
+        expect(result["@context"]).to eq "http://iiif.io/api/search/2/context.json"
+        expect(result["id"]).to eq "#{Rails.application.routes.url_helpers.search_master_file_url(parent_master_file.id)}"
+        expect(result["type"]).to eq "AnnotationPage"
+        expect(result["items"]).to be_blank
+      end
+    end
   end
 end

--- a/spec/lib/avalon/transcript_search_spec.rb
+++ b/spec/lib/avalon/transcript_search_spec.rb
@@ -64,6 +64,16 @@ describe Avalon::TranscriptSearch do
         end
       end
     end
+
+    context 'with empty search' do
+      subject { described_class.new(query: '', master_file: parent_master_file) }
+
+      it 'returns an empty hash' do
+        search = subject.perform_search
+        expect(search).to be_a Hash
+        expect(search).to be_blank
+      end
+    end
   end
 
   describe '#iiif_content_search' do
@@ -115,6 +125,19 @@ describe Avalon::TranscriptSearch do
           item = subject.iiif_content_search[:items].first
           expect(item[:target]).to include '#t=00:00:22.200,00:00:26.600'
         end
+      end
+    end
+
+    context 'with empty search' do
+      subject { described_class.new(query: '', master_file: parent_master_file) }
+
+      it 'returns valid empty IIIF content search response' do
+        allow(SecureRandom).to receive(:uuid).and_return('abc1234')
+        search = subject.iiif_content_search
+        expect(search["@context".to_sym]).to eq "http://iiif.io/api/search/2/context.json"
+        expect(search[:id]).to eq "#{Rails.application.routes.url_helpers.search_master_file_url(parent_master_file.id)}?q="
+        expect(search[:type]).to eq "AnnotationPage"
+        expect(search[:items]).to be_blank
       end
     end
   end


### PR DESCRIPTION
Crawlers have found the content search endpoint and have been making empty requests (no `q` param).  This currently throws an error leading to a large number of honeybadger errors (~2,000 on some days).  Ramp seems to only call the endpoint if there is non-blank query so this problem seems to be bot specific.  This PR checks for a blank query and returns a valid and empty IIIF content search response.