### PR TITLE
Update AWS setup of actionmailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,13 +162,13 @@ end
 
 # Install the bundle --with aws when running on Amazon Elastic Beanstalk
 group :aws, optional: true do
+  gem 'aws-actionmailer-ses'
   gem 'aws-activejob-sqs'
   gem 'aws-partitions'
   gem 'aws-sdk-rails'
   gem 'aws-sdk-cloudfront'
   gem 'aws-sdk-elastictranscoder'
   gem 'aws-sdk-s3'
-  gem 'aws-sdk-ses'
   gem 'aws-sdk-sqs'
   gem 'aws-sigv4'
   gem 'cloudfront-signer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,10 @@ GEM
     ast (2.4.3)
     audio_waveform-ruby (1.0.7)
       json (~> 2.3)
+    aws-actionmailer-ses (1.0.0)
+      actionmailer (>= 7.1.0)
+      aws-sdk-ses (~> 1, >= 1.50.0)
+      aws-sdk-sesv2 (~> 1, >= 1.34.0)
     aws-activejob-sqs (1.0.2)
       activejob (>= 7.1.0)
       aws-sdk-sqs (~> 1, >= 1.56.0)
@@ -215,6 +219,9 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-ses (1.85.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sesv2 (1.79.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-sqs (1.96.0)
@@ -987,13 +994,13 @@ DEPENDENCIES
   api-pagination
   audio_waveform-ruby (~> 1.0.7)
   avalon-about!
+  aws-actionmailer-ses
   aws-activejob-sqs
   aws-partitions
   aws-sdk-cloudfront
   aws-sdk-elastictranscoder
   aws-sdk-rails
   aws-sdk-s3
-  aws-sdk-ses
   aws-sdk-sqs
   aws-sigv4
   bixby

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -6,8 +6,10 @@ ActiveSupport.on_load(:action_mailer) do
   case Settings&.email&.mailer&.to_sym
   when :aws_sdk
     require 'aws-sdk-rails'
-    Aws::Rails.add_action_mailer_delivery_method(:aws_sdk)
-    ActionMailer::Base.delivery_method = :aws_sdk
+    require 'aws-actionmailer-ses'
+
+    ActionMailer::Base.delivery_method = :ses_v2
+    ActionMailer::Base.ses_v2_settings = Settings.email.config.to_h
   when :smtp
     ActionMailer::Base.delivery_method = :smtp
     ActionMailer::Base.smtp_settings = Settings.email.config.to_h


### PR DESCRIPTION
This appears to fix mail configuration for SES.

When deploying to demo the rails app errored when initializing because the `add_action_mailer_delivery_method` method no longer exists.