### PR TITLE
Fix collapse / auto expand of active sections on manage files

### DIFF
--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -110,7 +110,7 @@ $('.supplemental-file-form')
 
 /* Store collapsed section ids in localStorage if available */
 $('button[id^=edit_section').on('click', (e) => {
-  if (!Modernizr.localStorage) {
+  if (!(Modernizr.localStorage || Modernizr.localstorage)) {
     return;
   }
 
@@ -119,21 +119,21 @@ $('button[id^=edit_section').on('click', (e) => {
 
   var currentSection = e.target.dataset['sectionId'];
   var isCollapsed = e.target.getAttribute('aria-expanded') == 'true';
-  if (isCollapsed) {
+  if (!isCollapsed) {
     for (var i = 0; i < activeSections.length; i++) {
       if (activeSections[i] == currentSection) {
         activeSections.splice(i, 1);
       }
     }
-  } else {
+  } else if (!activeSections.includes(currentSection)) {
     activeSections.push(currentSection);
   }
   localStorage.setItem('activeSections', JSON.stringify(activeSections));
 });
 
 /* On page reload; collapse sections which were collapsed previously */
-$(document).ready(function () {
-  if (!Modernizr.localStorage) {
+window.addEventListener("load", function () {
+  if (!(Modernizr.localStorage || Modernizr.localstorage)) {
     return;
   }
 


### PR DESCRIPTION
The JS code for expanding active sections on the manage files page was throwing an error on every page load on MCO-staging.  This PR resolves that and fixes the functionality.  This code has already been loaded on mco-staging and this PR backports it to core.

Steps to test:
- Go to Manage Files edit page for an item
- Click the edit button next to a section
- Upload a captions file (this will cause a reloading of the page)
- Check that the section is expanded after page reload
- Close the section and manually reload the page
- Check that the section is closed after page reload