### PR TITLE
Fix browse everything upload

### DIFF
--- a/app/assets/javascripts/file_browse.js
+++ b/app/assets/javascripts/file_browse.js
@@ -43,9 +43,9 @@ document.addEventListener('DOMContentLoaded', function () {
       if (providerLink) providerLink.click();
     }).done(function (data) {
       if (data.length > 0) {
-        const uploadModal = getById('uploading');
-        if (uploadModal) {
-          const uploadModal = new bootstrap.Modal(uploadModal);
+        const uploadModalElement = getById('uploading');
+        if (uploadModalElement) {
+          const uploadModal = new bootstrap.Modal(uploadModalElement);
           uploadModal.show();
         }
         const dropboxWorkflowInput = query('#dropbox_form input[name=workflow]');


### PR DESCRIPTION
In the rework to remove jquery the "uploading" modal generated when submitting a browse everything upload was accidentally broken. We were attempting to set two `const` variables to the same name, `uploadModal`. This triggered a reference error which would crash the upload process. Setting the two variables to different names resolves the issue.