### PR TITLE
Add back vendor/assets styles for XML structure editor

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -37,3 +37,6 @@ $fa-font-path: '.';
 
 @import 'sortable';
 @import 'avalon';
+
+// XML Editor styles for Advanced Edit Structure modal
+@import '../../../vendor/assets/stylesheets/jquery.xmleditor';


### PR DESCRIPTION
Fix the styling issue for XML structure editor that is present in `avalon-dev` at the moment;

<img width="1339" height="890" alt="Screenshot 2025-11-12 at 1 26 34 PM" src="https://github.com/user-attachments/assets/62b5bfaf-265d-4b1e-97c7-fc27b23fb39e" />
