### PR TITLE
Change git workflow to use workflow_dispatch

### DIFF
--- a/.github/workflows/update-ramp.yml
+++ b/.github/workflows/update-ramp.yml
@@ -1,9 +1,13 @@
 name: Update Ramp Dependency
 
 on:
-  repository_dispatch:
-    types: [ramp-build-updated]
   workflow_dispatch:
+    inputs:
+      ramp_commit:
+        description: 'The commit hash from Ramp'
+        required: true
+  repository_dispatch:
+    types: [update-ramp]
 
 jobs:
   update-ramp:
@@ -14,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -52,7 +56,7 @@ jobs:
 
             ## Source commits
             ${{ steps.collect-existing.outputs.commits }}
-            - https://github.com/samvera-labs/ramp/commit/${{ github.event.client_payload.ramp_commit }}
+            - https://github.com/samvera-labs/ramp/commit/${{ github.event.inputs.ramp_commit }}
 
           branch: update-ramp-build
           base: develop


### PR DESCRIPTION
Related issue: #6121 

Use `workflow_dispatch` instead of `respository_dispatch` because `repository_dispatch` only triggers workflows in the default branch. This workflow needs to run off of the `develop` branch which is not the default branch.

This changes introduces the following changes;
- commit hash variable in Avalon's workflow `github.event.client_payload.ramp_commit` -> `github.event.inputs.ramp_commit`
- a dummy workflow file in Avalon's `main` branch for the repo to register the workflow  (https://github.com/avalonmediasystem/avalon/pull/6723)