### PR TITLE
Session should already have :user_return_to so shouldn't need :previous_url

### DIFF
--- a/app/views/media_objects/_checkout_authenticate.html.erb
+++ b/app/views/media_objects/_checkout_authenticate.html.erb
@@ -16,7 +16,6 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <div class="log-in-out text-muted header-user">
   <center>
-    <% session[:previous_url] = request.fullpath unless request.xhr? %>
     <%= link_to 'Sign in', main_app.new_user_session_path, :class=> "btn btn-info" %>
   </center>
 </div>

--- a/spec/requests/devise_login.rb
+++ b/spec/requests/devise_login.rb
@@ -29,13 +29,24 @@ describe 'devise login', type: :request do
       expect(response).to redirect_to(root_path)
     end
 
-    context 'when previous_url is in the session' do
+    context 'when user_return_to is in the session' do
       let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'restricted') }
 
       it 'redirects to url' do
         get "/media_objects/#{media_object.id}"
         post '/users/sign_in', params: { user: { login: user.username, password: user.password }, admin: true, email: true }
         expect(response).to redirect_to("/media_objects/#{media_object.id}")
+      end
+
+      context 'when public item is requested first' do
+        let!(:public_media_object) { FactoryBot.create(:published_media_object, :with_master_file, visibility: 'public') }
+
+        it 'redirects to correct media object' do
+          get "/media_objects/#{public_media_object.id}"
+          get "/media_objects/#{media_object.id}"
+          post '/users/sign_in', params: { user: { login: user.username, password: user.password }, admin: true, email: true }
+          expect(response).to redirect_to("/media_objects/#{media_object.id}")
+        end
       end
     end
   end


### PR DESCRIPTION
This view gets rendered whenever ramp gets rendered for a non-logged in user even though it itsn't always displayed.  Since :previous_url is prioritized over :user_return_to this leads to a confused login flow where a user is sent to the last media object show page that rendered ramp instead of a media object page that prompted them to login.  I believe that this line can safely be removed since the page should have already populated :user_return_to.

Steps for testing:
- When not logged in navigate to a public media object show page
- Navigate directly to a private media object by using the browser's address bar
- You should be prompted to login
- Login
- See that you're redirected back to the private media object show page and not the public one

Also need to test:
- When not logged in navigate to a CDL enabled, public media object show page
- Click Sign in button on media placeholder
- You should be promped to login
- Login
- See that you're redirected back to the media object show page