### PR TITLE
Initialize tags in playlist/timelines edit forms

### DIFF
--- a/app/views/playlists/_tag_form.html.erb
+++ b/app/views/playlists/_tag_form.html.erb
@@ -57,6 +57,14 @@ Unless required by applicable law or agreed to in writing, software distributed
           document.getElementById('taglist').value = JSON.stringify(values);
         }
       });
+
+      /*
+        Initialize hidden input with current tag values as a JSON array to be used
+        for form submission, if the user doesn't interact with tag selection element.
+      */
+      const initialTags = tagSelect.getValue();
+      const tagsArray = Array.isArray(initialTags) ? initialTags : [initialTags];
+      document.getElementById('taglist').value = JSON.stringify(tagsArray);
     });
   </script>
 <% end %>

--- a/app/views/timelines/_tag_form.html.erb
+++ b/app/views/timelines/_tag_form.html.erb
@@ -57,6 +57,14 @@ Unless required by applicable law or agreed to in writing, software distributed
           document.getElementById('taglist').value = JSON.stringify(values);
         }
       });
+      
+      /*
+        Initialize hidden input with current tag values as a JSON array to be used
+        for form submission, if the user doesn't interact with tag selection element.
+      */
+      const initialTags = tagSelect.getValue();
+      const tagsArray = Array.isArray(initialTags) ? initialTags : [initialTags];
+      document.getElementById('taglist').value = JSON.stringify(tagsArray);
     });
   </script>
 <% end %>


### PR DESCRIPTION
This reverts a buggy code change made in https://github.com/avalonmediasystem/avalon/pull/6619.

The absence of this code breaks the playlist/timeline details show page whenever a user edits relevant details and saves the edit form without interacting with the tag-select form field. Because with this particular workflow the hidden input that passes current tags to the back-end remains empty at the time of the form submission. And this default value is an empty string, which breaks the array-related methods associated with `playlist.tags` values.

Related issue: #6564 