### PR TITLE
Replace jQuery in .erb templates with plain JS

### DIFF
--- a/app/javascript/components/tables/hooks/useProgressUpdates.js
+++ b/app/javascript/components/tables/hooks/useProgressUpdates.js
@@ -59,7 +59,7 @@ const useProgressUpdates = ({ currentJobs, onProgressUpdate, progressUrl }) => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content'),
+          'X-CSRF-Token': query('meta[name="csrf-token"]')?.getAttribute('content'),
         },
         body: JSON.stringify({ ids: jobIds })
       });

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -48,31 +48,38 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
 <script>
   function inject_alert(message) {
-    let alertElement = $('#alerts');
+    let alertElement = getById('alerts');
     // Remove alert with previous errors
     if(alertElement) {
       alertElement.remove();
     }
-    $('.page-title').closest('.page-title-wrapper').before(
+    const pageTitle = query('.page-title');
+    const pageTitleWrapper = pageTitle.closest('.page-title-wrapper');
+    pageTitleWrapper.insertAdjacentHTML('beforebegin',
       '<div class="container-fluid" id="alerts"><div class="alert alert-danger"><button type="button" class="btn-close" data-bs-dismiss="alert"></button>' +
       message + '</div></div>');
   }
 
   function resetButton(btnName) {
-    let $btn = $(btnName)
-    const disableWith = $btn[0].dataset['disableWith'];
-    $btn.val(disableWith);
+    let btn = query(btnName);
+    const disableWith = btn.dataset['disableWith'];
+    btn.value = disableWith;
   }
 
-  $('form[data-remote][modal]').on('ajax:success', function(event) {
-    const [data, status, xhr]= event.detail;
+  const remoteForm = query('form[data-remote][modal]');
+
+  remoteForm.addEventListener('ajax:success', function(event) {
+    const [data, status, xhr] = event.detail;
     resetButton('.btn-stateful-loading');
     window.location = '/admin/collections/' + encodeURIComponent(data['id']);
-  }).on('ajax:error',function(event) {
-    const [data, status, xhr]= event.detail;
-    const responseJSON = $.parseJSON(xhr.response);
+  });
+
+  remoteForm.addEventListener('ajax:error', function(event) {
+    const [data, status, xhr] = event.detail;
+    const responseJSON = JSON.parse(xhr.response);
     if (responseJSON.hasOwnProperty('errors')) {
-      $(this).closest('.modal').modal('hide')
+      const modal = this.closest('.modal');
+      toggleModal(modal, false);
       if(responseJSON['errors'].length > 2) {
         // When there are multiple errors
         let markup = responseJSON['errors'][0];

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <% content_for :page_scripts do %>
 <script type="text/javascript">
-  new TomSelect('#target_collection_id', {
+  new TomSelect(getById('target_collection_id'), {
     searchField: ['text'],
     sortField: [
       { field: '$order' },

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -67,7 +67,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div class="row">
         <%= form_for @collection, url: attach_poster_admin_collection_path(@collection.id), html: {method: "post"} do |form| %>
           <%= form.file_field :poster, id: 'poster_input', class: "filedata", style: "height:0px;width:0px;", 'data-testid': "collection-poster-input" %>
-          <input type="button" class="btn btn-primary btn-sm me-2" onclick="$('.filedata').click();" value="<% if @collection.poster.present? %>Change Poster<%else%>Upload Poster<%end%>"
+          <input type="button" class="btn btn-primary btn-sm me-2" onclick="query('.filedata').click();" value="<% if @collection.poster.present? %>Change Poster<%else%>Upload Poster<%end%>"
             <% if cannot?(:edit, @collection) %>disabled<%end%> />
         <% end %>
         <%= form_for @collection, url: remove_poster_admin_collection_path(@collection.id), html: {method: "delete"} do |form| %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -99,24 +99,34 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 <script>
-  $('.select-groups').change(function () {
-    $('input[id^=user_ids_]').prop('checked', $(this).is(':checked')).trigger('change');
-  })
+  query('.select-groups').addEventListener('change', function () {
+    const isChecked = this.checked;
+    queryAll('input[id^=user_ids_]').forEach(function(checkbox) {
+      checkbox.checked = isChecked;
+      checkbox.dispatchEvent(new Event('change'));
+    });
+  });
 
-  $('input[id^=user_ids_]').change(function () {
-    if ($(this).is(':checked')) {
-      enableButtons();
-    } else if ($(':checked').length == 0) {
-      disableButtons();
-    }
-  })
+  queryAll('input[id^=user_ids_]').forEach(function(checkbox) {
+    checkbox.addEventListener('change', function () {
+      if (this.checked) {
+        enableButtons();
+      } else if (queryAll('input[id^=user_ids_]:checked').length === 0) {
+        disableButtons();
+      }
+    });
+  });
 
   function enableButtons() {
-    $('.delete').removeAttr('disabled');
+    queryAll('.delete').forEach(function(button) {
+      button.removeAttribute('disabled');
+    });
   }
 
   function disableButtons() {
-    $('.delete').attr('disabled', 'disabled');
+    queryAll('.delete').forEach(function(button) {
+      button.setAttribute('disabled', 'disabled');
+    });
   }
 </script>
 <% end %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -95,32 +95,40 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 <script>
-  $('.close').click(function () {
-    $(this).parent().remove();
-  })
+  queryAll('.close').forEach(function(closeBtn) {
+    closeBtn.addEventListener('click', function() {
+      this.parentElement.remove();
+    });
+  });
 
-  $('.select-groups').change(function () {
-    $('input[id^=group_ids_]').prop('checked', $(this).is(':checked')).trigger('change');
-  })
+  query('.select-groups').addEventListener('change', function () {
+    const isChecked = this.checked;
+    queryAll('input[id^=group_ids_]').forEach(function(checkbox) {
+      checkbox.checked = isChecked;
+      checkbox.dispatchEvent(new Event('change'));
+    });
+  });
 
-  $('input[id^=group_ids_]').change(function () {
-    if ($(this).is(':checked')) {
-      enableButtons();
-    } else if ($(':checked').length == 0) {
-      disableButtons();
-    }
-  })
+  queryAll('input[id^=group_ids_]').forEach(function(checkbox) {
+    checkbox.addEventListener('change', function () {
+      if (this.checked) {
+        enableButtons();
+      } else if (queryAll('input[id^=group_ids_]:checked').length === 0) {
+        disableButtons();
+      }
+    });
+  });
 
   function enableButtons() {
-    $('#add-ability').removeClass('disabled');
-    $('#remove-ability').removeClass('disabled');
-    $('.delete').removeAttr('disabled');
+    getById('add-ability').classList.remove('disabled');
+    getById('remove-ability').classList.remove('disabled');
+    query('.delete').removeAttribute('disabled');
   }
 
   function disableButtons() {
-    $('#add-ability').addClass('disabled');
-    $('#remove-ability').addClass('disabled');
-    $('.delete').attr('disabled', 'disabled');
+    getById('add-ability').classList.add('disabled');
+    getById('remove-ability').classList.add('disabled');
+    query('.delete').setAttribute('disabled', 'disabled');
   }
 </script>
 <% end %>

--- a/app/views/media_objects/_destroy_checkout.html.erb
+++ b/app/views/media_objects/_destroy_checkout.html.erb
@@ -49,10 +49,11 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-    $(document).ready(function() {
+    document.addEventListener('DOMContentLoaded', function () {
+      let interval = null;
       /* Calculate remaining days and time for the lending perriod */
       function calcRemainingTime() {
-        var dateStr = $('#return-btn').data().checkoutReturntime.replace(/['"]+/g, '');
+        var dateStr = getById('return-btn').dataset.checkoutReturntime.replace(/['"]+/g, '');
         var returnDate = new Date(dateStr);
         var currentDate = new Date();
 
@@ -80,22 +81,22 @@ Unless required by applicable law or agreed to in writing, software distributed
         setTime();
 
         // Check for remaining time on a minute interval
-        var interval = setInterval(setTime, 60000);
-      }, 5000);
+        interval = setInterval(setTime, 60000);
+      }, 1000);
 
       /* Interval update remaining time in the lending period */
       function setTime() {
-        if($('#return-btn').length > 0) {
+        if(getById('return-btn')) {
           let remainingTime = calcRemainingTime();
-          if(remainingTime == 'expired') {
+          if(remainingTime == 'expired' && !interval) {
             clearInterval(interval);
-            $('#check-out-expired').modal('show');
+            toggleModal(getById('check-out-expired'), true);
           } else {
             const { days, hours, minutes } = remainingTime;
             var daysText = `${days}<br />day${days > 1 ? 's': ''}`;
-            $('.days').html(daysText);
+            query('.days').innerHTML = daysText;
             var timeText = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}<br />hh:mm`;
-            $('.time').html(timeText);
+            query('.time').innerHTML = timeText;
           }
         }
       }

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -313,19 +313,19 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-    document.querySelectorAll('.filedata').forEach(fileInput => {
+    queryAll('.filedata').forEach(fileInput => {
       fileInput.addEventListener('change', function(e) {
         e.preventDefault();
         this.closest('form').submit();
       });
     });
 
-    document.querySelectorAll('.master-file-form').forEach(form => {
+    queryAll('.master-file-form').forEach(form => {
       form.addEventListener('ajax:success', (event) => {
-        event.currentTarget.querySelector('.flash-message').innerHTML = "Successfully updated.";
+        query('.flash-message', event.currentTarget).innerHTML = "Successfully updated.";
       });
       form.addEventListener('ajax:error', (event) => {
-        event.currentTarget.querySelector('.flash-message').innerHTML = "Failed to update.";
+        query('.flash-message', event.currentTarget).innerHTML = "Failed to update.";
       });
     });
   </script>

--- a/app/views/media_objects/_intercom_push_form.html.erb
+++ b/app/views/media_objects/_intercom_push_form.html.erb
@@ -48,7 +48,24 @@ Unless required by applicable law or agreed to in writing, software distributed
     </div>
   </div>
   <div class="mb-3">
-    <button class="btn btn-primary" form="intercom_push_form" data-loading-text="<i class='fa fa-spinner fa-spin '></i> Pushing" id="intercom_push_submit_button" onclick="$(this).button('loading')">Push</button>
+    <button class="btn btn-primary" form="intercom_push_form" data-loading-text="<i class='fa fa-spinner fa-spin '></i> Pushing" id="intercom_push_submit_button">Push</button>
     <button data-bs-dismiss="modal" aria-hidden="true" class="btn btn-danger">Cancel</button>
   </div>
 </div>
+
+<% content_for :page_scripts do %>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const pushButton = getById('intercom_push_submit_button');
+    if (pushButton) {
+      pushButton.addEventListener('click', function() {
+        const loadingText = this.dataset.loadingText;
+        if (loadingText) {
+          this.disabled = true;
+          this.innerHTML = loadingText;
+        }
+      });
+    }
+  });
+</script>
+<% end %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -62,7 +62,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <script>
     // When viewing video on smaller devices scroll to page content to fully
     // display the video player
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function () {
       const mediaObjectId = <%= @media_object.id.to_json.html_safe %>;
       const sectionIds = <%= @media_object.section_ids.to_json.html_safe %>;
       const sectionShareInfos = <%= @media_object.section_share_infos.to_json.html_safe %>;
@@ -71,7 +71,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       // Enable action buttons and token refresh after derivative is loaded
       setInterval(initPlayerListeners, 500);
       function initPlayerListeners() {
-        let player = document.getElementById('iiif-media-player');
+        let player = getById('iiif-media-player');
         if (player) {
           addActionButtonListeners(player, mediaObjectId, sectionIds, sectionShareInfos);
           initM3U8Reload(player, mediaObjectId, sectionIds, sectionShareInfos);
@@ -86,9 +86,10 @@ Unless required by applicable law or agreed to in writing, software distributed
           const screenHeight = screen.height;
           const playerHeight = player[0].style.height.replace(/[^-\d\.]/g, '');
           if(screenHeight - playerHeight < 200) {
-            $('html, body').animate({
-                scrollTop: $('#user-util-collapse').offset().top
-            }, 1000);
+            const userUtilCollapse = getById('user-util-collapse');
+            if (userUtilCollapse) {
+              userUtilCollapse.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
           }
           clearInterval(scrollInterval);
         }
@@ -96,7 +97,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
       let timeCheck = setInterval(initTranscriptCheck, 500);
       function initTranscriptCheck() {
-        let player = document.getElementById('iiif-media-player');
+        let player = getById('iiif-media-player');
         if(player) {
           addPlayerEventListeners(player, () => {
             clearInterval(timeCheck);
@@ -118,24 +119,24 @@ Unless required by applicable law or agreed to in writing, software distributed
         Set tabbed nav column height based on the content
       */
       function setColumnHeights() {
-        let activeTab = $('.tab-pane.active.show');
-        let tabsPanel = $('.ramp--tabs-panel');
+        let activeTab = query('.tab-pane.active.show');
+        let tabsPanel = query('.ramp--tabs-panel');
         // When the active tab is transcripts, check the transcript content height to
         // check there is overflowing content to set the column height. This is handled
         // seperately because the height check in the else block doesn't identify this since
         // since this content is set dynamically based on user selection in dropdown menu. 
-        if(activeTab.hasClass('ramp--transcripts_tab')) {
-          let transcriptContent = $('.transcript_content');
-          if(transcriptContent[0].scrollHeight > transcriptContent[0].clientHeight) {
-            activeTab[0].style.height = 'unset';
+        if(activeTab.classList.contains('ramp--transcripts_tab')) {
+          let transcriptContent = query('.transcript_content');
+          if(transcriptContent && transcriptContent.scrollHeight > transcriptContent.clientHeight) {
+            activeTab.style.height = 'unset';
           }
         } else {
           // Compare the active tab's scrollHeight and tab panel's height to identify overflowing content.
           // And set tab height to either 'unset' or 'fit-content' accordingly.
-          if (activeTab[0].scrollHeight > tabsPanel[0].clientHeight) {
-            activeTab[0].style.height = 'unset';
+          if (activeTab.scrollHeight > tabsPanel.clientHeight) {
+            activeTab.style.height = 'unset';
           } else {
-            activeTab[0].style.height = 'fit-content';
+            activeTab.style.height = 'fit-content';
           }
         }
       }
@@ -145,7 +146,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         let transcriptButton = document.evaluate('//button[text()="Transcripts"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
         let transcriptTab = transcriptButton?.parentElement
         let detailTab = document.evaluate('//button[text()="Details"]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-        
+
         if(!transcriptSections.includes(sectionId)) {
           // If transcript tab is the active tab when it is hidden, the tab goes away but the box still displays
           // the missing transcript file message. Force change over to a different tab to avoid this case.

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -136,33 +136,85 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 <script>
+  const extractor = new Xsd2Json('avalon_structure.xsd', {
+    'schemaURI': '/',
+    'rootElement': 'item'
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const structureEditModals = queryAll('.structure_edit.modal');
+    structureEditModals.forEach(function(modalElement) {
+      modalElement.addEventListener('shown.bs.modal', function() {
+        if (query('.xml_editor_container', modalElement)) return;
+
+        const te = query('.original_textarea', modalElement);
+        const modalBody = query('.modal-body', modalElement);
+
+        // TODO: xmlEditor is a jQuery plugin, this call still requires jQuery under the hood
+        $(te).xmlEditor({
+          schema: extractor.getSchema(),
+          floatingMenu: false,
+          confirmExitWhenUnsubmitted: false,
+          loadSchemaAsychronously: false,
+          xmlEditorLabel: 'Graphical',
+          textEditorLabel: 'Raw XML',
+          containerElement: {
+            element: $(modalBody),
+            fixedHeight: true,
+          },
+          submitButtonConfigs: [{
+            url: modalElement.dataset.submit_url,
+            responseHandler: attach_structure_response,
+            label: 'Save and Exit',
+            cssClass: 'btn btn-primary section_edit_submit',
+          }],
+          defaultView: 'text',
+        });
+      });
+    });
+
+    const filedataElements = queryAll('.filedata');
+    filedataElements.forEach(function(filedata) {
+      filedata.addEventListener('change', function() {
+        this.closest('form').submit();
+      });
+    });
+  });
+
   function htmlDecode(value) {
-    return $('<div/>').html(value).text();
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = value;
+    return textarea.value;
   }
 
   function parse_structure(xml, index) {
-    var $xml = $($.parseXML(xml));
-    var $item = $xml.find("Item");
-    if ($item.length) {
-      if ($item.children().length) return "<span>" + $item.attr('label') + "</span><ul>" + parse_section($item.first(),
-        index)[0] + "</ul>";
-      else return "<span>" + (index + 1) + ". " + $item.attr('label') + "</span>";
-    } else return "";
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xml, 'text/xml');
+    const item = xmlDoc.querySelector('Item');
+    if (item) {
+      if (item.children.length) {
+        return `<span>${item.getAttribute('label')}</span><ul>${parse_section(item, index)[0]}</ul>`;
+      } else {
+        return `<span>${index + 1}. ${item.getAttribute('label')}</span>`;
+      }
+    } else {
+      return "";
+    }
   }
 
   function parse_section(node, index) {
-    var contents = '';
-    var tracknumber;
-    var nodecontents;
-    if (node.children().length) {
+    let contents = '';
+    let tracknumber;
+    let nodecontents;
+    if (node.children.length) {
       tracknumber = 0;
-      $.each(node.children(), function (index, node) {
-        nodecontents = parse_node(node, tracknumber);
+      Array.from(node.children).forEach(function (childNode) {
+        nodecontents = parse_node(childNode, tracknumber);
         contents += nodecontents[0];
         tracknumber = nodecontents[1];
       });
     } else {
-      nodecontents = parse_node(node.first, index);
+      nodecontents = parse_node(node, index);
       contents = nodecontents[0];
       tracknumber = nodecontents[1];
     }
@@ -171,76 +223,45 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   function parse_node(node, tracknumber) {
     if (node.nodeName.toUpperCase() == "DIV") {
-      var contents = ''
-      $.each($(node).children(), function (index, node) {
-        var nodecontents = parse_node(node, tracknumber);
+      let contents = '';
+      Array.from(node.children).forEach(function (childNode) {
+        const nodecontents = parse_node(childNode, tracknumber);
         contents += nodecontents[0];
         tracknumber = nodecontents[1];
       });
-      return ["<li>" + $(node).attr('label') + "</li><li><ul>" + contents + "</ul></li>", tracknumber];
-    } else if ($.inArray(node.nodeName.toUpperCase(), ['SPAN', 'ITEM']) != -1) {
+      return [`<li>${node.getAttribute('label')}</li><li><ul>${contents}</ul></li>`, tracknumber];
+    } else if (['SPAN', 'ITEM'].includes(node.nodeName.toUpperCase())) {
       tracknumber += 1;
-      return ["<li class='stream-li'>" + tracknumber + ". " + $(node).attr('label') + "</li>", tracknumber];
+      return [`<li class='stream-li'>${tracknumber}.${node.getAttribute('label')}</li>`, tracknumber];
     } else {
       return ["", tracknumber];
     }
   }
 
-  $('.filedata').change(function () {
-    $(this).closest('form').submit();
-  });
-
   function populate_structure_preview(index) {
-    $xmltextarea = $('#advanced_edit_structure_' + index).find('textarea.original_textarea');
-    $('#structure_' + index).find('.structure_view').html(parse_structure(htmlDecode($xmltextarea.html()), index));
+    const modal = getById('advanced_edit_structure_' + index);
+    const xmltextarea = query('textarea.original_textarea', modal);
+    const structureView = query('.structure_view', getById('structure_' + index));
+    structureView.innerHTML = parse_structure(htmlDecode(xmltextarea.innerHTML), index);
   }
 
   function attach_structure_response(r) {
     if (r['flash'] && r['flash'].length) {
-      msg = ''
-      for (var i = 0; i < r['flash'].length; i++) {
-        for (var j = 0; j < r['flash'][i][1].length; j++) {
+      let msg = '';
+      for (let i = 0; i < r['flash'].length; i++) {
+        for (let j = 0; j < r['flash'][i][1].length; j++) {
           msg += r['flash'][i][1][j] + '<br/>';
         }
       }
       return msg;
     } else {
-      modal = $(`.structure_edit[data-submit_url='${$(this)[0].url}']`)
-      modal.find('textarea.original_textarea').html(r['structure']);
-      section_index = parseInt(modal.attr('id').split('_').pop());
+      const modal = query(`.structure_edit[data-submit_url='${this.url}']`);
+      const textarea = query('textarea.original_textarea', modal);
+      textarea.innerHTML = r['structure'];
+      const section_index = parseInt(modal.id.split('_').pop());
       populate_structure_preview(section_index);
-      modal.modal('hide');
+      toggleModal(modal, false);
     }
   }
-
-  var extractor = new Xsd2Json('avalon_structure.xsd', {
-    'schemaURI': '/',
-    'rootElement': 'item'
-  });
-  $('.structure_edit.modal').on('shown.bs.modal', function () {
-    modal = $(this);
-    if (modal.find('.xml_editor_container').length > 0) return;
-
-    te = modal.find('.original_textarea').first();
-    te.xmlEditor({
-      schema: extractor.getSchema(),
-      floatingMenu: false,
-      confirmExitWhenUnsubmitted: false,
-      loadSchemaAsychronously: false,
-      xmlEditorLabel: 'Graphical',
-      textEditorLabel: 'Raw XML',
-      containerElement: {
-        element: modal.find('.modal-body').first(),
-        fixedHeight: true,
-      },
-      submitButtonConfigs: [{
-        url: $(this).data('submit_url'),
-        responseHandler: attach_structure_response,
-        label: 'Save and Exit',
-        cssClass: 'btn btn-primary section_edit_submit',
-      }],
-      defaultView: 'text',
-    });
-  });
 </script>
 <% end %>

--- a/app/views/media_objects/_supplemental_files_upload.html.erb
+++ b/app/views/media_objects/_supplemental_files_upload.html.erb
@@ -19,7 +19,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= form_for :supplemental_file, :url => object_supplemental_files_path(section), html: { method: "post" } do |form| %>
     <%= form.hidden_field(:tags, multiple: true, value: tag) if tag.present? %>
     <%= form.file_field :file, class: "filedata", data: { testid: "media-object-upload-button-#{tag.presence || 'supplemental'}" } %>
-    <input type="button" class="btn btn-primary btn-sm" onclick="document.querySelector('#<%= file_section %> .filedata').click();"
+    <input type="button" class="btn btn-primary btn-sm" onclick="query('#<%= file_section %> .filedata').click();"
       value="Upload" />
   <% end %>
   <% if file_section.include?("caption") && !section.finished_processing? %>

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -62,7 +62,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 <script>
   document.cookie = 'test_cookie=true'
   if(!document.cookie.match(/^(.*;)?\s*test_cookie\s*=\s*[^;]+(.*)?$/)){
-    $('#cookieless').css("display", "block")
+    const cookielessAlert = getById('cookieless');
+    if (cookielessAlert) {
+      cookielessAlert.style.display = 'block';
+    }
   } else{
     document.cookie = 'test_cookie=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
   }

--- a/app/views/playlists/_action_buttons.html.erb
+++ b/app/views/playlists/_action_buttons.html.erb
@@ -39,7 +39,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 <script>
-  $(document).ready(function () {
+  document.addEventListener('DOMContentLoaded', function() {
     window.add_copy_playlist_button_event()
   });
 </script>

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -179,105 +179,175 @@ Unless required by applicable law or agreed to in writing, software distributed
   <script>
 
     function toggleState(ele, text, state) {
-      ele.html(text);
-      ele.prop('disabled', state);
+      ele.innerHTML = text;
+      ele.setAttribute('disabled', state);
     }
     
-    // Handle move selected items to new playlist
-    $('.move_to_playlist, .copy_to_playlist').click(function(event) {
-      event.preventDefault();
-      $('#new_playlist_id').val($(this).data('id'));
-      $('#action_type').val(event.target.getAttribute('class'));
-      $('#'+$(this).attr('form')).submit();
-    });
-
-    // Handle playlist edit cancel
-    $('#playlist_edit_cancel').click(function(event) {
-      $('#playlist_form #playlist_title').val('<%= j @playlist.title %>');
-      $('#playlist_form #playlist_comment').val('<%= j @playlist.comment %>');
-
-      <% if @playlist.visibility==Playlist::PRIVATE %>
-        $('#playlist_form #playlist_visibility_private').prop('checked', true);
-      <% elsif @playlist.visibility==Playlist::PUBLIC %>
-        $('#playlist_form #playlist_visibility_public').prop('checked', true);
-      <% else %>
-        $('#playlist_form #playlist_visibility_private-with-token').prop('checked', true);
-      <% end %>
-    });
-
-    // Handle select all checkbox (enable/disable move and delete buttons)
-    $('#select_all').click(function(event) {
-      $('input:checkbox').prop('checked', $(this).prop('checked'))
-      $('#edit_playlist_<%= @playlist.id %> :submit').prop('disabled', !$(this).prop('checked') );
-      $('.copy_to, .move_to').prop('disabled', !$(this).prop('checked') )
-    });
-
-    // Handle selection of playlist item (enable/disable move and delete buttons)
-    $('.playlist_item_select').click(function(event) {
-      $('#edit_playlist_<%= @playlist.id %> :submit').prop('disabled',  $( ".playlist_item_select:checked" ).length < 1  );
-      $('.copy_to, .move_to').prop('disabled', $( ".playlist_item_select:checked" ).length < 1 );
-      $('#select_all').prop('checked', $( ".playlist_item_select:checked" ).length == <%= @playlist.items.length %> );
-    });
-
-    // Handle playlist item edit form submission
-    $('.playlist_item_form_submit').click(function(event) {
-      event.preventDefault();
-      var $button = $(this);
-      toggleState($button, 'Saving...', true);
-      var $form = $(this).closest('form');
-      var id = $(this).data('id');
-      return $.ajax({
-        url: '/playlist_items/' + id + '.json',
-        type: 'PATCH',
-        data: {
-          playlist_id: $('#playlist_id').val(),
-          playlist_item: {
-            title: $('#avalon_clip_title_'+id).val(),
-            comment: $('#avalon_clip_comment_'+id).val(),
-            start_time: $('#avalon_clip_start_time_'+id).val(),
-            end_time: $('#avalon_clip_end_time_'+id).val(),
-          }
-        },
-        success: function(response) {
-          // alert success
-          var alert = "<div class='alert alert-success' style='padding:0 10px; margin-bottom: 0;'>";
-          alert += "<button type='button' class='btn-close' data-bs-dismiss='alert'></button>";
-          alert += "<span>"+response.message+"</span></div>";
-	        $('#playlist_item_edit_alert_'+id).html(alert);
-          // update original values with those newly saved in case of future cancel
-          $form.find('.title_original').data('value',$('#avalon_clip_title_'+id).val());
-          $form.find('.comment_original').data('value',$('#avalon_clip_comment_'+id).val());
-          $form.find('.start_time_original').data('value',$('#avalon_clip_start_time_'+id).val());
-          $form.find('.end_time_original').data('value',$('#avalon_clip_end_time_'+id).val());
-          $('#playlist_item_title_label_'+id).html($('#avalon_clip_title_'+id).val());
-          setTimeout(function() {
-            toggleState($button, 'Save Item', false)
-          }, 500);
-        },
-        error: function(response) {
-          // alert failure
-          var alert = "<div class='alert alert-danger' style='padding:0 10px; margin-bottom: 0;'>";
-          alert += "<button type='button' class='btn-close' data-bs-dismiss='alert'></button>";
-          alert += "<span>"+response.responseJSON.message+"</span></div>";
-	        $('#playlist_item_edit_alert_'+id).html(alert);
-          setTimeout(function() {
-            toggleState($button, 'Save Item', false)
-          }, 500);
-        }
+    document.addEventListener('DOMContentLoaded', function() {
+      // Handle move selected items to new playlist
+      const moveAndCopyLinks = queryAll('.move_to_playlist, .copy_to_playlist');
+      moveAndCopyLinks.forEach(function(link) {
+        link.addEventListener('click', function(event) {
+          event.preventDefault();
+          const newPlaylistIdField = getById('new_playlist_id');
+          const actionTypeField = getById('action_type');
+          newPlaylistIdField.value = this.dataset.id;
+          actionTypeField.value = event.target.getAttribute('class');
+          const formId = this.getAttribute('form');
+          getById(formId).submit();
+        });
       });
-    });
 
-    // Cancel playlist item editing
-    $('.playlist_item_edit_cancel').click(function(event){
-      var $form = $(this).closest('form');
-      var id = $(this).data('id');
-      // reset form to original values
-      $('#avalon_clip_title_'+id).val($form.find('.title_original').data('value'));
-      $('#avalon_clip_comment_'+id).val($form.find('.comment_original').data('value'));
-      $('#avalon_clip_start_time_'+id).val($form.find('.start_time_original').data('value'));
-      $('#avalon_clip_end_time_'+id).val($form.find('.end_time_original').data('value'));
-      $('#playlist_item_edit_alert_'+id).html('');
-      $('#'+$(this).data('target')).removeClass('show');
+      // Handle playlist edit cancel
+      const editCancelButton = getById('playlist_edit_cancel');
+      if (editCancelButton) {
+        editCancelButton.addEventListener('click', function(e) {
+          const playlistForm = getById('playlist_form');
+          const playlistTitle = query('#playlist_title', playlistForm);
+          playlistTitle.value = '<%= j @playlist.title %>';
+          const playlistComment = query('#playlist_comment', playlistForm);
+          playlistComment.value = '<%= j @playlist.comment %>';
+
+          <% if @playlist.visibility==Playlist::PRIVATE %>
+            query('#playlist_visibility_private', playlistForm).checked = true;
+          <% elsif @playlist.visibility==Playlist::PUBLIC %>
+            query('#playlist_visibility_public', playlistForm).checked = true;
+          <% else %>
+            query('#playlist_visibility_private-with-token', playlistForm).checked = true;
+          <% end %>
+        });
+      }
+
+      // Handle select all checkbox (enable/disable move and delete buttons)
+      const selectAllCheckbox = getById('select_all');
+      if (selectAllCheckbox) {
+        selectAllCheckbox.addEventListener('click', function(event) {
+          const isChecked = this.checked;
+          const allCheckboxes = queryAll('input[type="checkbox"]');
+          allCheckboxes.forEach(checkbox => checkbox.checked = isChecked);
+
+          const editPlaylistForm = getById('edit_playlist_<%= @playlist.id %>');
+          const submitButtons = queryAll('input[type="submit"], button[type="submit"]', editPlaylistForm);
+          submitButtons.forEach(btn => btn.disabled = !isChecked);
+
+          const moveAndCopyButtons = queryAll('.copy_to, .move_to');
+          moveAndCopyButtons.forEach(btn => btn.disabled = !isChecked);
+        });
+      }
+
+      // Handle selection of playlist item (enable/disable move and delete buttons)
+      const playlistItemCheckboxes = queryAll('.playlist_item_select');
+      playlistItemCheckboxes.forEach(function(checkbox) {
+        checkbox.addEventListener('click', function(event) {
+          const checkedItems = queryAll('.playlist_item_select:checked');
+          const hasCheckedItems = checkedItems.length > 0;
+
+          const editPlaylistForm = getById('edit_playlist_<%= @playlist.id %>');
+          const submitButtons = queryAll('input[type="submit"], button[type="submit"]', editPlaylistForm);
+          submitButtons.forEach(btn => btn.disabled = !hasCheckedItems);
+
+          const moveAndCopyButtons = queryAll('.copy_to, .move_to');
+          moveAndCopyButtons.forEach(btn => btn.disabled = !hasCheckedItems);
+
+          const selectAll = getById('select_all');
+          if (selectAll) {
+            selectAll.checked = checkedItems.length === <%= @playlist.items.length %>;
+          }
+        });
+      });
+
+      // Handle playlist item edit form submission
+      const playlistItemFormSubmitButtons = queryAll('.playlist_item_form_submit');
+      playlistItemFormSubmitButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+          event.preventDefault();
+          toggleState(button, 'Saving...', true);
+          const form = this.closest('form');
+          const id = this.dataset.id;
+
+          const playlistIdField = getById('playlist_id');
+          const requestData = {
+            playlist_id: playlistIdField.value,
+            playlist_item: {
+              title: getById('avalon_clip_title_' + id).value,
+              comment: getById('avalon_clip_comment_' + id).value,
+              start_time: getById('avalon_clip_start_time_' + id).value,
+              end_time: getById('avalon_clip_end_time_' + id).value,
+            }
+          };
+
+          fetch('/playlist_items/' + id + '.json', {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRF-Token': query('meta[name="csrf-token"]').content
+            },
+            body: JSON.stringify(requestData)
+          })
+          .then(response => response.json())
+          .then(function(response) {
+            // alert success
+            let alert = "<div class='alert alert-success' style='padding:0 10px; margin-bottom: 0;'>";
+            alert += "<button type='button' class='btn-close' data-bs-dismiss='alert'></button>";
+            alert += "<span>" + response.message + "</span></div>";
+            getById('playlist_item_edit_alert_' + id).innerHTML = alert;
+
+            // update original values with those newly saved in case of future cancel
+            const titleValue = getById('avalon_clip_title_' + id).value;
+            const commentValue = getById('avalon_clip_comment_' + id).value;
+            const startTimeValue = getById('avalon_clip_start_time_' + id).value;
+            const endTimeValue = getById('avalon_clip_end_time_' + id).value;
+
+            query('.title_original', form).dataset.value = titleValue;
+            query('.comment_original', form).dataset.value = commentValue;
+            query('.start_time_original', form).dataset.value = startTimeValue;
+            query('.end_time_original', form).dataset.value = endTimeValue;
+
+            getById('playlist_item_title_label_' + id).innerHTML = titleValue;
+
+            setTimeout(function() {
+              toggleState(button, 'Save Item', false);
+            }, 500);
+          })
+          .catch(function(error) {
+            // alert failure
+            let alert = "<div class='alert alert-danger' style='padding:0 10px; margin-bottom: 0;'>";
+            alert += "<button type='button' class='btn-close' data-bs-dismiss='alert'></button>";
+            alert += "<span>" + (error.message || 'An error occurred') + "</span></div>";
+            getById('playlist_item_edit_alert_' + id).innerHTML = alert;
+
+            setTimeout(function() {
+              toggleState(button, 'Save Item', false);
+            }, 500);
+          });
+        });
+      });
+
+      // Cancel playlist item editing
+      const playlistItemEditCancelButtons = queryAll('.playlist_item_edit_cancel');
+      playlistItemEditCancelButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+          const form = this.closest('form');
+          const id = this.dataset.id;
+
+          // reset form to original values
+          const titleOriginal = query('.title_original', form);
+          const commentOriginal = query('.comment_original', form);
+          const startTimeOriginal = query('.start_time_original', form);
+          const endTimeOriginal = query('.end_time_original', form);
+
+          getById('avalon_clip_title_' + id).value = titleOriginal.dataset.value;
+          getById('avalon_clip_comment_' + id).value = commentOriginal.dataset.value;
+          getById('avalon_clip_start_time_' + id).value = startTimeOriginal.dataset.value;
+          getById('avalon_clip_end_time_' + id).value = endTimeOriginal.dataset.value;
+          getById('playlist_item_edit_alert_' + id).innerHTML = '';
+
+          const targetElement = getById(this.dataset.target);
+          if (targetElement) {
+            targetElement.classList.remove('show');
+          }
+        });
+      });
     });
   </script>
 

--- a/app/views/playlists/_share.html.erb
+++ b/app/views/playlists/_share.html.erb
@@ -26,21 +26,43 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
 
 <script>
-  $(document).ready(function() {
+  document.addEventListener('DOMContentLoaded', function() {
     setInterval(shareResourceListener, 500);
 
     function shareResourceListener() {
-      if(!$('nav.share-tabs').first().hasClass('active')) {
-        $('nav.share-tabs').first().toggleClass('active');
-        $('.share-tabs a').first().attr('aria-selected', true);
-        $('#share-list .tab-content .tab-pane').first().toggleClass('active');
+      const firstShareTab = query('nav.share-tabs');
+      if (firstShareTab && !firstShareTab.classList.contains('active')) {
+        firstShareTab.classList.add('active');
+
+        const firstTabLink = query('.share-tabs a');
+        if (firstTabLink) {
+          firstTabLink.setAttribute('aria-selected', 'true');
+        }
+
+        const firstTabPane = query('#share-list .tab-content .tab-pane');
+        if (firstTabPane) {
+          firstTabPane.classList.add('active');
+        }
       }
 
-      $('.share-tabs a').click(function (e) {
-        e.preventDefault();
-        $(this).tab('show');
-        $('.share-tabs a').attr('aria-selected', false);
-        $(this).attr('aria-selected', true);
+      const shareTabLinks = queryAll('.share-tabs a');
+      shareTabLinks.forEach(function(link) {
+        // Remove existing listeners by cloning (prevents duplicate listeners)
+        const newLink = link.cloneNode(true);
+        link.parentNode.replaceChild(newLink, link);
+
+        newLink.addEventListener('click', function(e) {
+          e.preventDefault();
+
+          // Show the tab using Bootstrap's Tab API
+          const tab = new bootstrap.Tab(this);
+          tab.show();
+
+          // Update aria-selected attributes
+          const allTabLinks = queryAll('.share-tabs a');
+          allTabLinks.forEach(tabLink => tabLink.setAttribute('aria-selected', 'false'));
+          this.setAttribute('aria-selected', 'true');
+        });
       });
     }
   })

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -66,11 +66,12 @@ Unless required by applicable law or agreed to in writing, software distributed
       </dd>
       <dt class="col-sm-2"><%= t("playlist.tags.label") %>:</dt>
       <dd class="col-sm-10">
-        <% if @playlist.tags.empty? %>
-        <span class="info-text-gray">No tags</span>
-        <% end %>
-        <% @playlist.tags.each do |tag| %>
-        <span class="btn btn-sm btn-info"><%=tag%></span>
+        <% if @playlist.tags.empty? || @playlist.tags.is_a?(String) %>
+          <span class="info-text-gray">No tags</span>
+        <% else %>
+          <% @playlist.tags.each do |tag| %>
+            <span class="btn btn-sm btn-info"><%=tag%></span>
+          <% end %>
         <% end %>
       </dd>
     </dl>
@@ -83,45 +84,46 @@ Unless required by applicable law or agreed to in writing, software distributed
       target.setContent();
     }
 
-    if (!!document.querySelector('#playlist-share-btn')) {
-      var playlistShareBtn = new bootstrap.Popover(document.querySelector("#playlist-share-btn"), {
+    const playlistShareBtnElement = getById('playlist-share-btn');
+    if (playlistShareBtnElement) {
+      const playlistShareBtn = new bootstrap.Popover(getById("playlist-share-btn"), {
         trigger: 'hover',
         placement: 'top',
         content: 'Copy share link'
       });
+
+      playlistShareBtnElement.addEventListener('click', function(event) {
+        const copytarget = getById('playlist-share-link');
+
+        // select text
+        copytarget.select();
+        try {
+          // copy text
+          document.execCommand('copy');
+          copytarget.blur();
+          setPopoverContent(playlistShareBtn, "Copied to clipboard");
+        } catch (err) {
+          setPopoverContent(playlistShareBtn, "Please press Ctrl/Cmd+C to copy");
+        }
+        setTimeout(function () {
+          playlistShareBtn.hide();
+          setPopoverContent(playlistShareBtn, "Copy share link");
+        }, 3000);
+      });
     }
 
-    $('#playlist-share-btn').click(function (event) {
-      var copytarget = $('#playlist-share-link');
-
-      // select text
-      copytarget.select();
-      try {
-        // copy text
-        document.execCommand('copy');
-        copytarget.blur();
-        setPopoverContent(playlistShareBtn, "Copied to clipboard");
-      } catch (err) {
-        setPopoverContent(playlistShareBtn, "Please press Ctrl/Cmd+C to copy");
-      }
-      setTimeout(function () {
-        playlistShareBtn.hide();
-        setPopoverContent(playlistShareBtn, "Copy share link");
-      }, 3000);
-    });
-
-    var popover_content = '<p>If you get a new link, the previous link will stop working.<p>' +
+    const popover_content = '<p>If you get a new link, the previous link will stop working.<p>' +
       '<div>' +
       '<button type="submit" onclick="new_link_confirm()" class="btn btn-danger btn-confirm" style="margin-right:5px;">Yes</button>' +
       '<button type="submit" onclick="new_link_cancel()" class="btn btn-primary btn-confirm">Cancel</button>' +
       '</div>'
-    var popover_template = '<div class="popover" role="tooltip" style="width: 12em;">' +
+    const popover_template = '<div class="popover" role="tooltip" style="width: 15em;">' +
       '<div class="arrow"></div>' +
       '<h3 class="popover-header"></h3>' +
       '<div class="popover-body"></div>' +
       '</div>'
 
-    var getNewLink = new bootstrap.Popover('#get-new-link', {
+    const getNewLink = new bootstrap.Popover('#get-new-link', {
       trigger: 'click',
       html: true,
       sanitize: false,
@@ -131,20 +133,28 @@ Unless required by applicable law or agreed to in writing, software distributed
       content: popover_content
     });
 
-    var new_link_cancel = function (event) {
+    const new_link_cancel = function (event) {
       getNewLink.hide();
     }
 
-    var new_link_confirm = function (event) {
-      $.ajax({
-        type: "PATCH",
-        url: '/playlists/' + $('#get-new-link').data().playlistId + '/regenerate_access_token',
-        success: function (data, status) {
-          $('#playlist-share-link').attr('value', data.access_token_url)
-        },
-        complete: function () {
-          getNewLink.hide()
+    const new_link_confirm = function (event) {
+      const getNewLinkButton = getById('get-new-link');
+      const playlistId = getNewLinkButton.dataset.playlistId;
+
+      fetch('/playlists/' + playlistId + '/regenerate_access_token', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': query('meta[name="csrf-token"]').content
         }
+      })
+      .then(response => response.json())
+      .then(function(data) {
+        const playlistShareLink = getById('playlist-share-link');
+        playlistShareLink.value = data.access_token_url;
+      })
+      .finally(function() {
+        getNewLink.hide();
       });
     }
   </script>

--- a/app/views/playlists/_tag_form.html.erb
+++ b/app/views/playlists/_tag_form.html.erb
@@ -26,7 +26,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      const tagSelect = new TomSelect('#tag-select', {
+      const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],
         closeAfterSelect: true,
         create: true,

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -32,7 +32,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <%= form_tag(import_variations_playlist_playlists_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
                   <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
                   <input type="button" class="btn btn-primary" id="variations_import"
-                    onclick="$(this).closest('form').find('.filedata').click();" value="Import Variations Playlist" />
+                    onclick="this.closest('form').querySelector('.filedata').click();" value="Import Variations Playlist" />
                 <% end %>
               <% end %>
             </div>
@@ -56,8 +56,13 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-    $('.filedata').change(function () {
-      $(this).closest('form').submit();
+    document.addEventListener('DOMContentLoaded', function() {
+      const filedataElements = queryAll('.filedata');
+      filedataElements.forEach(function(filedata) {
+        filedata.addEventListener('change', function() {
+          this.closest('form').submit();
+        });
+      });
     });
   </script>
 <% end %>

--- a/app/views/timelines/_show_timeline_details.html.erb
+++ b/app/views/timelines/_show_timeline_details.html.erb
@@ -35,92 +35,106 @@ Unless required by applicable law or agreed to in writing, software distributed
       target.setContent();
     }
 
-    if (!!document.querySelector('#timeline-share-btn')) {
-      var startingVisiblity = "<%= @timeline.visibility %>";
-      $('input[type=radio][name="timeline[visibility]"]').change( function (event) {
-        if (event.target.value == 'private-with-token' && startingVisiblity == 'private-with-token') {
-          $('#timeline_token_row').collapse('show')
-        } else {
-          $('#timeline_token_row').collapse('hide')
-        }
-      })
-
-      if (!!document.querySelector('#timeline-share-btn')) {
-        var timelineShareBtn = new bootstrap.Popover('#timeline-share-btn', {
-          trigger: 'hover',
-          placement: 'top',
-          content: 'Copy share link'
-        });
-      }
-
-      if (!!document.querySelector('#timeline-lti-share-btn')) {
-        var timelineLtiShareBtn = new bootstrap.Popover('#timeline-lti-share-btn', {
-          trigger: 'hover',
-          placement: 'top',
-          content: 'Copy share link'
-        });
-      }
-
-      $('#timeline-share-btn, #timeline-lti-share-btn').click( function (event) {
-        var targetid = event.target.id
-        var copytarget = $('#'+targetid.replace('-btn','-link'));
-        var copyresult = $('#'+targetid)
-        var copypopover = bootstrap.Popover.getInstance(copyresult);
-
-        // select text
-        copytarget.select();
-        try {
-          // copy text
-          document.execCommand('copy');
-          copytarget.blur();
-          setPopoverContent(copypopover, "Copied to clipboard");
-        }
-        catch (err) {
-          setPopoverContent(copypopover, "Please press Ctrl/Cmd+C to copy");
-        }
-        setTimeout(function() {
-          copypopover.hide();
-          setPopoverContent(copypopover, "Copy share link");
-        }, 3000);
-      });
-
-      var popover_content = '<p>If you get a new link, the previous link will stop working.<p>' +
-        '<div>' +
-        '<button type="submit" onclick="new_link_confirm()" class="btn btn-danger btn-confirm" style="margin-right:5px;">Yes</button>' +
-        '<button type="submit" onclick="new_link_cancel()" class="btn btn-primary btn-confirm">Cancel</button>' +
-        '</div>'
-      var popover_template = '<div class="popover" role="tooltip" style="width: 12em;">' +
-        '<div class="arrow"></div>' +
-        '<h3 class="popover-header"></h3>' +
-        '<div class="popover-body"></div>' +
-        '</div>'
-
-      var getNewLink = new bootstrap.Popover('#get-new-link', {
-        trigger: 'click',
-        html: true,
-        sanitize: false,
-        placement: 'top',
-        title: 'Get a new link?',
-        template: popover_template,
-        content: popover_content
-      });
-
-      var new_link_cancel = function (event) {
-        getNewLink.hide();
-      }
-
-      var new_link_confirm = function (event) {
-        $.ajax({
-          type: "PATCH",
-          url: '/timelines/' + $('#get-new-link').data().timelineId + '/regenerate_access_token',
-          success: function (data, status) {
-            $('#timeline-share-link').attr('value', data.access_token_url)
-          },
-          complete: function () {
-              getNewLink.hide();
+    const timelineShareBtnElement = getById('timeline-share-btn');
+    if (timelineShareBtnElement) {
+      let startingVisiblity = "<%= @timeline.visibility %>";
+      let visibilityRadioSelect = query('input[type=radio][name="timeline[visibility]"]')
+      if (visibilityRadioSelect) {
+        visibilityRadioSelect.addEventListener('change', function (event) {
+          if (event.target.value == 'private-with-token' && startingVisiblity == 'private-with-token') {
+            showOrCollapse(getById('timeline_token_row'), true);
+          } else {
+            showOrCollapse(getById('timeline_token_row'), false);
           }
         });
       }
+
+      new bootstrap.Popover(getById('timeline-share-btn'), {
+        trigger: 'hover',
+        placement: 'top',
+        content: 'Copy share link'
+      });
+
+      const timelineLTIShareBtnElement = getById('timeline-lti-share-btn');
+      if (timelineLTIShareBtnElement) {
+        new bootstrap.Popover(getById('timeline-lti-share-btn'), {
+          trigger: 'hover',
+          placement: 'top',
+          content: 'Copy share link'
+        });
+      }
+
+      const timelineShareButtons = queryAll('#timeline-share-btn, #timeline-lti-share-btn');
+      timelineShareButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+          const targetid = event.target.id;
+          const copytarget = getById(targetid.replace('-btn', '-link'));
+          const copyresult = getById(targetid);
+          const copypopover = bootstrap.Popover.getInstance(copyresult);
+
+          // select text
+          copytarget.select();
+          try {
+            // copy text
+            document.execCommand('copy');
+            copytarget.blur();
+            setPopoverContent(copypopover, "Copied to clipboard");
+          }
+          catch (err) {
+            setPopoverContent(copypopover, "Please press Ctrl/Cmd+C to copy");
+          }
+          setTimeout(function() {
+            copypopover.hide();
+            setPopoverContent(copypopover, "Copy share link");
+          }, 3000);
+        });
+      });
+    }
+
+    const popover_content = '<p>If you get a new link, the previous link will stop working.<p>' +
+      '<div>' +
+      '<button type="submit" onclick="new_link_confirm()" class="btn btn-danger btn-confirm" style="margin-right:5px;">Yes</button>' +
+      '<button type="submit" onclick="new_link_cancel()" class="btn btn-primary btn-confirm">Cancel</button>' +
+      '</div>'
+    const popover_template = '<div class="popover" role="tooltip" style="width: 15em;">' +
+      '<div class="arrow"></div>' +
+      '<h3 class="popover-header"></h3>' +
+      '<div class="popover-body"></div>' +
+      '</div>'
+
+    const getNewLink = new bootstrap.Popover(getById('get-new-link'), {
+      trigger: 'click',
+      html: true,
+      sanitize: false,
+      placement: 'top',
+      title: 'Get a new link?',
+      template: popover_template,
+      content: popover_content
+    });
+
+    const new_link_cancel = function (event) {
+      getNewLink.hide();
+    }
+
+    const new_link_confirm = function (event) {
+      const getNewLinkButton = getById('get-new-link');
+      const timelineId = getNewLinkButton.dataset.timelineId;
+
+      fetch('/timelines/' + timelineId + '/regenerate_access_token', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': query('meta[name="csrf-token"]').content
+        }
+      })
+      .then(response => response.json())
+      .then(function(data) {
+        const timelineShareLink = getById('timeline-share-link');
+        timelineShareLink.value = data.access_token_url;
+      })
+      .finally(function() {
+        getNewLink.hide();
+      });
     }
   </script>
 <% end %>

--- a/app/views/timelines/_tag_form.html.erb
+++ b/app/views/timelines/_tag_form.html.erb
@@ -26,7 +26,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% content_for :page_scripts do %>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      const tagSelect = new TomSelect('#tag-select', {
+      const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],
         closeAfterSelect: true,
         create: true,

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -30,7 +30,7 @@ Unless required by applicable law or agreed to in writing, software distributed
               <% if Settings['variations'].present? %>
                 <%= form_tag(import_variations_timeline_timelines_path, method:"post", enctype:"multipart/form-data", style:"display:inline") do %>
                   <input type="file" name="Filedata" class="filedata" style="visibility:hidden; display:inline; width:0;" />
-                  <input type="button" class="btn btn-primary" id="variations_import" onclick="$(this).closest('form').find('.filedata').click();" value="Import Variations Timeline" />
+                  <input type="button" class="btn btn-primary" id="variations_import" onclick="this.closest('form').querySelector('.filedata').click();" value="Import Variations Timeline" />
                 <% end %>
               <% end %>
             </div>
@@ -54,8 +54,13 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-    $( '.filedata' ).change(function() {
-      $(this).closest('form').submit();
+    document.addEventListener('DOMContentLoaded', function() {
+      const filedataElements = queryAll('.filedata');
+      filedataElements.forEach(function(filedata) {
+        filedata.addEventListener('change', function() {
+          this.closest('form').submit();
+        });
+      });
     });
   </script>
 <% end %>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -19,9 +19,12 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
   <script>
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function() {
       // Push footer to the bottom of the page content
-      $('#footer').css('top', $(this).height() + 5);
+      const footer = getById('footer');
+      if (footer) {
+        footer.style.top = (document.documentElement.scrollHeight + 5) + 'px';
+      }
     });
   </script>
 <% end %>


### PR DESCRIPTION
Related issue: #6564 

This PR removes the jQuery code in the scripts in our `.erb` templates. This is the last portion of `jQuery` code that needed removing as part of this work (except for the XML editor plugin code).

I tested almost all of these code changes in the app, except for the intercom push related code changes.