### PR TITLE
Redirect to fedora on missing MasterFile proxy

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -377,9 +377,9 @@ protected
 
   def set_masterfile_proxy
     @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id], load_reflections: true)
-    if params[:id].blank? || @master_file.nil?
-      flash[:notice] = "MasterFile #{params[:id]} does not exist"
-    end
+    flash[:notice] = "MasterFile #{params[:id]} does not exist" if params[:id].blank?
+    set_masterfile if @master_file.nil?
+    @master_file
   end
 
   # return deflated waveform content. deflate only if necessary

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -369,15 +369,13 @@ class MasterFilesController < ApplicationController
 
 protected
   def set_masterfile
-    if params[:id].blank? || (not MasterFile.exists?(params[:id]))
-      flash[:notice] = "MasterFile #{params[:id]} does not exist"
-    end
     @master_file = MasterFile.find(params[:id])
+  rescue ArgumentError
+    flash[:notice] = "MasterFile #{params[:id]} does not exist"
   end
 
   def set_masterfile_proxy
     @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id], load_reflections: true)
-    flash[:notice] = "MasterFile #{params[:id]} does not exist" if params[:id].blank?
     set_masterfile if @master_file.nil?
     @master_file
   end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -345,6 +345,18 @@ describe MasterFilesController do
         expect(response.response_code).to eq(404)
       end
     end
+
+    context 'deleted master file' do
+      before do
+        master_file.destroy
+      end
+
+      it 'should redirect to deleted_pid page' do
+        get 'show', params: { id: master_file.id }
+        expect(response).to render_template("errors/deleted_pid")
+        expect(response.response_code).to eq(410)
+      end
+    end
   end
 
   describe "#embed" do
@@ -718,8 +730,8 @@ describe MasterFilesController do
         master_file.destroy
       end
 
-      it 'returns gone (403)' do
-        expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:unauthorized)
+      it 'returns gone (410)' do
+        expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:gone)
       end
     end
 


### PR DESCRIPTION
Related issue: #5998

Can reexamine approach if this is found to be too non-performant in more real world environments.