### PR TITLE
Do not index private transcripts

### DIFF
--- a/app/models/supplemental_file.rb
+++ b/app/models/supplemental_file.rb
@@ -135,7 +135,7 @@ class SupplementalFile < ApplicationRecord
     solr_doc["mime_type_ssi"] = mime_type
     solr_doc["label_ssi"] = label
     solr_doc["language_ssi"] = language
-    solr_doc["transcript_tsim"] = segment_transcript(file) if transcript?
+    solr_doc["transcript_tsim"] = segment_transcript(file) if transcript? && !private?
     solr_doc["isPartOf_ssim"] = [parent_id]
     solr_doc
   end

--- a/spec/models/supplemental_file_spec.rb
+++ b/spec/models/supplemental_file_spec.rb
@@ -150,6 +150,19 @@ describe SupplementalFile do
           expect(after_doc["transcript_tsim"]).to be_nil
         end
       end
+
+      context 'private transcript' do
+        let(:transcript) { FactoryBot.create(:supplemental_file, :with_transcript_file, :with_transcript_tag) }
+
+        it 'removes the transcript_tsim content when private tag is added' do
+          before_doc = ActiveFedora::SolrService.query("id:#{RSolr.solr_escape(transcript.to_global_id.to_s)}").first
+          expect(before_doc["transcript_tsim"].first).to eq "00:00:03.500 --> 00:00:05.000 Example captions"
+          transcript.tags = ['transcript', 'private']
+          transcript.save
+          after_doc = ActiveFedora::SolrService.query("id:#{RSolr.solr_escape(transcript.to_global_id.to_s)}").first
+          expect(after_doc["transcript_tsim"]).to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Related issue: #6709

There is a possibility for future problems if we are trying to script retrieval of transcripts by leveraging Solr. We will need to remember that private transcripts are not indexed and we need to hit the database to retrieve those files. This seems like an acceptable gotcha currently, but should be ocassionally reassessed.