### PR TITLE
Prevent m3u8 reload from being added multiple times

### DIFF
--- a/app/assets/javascripts/player_listeners.js
+++ b/app/assets/javascripts/player_listeners.js
@@ -18,6 +18,7 @@ let canvasIndex = -1;
 let currentSectionLabel = undefined;
 let addToPlaylistListenersAdded = false;
 let firstLoad = true;
+let reloadAdded = false;
 let streamId = '';
 let isMobile = false;
 let isPlaying = false;
@@ -629,7 +630,7 @@ function handleCreateTimelineModalShow() {
  */
 function initM3U8Reload(player) {
   if (player && player.player != undefined) {
-    if (firstLoad === true) {
+    if (reloadAdded === false) {
       player.player.on('pause', () => {
         currentTime = player.player.currentTime();
         // How long to wait before resetting stream tokens: default 5 minutes
@@ -647,6 +648,8 @@ function initM3U8Reload(player) {
       player.player.on('waiting', () => {
         m3u8Reload();
       });
+
+      reloadAdded = true;
     }
   }
 }


### PR DESCRIPTION
Related issue: #6635

The root cause of the behavior was a race condition where the first load would sometimes take long enough for the m3u8 reload initialization to be triggered twice or more. This resulted in multiple event listeners, each creating a reload interval when pausing playback. However, these intervals were being set to the same variable so when playback was resumed the interval removal would only remove the most recently created interval. Using a flag specific to the reload being added to the page should fix the behavior.