### PR TITLE
Pass section thumbnail urls to iiif_manifest

### DIFF
--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -228,7 +228,8 @@ class IiifCanvasPresenter
         height: (master_file.height || MasterFile::AUDIO_HEIGHT).to_i,
         duration: stream_info[:duration],
         type: media_type,
-        format: mimetype
+        format: mimetype,
+        thumbnail: [{ id: thumbnail_url, type: 'Image' }]
       }.compact
 
       if master_file.media_object.visibility == 'public'
@@ -307,5 +308,13 @@ class IiifCanvasPresenter
           }
         ]
       }
+    end
+
+    def thumbnail_url
+      if master_file.is_video?
+        Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file.id)
+      else
+        ActionController::Base.helpers.asset_url('audio_icon.png')
+      end
     end
 end

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -201,7 +201,8 @@ class IiifPlaylistCanvasPresenter
         height: (master_file.height || MasterFile::AUDIO_HEIGHT).to_i,
         duration: stream_info[:duration],
         type: media_type,
-        format: mimetype
+        format: mimetype,
+        thumbnail: [{ id: thumbnail_url, type: 'Image' }]
       }.compact
 
       if master_file.media_object.visibility == 'public'
@@ -262,5 +263,13 @@ class IiifPlaylistCanvasPresenter
           }
         ]
       }
+    end
+
+    def thumbnail_url
+      if master_file.is_video?
+        Rails.application.routes.url_helpers.thumbnail_master_file_url(master_file.id)
+      else
+        ActionController::Base.helpers.asset_url('audio_icon.png')
+      end
     end
 end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -89,6 +89,10 @@ describe IiifCanvasPresenter do
         expect(subject.height).to eq 40
       end
 
+      it 'has thumbnail' do
+        expect(subject.thumbnail.first[:id]).to start_with "http://test.host/assets/audio_icon"
+      end
+
       context 'with mp3 file' do
         let(:mp3_url) { 'https://streaming.example.com/dir/file.mp3' }
         let(:derivative) { FactoryBot.build(:derivative, hls_url: mp3_url, mime_type: 'audio/mpeg' ) }
@@ -111,6 +115,10 @@ describe IiifCanvasPresenter do
       it 'has height and width' do
         expect(subject.width).to eq 1024
         expect(subject.height).to eq 768
+      end
+
+      it 'has thumbnail' do
+        expect(subject.thumbnail.first[:id]).to eq "http://test.host/master_files/#{master_file.id}/thumbnail"
       end
 
       context 'with mp4 file' do

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -91,6 +91,10 @@ describe IiifPlaylistCanvasPresenter do
         expect(subject.height).to eq 40
       end
 
+      it 'has thumbnail' do
+        expect(subject.thumbnail.first[:id]).to start_with "http://test.host/assets/audio_icon"
+      end
+
       context 'with mp3 file' do
         let(:mp3_url) { 'https://streaming.example.com/dir/file.mp3' }
         let(:derivative) { FactoryBot.build(:derivative, hls_url: mp3_url, mime_type: 'audio/mpeg' ) }
@@ -117,6 +121,10 @@ describe IiifPlaylistCanvasPresenter do
       it 'has height and width' do
         expect(subject.width).to eq 1024
         expect(subject.height).to eq 768
+      end
+
+      it 'has thumbnail' do
+        expect(subject.thumbnail.first[:id]).to eq "http://test.host/master_files/#{master_file.id}/thumbnail"
       end
 
       context 'with mp4 file' do


### PR DESCRIPTION
Resolves #6652 

Future work could be to add `format`, `width`, and `height` attributes to the thumbnail hash.