### PR TITLE
Run DeleteOldSearchesJob every 20 min

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -22,6 +22,7 @@ Rails.application.config.to_prepare do
     Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification of Existing Batches - every 15min', cron: '*/15 * * * *', class: 'IngestBatchStatusEmailJobs::IngestFinished')
     Sidekiq::Cron::Job.create(name: 'Status Checking and Email Notification for Stalled Batches - every 1day', cron: '0 1 * * *', class: 'IngestBatchStatusEmailJobs::StalledJob')
     Sidekiq::Cron::Job.create(name: 'Clean out user sessions older than 7 days - every 6hour', cron: '0 */6 * * *', class: 'CleanupSessionJob')
+    Sidekiq::Cron::Job.create(name: 'Clean out searches older than 20 minutes - every 20min', cron: '*/20 * * * *', class: 'DeleteOldSearchesJob')
     Sidekiq::Cron::Job.create(name: 'Clean out expired stream tokens - every 5min', cron: '*/5 * * * *', class: 'CleanupStreamTokenJob')
   rescue Redis::CannotConnectError => e
     Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"


### PR DESCRIPTION
Currently the searches table isn't getting cleaned automatically so it can grow to be really really big.  This can cause problems in storage constrained environments.  Additionally this search data isn't used by Avalon anywhere so we have no need to keep it.