### PR TITLE
Add dummy workflow file to trigger workflow API

### DIFF
--- a/.github/workflows/update-ramp.yml
+++ b/.github/workflows/update-ramp.yml
@@ -1,0 +1,19 @@
+name: Update Ramp Dependency
+
+# This file must exist on 'main' for the API to find the workflow name.
+# Once registered, the API can trigger the 'develop' version.
+
+on:
+  repository_dispatch:
+    types: [update-ramp]
+  workflow_dispatch:
+    inputs:
+      ramp_commit:
+        description: 'The commit hash from Ramp'
+        required: true
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a placeholder registering the workflow for updating Ramp dependency to the latest build."


### PR DESCRIPTION
Related issue: #6121 

This PR adds a placeholder for registering the `update-ramp.yml` Git workflow for the Git API to update Ramp dependency in Avalon when a new build is created in Ramp repository.