### PR TITLE
Manager list should be empty (only inherited) when creating a new collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -104,7 +104,7 @@ class Admin::CollectionsController < ApplicationController
   # POST /collections
   def create
     unit_id = collection_params['unit_id'].presence || convert_unit(collection_params["unit_name"])
-    @collection = Admin::Collection.create(collection_params.merge(managers: [current_user.user_key], unit_id: unit_id, governing_policy_id: unit_id))
+    @collection = Admin::Collection.create(collection_params.merge(unit_id: unit_id, governing_policy_id: unit_id))
     if @collection.persisted?
       User.where(Devise.authentication_keys.first => [Avalon::RoleControls.users('administrator')].flatten).each do |admin_user|
         NotificationsMailer.new_collection(

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -30,7 +30,6 @@ class Admin::Collection < ActiveFedora::Base
 
   validates :name, uniqueness: { solr_name: 'name_uniq_si' }, presence: true
   validates :unit, presence: true
-  validates :managers, length: { minimum: 1, message: "list can't be empty." }
   validates :contact_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validates :website_url, format: { with: URI.regexp }, allow_blank: true
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -369,11 +369,11 @@ describe Admin::CollectionsController, type: :controller do
       expect(new_collection.unit_id). to eq collection.unit.id
       expect(new_collection.governing_policy_id).to eq collection.unit.id
     end
-    it "should create a new collection with default manager list containing current API user" do
+    it "should create a new collection with manager list empty" do
       post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id } }
       expect(JSON.parse(response.body)['id'].class).to eq String
       collection = Admin::Collection.find(JSON.parse(response.body)['id'])
-      expect(collection.managers).to eq([administrator.username])
+      expect(collection.managers).to eq([])
     end
     it "should return 422 if collection creation failed" do
       post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description } }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -215,7 +215,6 @@ describe Admin::Collection do
     it { is_expected.not_to allow_value('collection@').for(:contact_email) }
     it { is_expected.to allow_value('https://collection.example.com').for(:website_url) }
     it { is_expected.not_to allow_value('collection.example.com').for(:website_url) }
-    it "should ensure length of :managers is_at_least(1)"
 
     it "should have attributes" do
       expect(subject.name).to eq("Herman B. Wells Collection")


### PR DESCRIPTION
Resolves #6684 