### PR TITLE
Split terms on basic space and CJK space

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -83,7 +83,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     transcripts_fl = ['id'] if transcripts_present
 
     # Add fields for each term in the query, explictly escape closing parenthesis to prevent error
-    terms = solr_parameters[:q].gsub(/(\))/, "\\\\\1").split
+    terms = solr_parameters[:q].gsub(/(\))/, "\\\\\1").split(/[\s\u3000]/).compact_blank
     terms.each_with_index do |term, i|
       fl << "metadata_tf_#{i}:termfreq(mods_tesim,#{RSolr.solr_escape(term)})"
       fl << "structure_tf_#{i}:termfreq(section_label_tesim,#{RSolr.solr_escape(term)})"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -218,7 +218,7 @@ describe CatalogController do
         expect(assigns(:response).documents.collect(&:id)).to eq [media_object_1.id, @media_object.id]
       end
       it 'should not error when special characters are in the query' do
-        ['+', '-', '&', '|', '"', '(', ')', '{', '}', '[', ']', '^', '~', '*', '?', ':', '/', '$'].each do |char|
+        ['+', '-', '&', '|', '"', '(', ')', '{', '}', '[', ']', '^', '~', '*', '?', ':', '/', '$', ' ', "\u3000"].each do |char|
           expect { get 'index', params: { q: "#{char} Test Label" } }.to_not raise_error
           expect(assigns(:response).documents.count).to eq 1
           expect(assigns(:response).documents.collect(&:id)).to eq [@media_object.id]

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -79,6 +79,34 @@ RSpec.describe SearchBuilder do
         expect(solr_parameters["sections.transcripts.fl"]).to eq "id,transcript_tf_0:termfreq(transcript_tsim,Example)"
         expect(solr_parameters["sections.transcripts.q"]).to eq "{!terms f=isPartOf_ssim v=$row.id}{!join to=id from=isPartOf_ssim}"
       end
+
+      context 'with multiple terms' do
+        let(:solr_parameters) { { q: 'Example query' } }
+
+        it "should add transcript options to query" do
+          subject.term_frequency_counts(solr_parameters)
+          expect(solr_parameters[:fl]).to include "metadata_tf_0:termfreq(mods_tesim,Example),structure_tf_0:termfreq(section_label_tesim,Example),transcript_tf_0"
+          expect(solr_parameters[:fl]).to include "metadata_tf_1:termfreq(mods_tesim,query),structure_tf_1:termfreq(section_label_tesim,query),transcript_tf_1"
+          expect(solr_parameters["sections.fl"]).to eq "id,transcript_tf_0,transcript_tf_1,transcripts:[subquery]"
+          expect(solr_parameters["sections.transcripts.fl"]).to include "transcript_tf_0:termfreq(transcript_tsim,Example)"
+          expect(solr_parameters["sections.transcripts.fl"]).to include "transcript_tf_1:termfreq(transcript_tsim,query)"
+          expect(solr_parameters["sections.transcripts.q"]).to eq "{!terms f=isPartOf_ssim v=$row.id}{!join to=id from=isPartOf_ssim}"
+        end
+
+        context 'with CJK whitespace' do
+          let(:solr_parameters) { { q: 'Example　query' } }
+
+          it "should add transcript options to query" do
+            subject.term_frequency_counts(solr_parameters)
+            expect(solr_parameters[:fl]).to include "metadata_tf_0:termfreq(mods_tesim,Example),structure_tf_0:termfreq(section_label_tesim,Example),transcript_tf_0"
+            expect(solr_parameters[:fl]).to include "metadata_tf_1:termfreq(mods_tesim,query),structure_tf_1:termfreq(section_label_tesim,query),transcript_tf_1"
+            expect(solr_parameters["sections.fl"]).to eq "id,transcript_tf_0,transcript_tf_1,transcripts:[subquery]"
+            expect(solr_parameters["sections.transcripts.fl"]).to include "transcript_tf_0:termfreq(transcript_tsim,Example)"
+            expect(solr_parameters["sections.transcripts.fl"]).to include "transcript_tf_1:termfreq(transcript_tsim,query)"
+            expect(solr_parameters["sections.transcripts.q"]).to eq "{!terms f=isPartOf_ssim v=$row.id}{!join to=id from=isPartOf_ssim}"
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
\u3000 is a CJK space character which causes solr term frequency subqueries to break and return a 500 on catalog searches.

Seen in one of the instances of https://app.honeybadger.io/projects/54117/faults/123976516

This honeybadger report includes other characters (possibly `,`) which we should probably handle too.