### PR TITLE
Use SpeedyAF to scan collection dropboxes at scale

### DIFF
--- a/app/jobs/batch_scan_job.rb
+++ b/app/jobs/batch_scan_job.rb
@@ -23,7 +23,7 @@ class BatchScanJob < ActiveJob::Base
   # @param [String] the path to the manifest in the form of S3://...
   def perform
     Rails.logger.info "<< Scanning for new batch packages in existing collections >>"
-    Admin::Collection.all.each do |collection|
+    SpeedyAF::Base.where('has_model_ssim:"Admin::Collection"').each do |collection|
       Avalon::Batch::Ingest.new(collection).scan_for_packages
     end
   end


### PR DESCRIPTION
MCO has 800+ collections so loading each one from Fedora takes a while (~4.5m) versus proxies from solr (<0.5s).  This job is scheduled to run every minute so we want it to be fairly fast so catalogers who upload batches don't have to wait 5 minutes to see if they have an error in their manifest or not.  As well as reduce load on Fedora and sidekiq.