### PR TITLE
Provide migration to make playlist description be a text column…

### DIFF
--- a/db/migrate/20251118195618_change_playlists_comment_to_text.rb
+++ b/db/migrate/20251118195618_change_playlists_comment_to_text.rb
@@ -1,0 +1,5 @@
+class ChangePlaylistsCommentToText < ActiveRecord::Migration[8.0]
+  def change
+    change_column :playlists, :comment, :text, limit: 65_535
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_08_22_194731) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_18_195618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
…and allow lengths greater than 255 characters

This is a follow up to #5847 which just changed the schema.rb without providing a migration.  It didn't seem to be needed with postgres but is with existing mysql tables.

Tested on mco-staging and is working.
