### PR TITLE
Change modal and structure heights to make save btn visible

### DIFF
--- a/app/javascript/components/ReactButtonContainer.scss
+++ b/app/javascript/components/ReactButtonContainer.scss
@@ -23,7 +23,6 @@
 }
 
 .modal-open .modal {
-  height: calc(100vh - 80px);
   overflow: scroll;
 }
 
@@ -34,11 +33,15 @@
 
   .modal-wrapper-body {
     width: 90%;
-    top: 50px;
   }
 
   .modal-title {
     display: inline-block;
+  }
+
+  .structure-section>.structure-lists {
+    height: fit-content;
+    max-height: 28vh;
   }
 }
 


### PR DESCRIPTION
Related issue: #6699 

Changes in this PR:
- Remove the `height` CSS rule for the modal and add height related rules to the structure div inside SME
- Set `height: 'fit-content'` for the structure div inside SME , which makes `Save Structure` button visible for smaller structures without additional white-space in between the `Save Structure` button and structure
- Set a `max-height: '28vh'` to the same structure div so that, it doesn't create a longer structure div pushing the `Save Structure` button further down in the modal requiring user to scroll the waveform and player out of view to edit longer structures
- Remove the space above the modal so that, SME can have more real estate to render content


| Before | After |
| --- | --- |
| <img width="1990" height="973" alt="Screenshot 2026-01-27 at 9 34 48 AM" src="https://github.com/user-attachments/assets/c98f734e-fe2d-467c-8ff6-b267d23a91e3" /> | <img width="1990" height="973" alt="Screenshot 2026-01-27 at 9 33 57 AM" src="https://github.com/user-attachments/assets/8721510b-4525-476e-9654-69c6981ca0aa" /> |
| <img width="1990" height="973" alt="Screenshot 2026-01-27 at 9 34 58 AM" src="https://github.com/user-attachments/assets/477d9d4b-7da1-48b5-9947-1d7b845a4668" /> | <img width="1990" height="973" alt="Screenshot 2026-01-27 at 9 33 46 AM" src="https://github.com/user-attachments/assets/f6af821c-aa85-44fc-8a44-ea69268e2c8e" /> |

