### PR TITLE
Use delete_all because it is more performant

### DIFF
--- a/app/jobs/delete_old_searches_job.rb
+++ b/app/jobs/delete_old_searches_job.rb
@@ -13,9 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 class DeleteOldSearchesJob < ActiveJob::Base
-
   def perform
-    Search.where(['created_at < ? AND user_id IS NULL', 20.minutes.ago]).destroy_all
+    Search.where(['created_at < ? AND user_id IS NULL', 20.minutes.ago]).delete_all
   end
-
 end


### PR DESCRIPTION
We don't need to worry about running callbacks and anyways Blacklight uses delete_all in it's implementation.

This is a follow up to #6660 