### PR TITLE
Support mp3 skip transcoding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     bcp47_spec (0.2.1)
     bcrypt (3.1.20)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     bindex (0.8.1)
     bixby (5.0.2)
       rubocop (= 1.28.2)
@@ -310,7 +310,7 @@ GEM
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.3)
+    connection_pool (2.5.4)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -558,7 +558,7 @@ GEM
     mysql2 (0.5.6)
     net-http (0.6.0)
       uri
-    net-imap (0.5.9)
+    net-imap (0.5.10)
       date
       net-protocol
     net-ldap (0.19.0)

--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -78,7 +78,8 @@ class Derivative < ActiveFedora::Base
     if managed
       path = Addressable::URI.parse(absolute_location).path
       self.location_url = Avalon::StreamMapper.stream_path(path)
-      self.hls_url = Avalon::StreamMapper.map(path, 'http', format)
+      is_mp3 = format == "audio" && audio_codec == "mp3"
+      self.hls_url = Avalon::StreamMapper.map(path, 'http', (is_mp3 ? "audio_mp3" : format))
     end
     self
   end
@@ -115,6 +116,10 @@ class Derivative < ActiveFedora::Base
     derivative.video_bitrate = output[:video_bitrate]
     derivative.video_codec = output[:video_codec]
     derivative.resolution = "#{output[:width]}x#{output[:height]}" if output[:width] && output[:height]
+
+    if derivative.format == "audio" && derivative.audio_codec == "mp3"
+      derivative.mime_type ||= "audio/mpeg"
+    end
 
     # FIXME: Transform to stream url here? How do we distribute to the streaming server?
     derivative.location_url = output[:url]

--- a/config/url_handlers.yml
+++ b/config/url_handlers.yml
@@ -15,4 +15,5 @@ nginx:
   http:
     video: <%=http_base%>/<%=path%>/<%=filename%>.<%=extension%>/index.m3u8
     audio: <%=http_base%>/<%=path%>/<%=filename%>.<%=extension%>/index.m3u8
+    audio_mp3: <%=http_base%>/<%=path%>/<%=filename%>.<%=extension%>
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,10 +65,11 @@ services:
       - ./solr/conf:/opt/solr/avalon_conf
 
   hls:
-    image: avalonmediasystem/nginx:minio-jammy
+    image: avalonmediasystem/nginx:noble
     environment:
       - AVALON_DOMAIN=http://avalon:3000
       - AVALON_STREAMING_BUCKET_URL=http://minio:9000/derivatives/
+      - VOD_MODE=remote
     volumes:
       - ./log/nginx:/var/log/nginx
     ports:


### PR DESCRIPTION
Resolves #6315

This PR adds a new url handler specifically for streaming skip transcoded mp3s and makes a few small changes to make use of it.  Besides changing the streaming url, a new version of the nginx hls container has been made that handles streaming both mp3s through progressive download and avalon's default mp4s through HLS (see https://github.com/avalonmediasystem/avalon-docker/pull/94 and `avalonmediasystem/nginx:noble`)