### PR TITLE
Modify RSolr::Client#build_request override to pass query as post body

### DIFF
--- a/config/initializers/rsolr.rb
+++ b/config/initializers/rsolr.rb
@@ -15,6 +15,11 @@ RSolr::Client.class_eval do
       opts[:data] = RSolr::Uri.params_to_solr opts[:data]
       opts[:headers] ||= {}
       opts[:headers]['Content-Type'] ||= 'application/x-www-form-urlencoded; charset=UTF-8'
+    elsif opts[:data].blank? && opts[:method] == :post
+      opts[:data] = opts.delete(:query)
+      query = nil
+      opts[:headers] ||= {}
+      opts[:headers]['Content-Type'] ||= 'application/x-www-form-urlencoded; charset=UTF-8'
     end
     opts[:path] = path
     opts[:uri] = base_uri.merge(path.to_s + (query ? "?#{query}" : "")) if base_uri


### PR DESCRIPTION
Resolves #6578 and #5092

We're already overriding `RSolr::Client#build_request` to have it prefer the configured http method (for us `post`).  This PR furthers that work by making sure that the solr query does not get appended to the uri but is sent as the request body when it is a post request.

This is the simplest PR I could make.  I first started by modifying `ActiveFedora::Base#search_in_batches`, `RSolr::Client#paginate`, and/or `RSolr::Client#build_paginated_request` but there are dragons down this path.  I ran into the issue where requests come into `search_in_batches` with a `:rows` param but `paginate` expects this param isn't set but the error doesn't raise because of a [bug in RSolr at this line](https://github.com/rsolr/rsolr/blob/a60ec42b58f3b068f23537e49d0b6510bb12ee17/lib/rsolr/client.rb#L78).  Furthermore `paginate` sets the `"rows"` and `"start"` params.  These are required by the `RSolr::Response::PaginatedDocSet` to answer `#has_next?` used in `search_in_batches` and this method will fail if `:rows` and `:start` are set instead.  This makes a messy situation where many requests coming through `search_in_batches` end up having two `rows` params because both `:rows` and `"rows"` makes it into the solr query.  I don't know how solr handles precedence when params exist twice in a query.  I tried different combination of `:rows` and `"rows"` but ran into failing tests so I backed up and went with the minimal change that preserves the buggy and brittle but working existing code.  It would probably be good to go back and clean up this messy situation and possibly rethink how we do pagination to possibly avoid the use of `api-pagination`, `kaminari`, and `RSolr::Client#paginate`.  Also the kaminari implementation I did some years ago is really for ActiveFedora::Base objects so it fetches data from fedora so paginated API requests can't use only solr.