### PR TITLE
Remove custom styling for VideoJS big-play button

### DIFF
--- a/app/javascript/components/Ramp.scss
+++ b/app/javascript/components/Ramp.scss
@@ -25,20 +25,9 @@
   }
 
   .ramp--media_player {
-    .video-js .vjs-big-play-button {
-      left: 55% !important;
-    }
+    // reduce player height to match with adjusted font-size
+    // for smaller screens
     @media (max-width: 585px) {
-      .video-js .vjs-big-play-button {
-        scale: 1.5;
-      }
-
-      .video-js .vjs-control-bar {
-        font-size: 90% !important;
-      }
-
-      // reduce player height to match with adjusted font-size
-      // for smaller screens
       .video-js.vjs-audio {
         min-height: 2.9em;
       }


### PR DESCRIPTION
Avalon had some custom styling to handle the big-play button in Ramp video player to make it scale and position it in the center of the video player.
With [latest changes](https://github.com/samvera-labs/ramp/pull/877) made to this element on the Ramp side the button now appears not centered in all view-ports and very large on smaller view-ports. Additionally the control-bar is overflowing the width of the player on the left-side on smaller view-ports.
<img width="712" height="402" alt="Screenshot 2025-11-12 at 3 25 43 PM" src="https://github.com/user-attachments/assets/9424f24d-d648-44cc-91df-22ef4e878b0d" />
<img width="567" height="323" alt="Screenshot 2025-11-12 at 3 28 04 PM" src="https://github.com/user-attachments/assets/4da03485-1d31-432a-96f8-e6c109e87b34" />

This PR removes related custom styling to fix these issues.