### PR TITLE
Limit collection move dropdown list

### DIFF
--- a/app/views/bookmarks/move.html.erb
+++ b/app/views/bookmarks/move.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= form_tag url_for(:controller => "bookmarks", :action => "move"), :id => 'move_form', :method => :post do %>
     <div class="modal-body">
       <div class="row-fluid">
-        <% if  @candidates.count <= 1 || @documents.empty? %>
+        <% if  (@documents.length == 1 && @candidates.empty?) || (@documents.length > 1 && @candidates.count <= 1) || @documents.empty? %>
           <div class="alert alert-danger">
             <% if @documents.empty? %>
                     <p><%= t('blacklight.bookmarks.no_bookmarks') %></p>


### PR DESCRIPTION
Related issue: #6692

Behavior changes:
* Managers of a single collection receive warning they do not have permissions to move items to another collection
* When a single item is selected, the collection it belongs to is removed from the dropdown list.