### PR TITLE
Clean out environment before running asset compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ COPY        --from=node-modules --chown=app:app /node_modules ./node_modules
 USER        app
 ENV         RAILS_ENV=production
 
-RUN         SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') bundle exec rake assets:precompile
+RUN         env -i HOME=/root BUNDLE_APP_CONFIG=/usr/local/bundle GEM_HOME=/usr/local/bundle SECRET_KEY_BASE=$(ruby -r 'securerandom' -e 'puts SecureRandom.hex(64)') SHAKAPACKER_ASSET_HOST='' bash -l -c 'bundle exec rake assets:precompile'
 RUN         cp -n config/controlled_vocabulary.yml.example config/controlled_vocabulary.yml
 
 


### PR DESCRIPTION
Avalon docker image building may include local environment variables which has the potential of exposing them by 3rd party JS libraries due to an issue in shakapacker <9.5.0.  This change clears out the environment before asset compilation as a precaution.  This workaround will be unnecessary once we upgrade to shakapacker 9.5.0.  See https://github.iu.edu/advisories/GHSA-96qw-h329-v5rg