### PR TITLE
Use `-=` when changing MO collection governing policy

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -212,7 +212,7 @@ class MediaObject < ActiveFedora::Base
   def collection= co
     old_collection = self.collection
     self._collection= co
-    self.governing_policies.delete(old_collection) if old_collection
+    self.governing_policies -= [old_collection] if old_collection
     self.governing_policies += [co]
     if self.new_record?
       self.hidden = co.default_hidden


### PR DESCRIPTION
Related issue: #6719

The loss of bookmark was caused by the `governing_policies.delete` clause. The delete action triggers a save, which would trigger the after save callback to the `remove_bookmarks` method. The media object has no governing policy in that moment, so the bookmark would get removed because the manager did not have read permissions for the media object. Changing from `delete` to `-=` prevents this callback from being triggered at that moment and improves the efficiency of the background job by removing the superfluous save within the `collection=` method and relying on the `if media_object.save` within the job itself.