### PR TITLE
Refactor thumbnail retrieval

### DIFF
--- a/app/components/thumbnail_media_object_component.html.erb
+++ b/app/components/thumbnail_media_object_component.html.erb
@@ -1,8 +1,6 @@
-<% value = presenter.thumbnail.render(@image_options) %>
-
 <div class="document-thumbnail col-md-12 col-lg-4 row">
-  <% if value %>
-    <%= helpers.link_to_document(presenter.document, value, 'aria-hidden': true, tabindex: -1, counter: @counter) %>
+  <% if thumbnail_value %>
+    <%= helpers.link_to_document(presenter.document, thumbnail_value, class: 'result-thumbnail', 'aria-hidden': true, tabindex: -1, counter: @counter) %>
   <% else %>
     <%= image_tag 'no_icon.png', alt: "", class: 'result-thumbnail no-icon' %>
   <% end %>

--- a/app/components/thumbnail_media_object_component.rb
+++ b/app/components/thumbnail_media_object_component.rb
@@ -1,2 +1,7 @@
 class ThumbnailMediaObjectComponent < Blacklight::Document::ThumbnailComponent
+  # For some reason this method does not exist in this class even though it is present
+  # in the superclass. We have to explicitly add it.
+  def thumbnail_value
+    @thumbnail_value ||= presenter.thumbnail.render(@image_options)
+  end
 end

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -218,22 +218,20 @@ class MasterFilesController < ApplicationController
   def get_frame
     mimeType = "image/jpeg"
     content = if params[:offset]
-      authorize! :edit, @master_file, message: "You do not have sufficient privileges to edit this file"
-      opts = { :type => params[:type], :size => params[:size], :offset => params[:offset].to_f*1000, :preview => true }
-      @master_file.extract_still(opts)
-    else
-      authorize! :read, @master_file, message: "You do not have sufficient privileges to view this file"
-      whitelist = ["thumbnail", "poster"]
-      if whitelist.include? params[:type]
-        ds = @master_file.send(params[:type].to_sym)
-        mimeType = ds.mime_type
-        ds.content
-      else
-        nil
-      end
-    end
+                authorize! :edit, @master_file, message: "You do not have sufficient privileges to edit this file"
+                opts = { type: params[:type], size: params[:size], offset: params[:offset].to_f * 1000, preview: true }
+                @master_file.extract_still(opts)
+              else
+                authorize! :read, @master_file, message: "You do not have sufficient privileges to view this file"
+                whitelist = ["thumbnail", "poster"]
+                if whitelist.include? params[:type]
+                  ds = @master_file.send(params[:type].to_sym)
+                  mimeType = ds.mime_type
+                  ds.content
+                end
+              end
     if content
-      send_data content, :filename => "#{params[:type]}-#{@master_file.id.split(':')[1]}", :disposition => :inline, :type => mimeType
+      send_data content, filename: "#{params[:type]}-#{@master_file.id.split(':')[1]}", disposition: :inline, type: mimeType
     elsif @master_file.is_video?
       redirect_to ActionController::Base.helpers.asset_path('video_icon.png')
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,35 +57,27 @@ module ApplicationHelper
   def image_for(document)
     master_file_id = document["section_id_ssim"].try :first
 
-    video_count = document["avalon_resource_type_ssim"].count{|m| m.downcase.start_with?('moving image') } rescue 0
-    audio_count = document["avalon_resource_type_ssim"].count{|m| m.downcase.start_with?('sound recording') } rescue 0
+    video_count = document["avalon_resource_type_ssim"].count { |m| m.downcase.start_with?('moving image') } rescue 0
+    audio_count = document["avalon_resource_type_ssim"].count { |m| m.downcase.start_with?('sound recording') } rescue 0
 
     if master_file_id
-      if video_count > 0
+      if video_count.positive?
         thumbnail_master_file_path(master_file_id)
-      elsif audio_count > 0
+      elsif audio_count.positive?
         asset_path('audio_icon.png')
-      else
-        nil
       end
-    else
-      if video_count > 0 && audio_count > 0
-        asset_path('hybrid_icon.png')
-      elsif video_count > audio_count
-        asset_path('video_icon.png')
-      elsif audio_count > video_count
-        asset_path('audio_icon.png')
-      else
-        nil
-      end
+    elsif video_count.positive? && audio_count.positive?
+      asset_path('hybrid_icon.png')
+    elsif video_count > audio_count
+      asset_path('video_icon.png')
+    elsif audio_count > video_count
+      asset_path('audio_icon.png')
     end
   end
 
-  def avalon_image_tag(document, image_options)
+  def avalon_image_tag(document, _image_options)
     image_url = image_for(document)
-    link_to(media_object_path(document[:id]), {class: 'result-thumbnail'}) do
-      image_url.present? ? image_tag(image_url) : image_tag('no_icon.png')
-    end
+    image_url.present? ? image_tag(image_url) : image_tag('no_icon.png')
   end
 
   def display_metadata(label, value, default=nil)


### PR DESCRIPTION
This commit makes some minor changes to how thumbnails are retrieved and formatted for display. This removes an unnecessary nested link structure from the html and simplifies some of the underlying code structure. It also includes a variety of small rubocop linting changes.