### PR TITLE
Fix tooltip click event targets

### DIFF
--- a/app/assets/javascripts/pop_help.js
+++ b/app/assets/javascripts/pop_help.js
@@ -33,6 +33,13 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  // Prevent tooltip 'click' event bubbling up into the form-label, which focuses the input
+  queryAll('.tooltip-label').forEach(function (element) {
+    element.addEventListener('click', function (event) {
+      event.preventDefault();
+    });
+  });
+
   queryAll('.form-text .btn-close').forEach(function (element) {
     element.addEventListener('click', function (event) {
       event.preventDefault();

--- a/app/views/modules/_tooltip.html.erb
+++ b/app/views/modules/_tooltip.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% options[:display_label] ||= options[:multivalued] ? "#{field.to_s.humanize}(s)" : field.to_s.humanize %>
 
     <%= form.label(field, class: 'col-form-label') do %>
-      <%= content_tag :span, class: 'tooltip-label', :'data-title' => options[:display_label], :'data-tooltip' => "##{field.to_s}_tooltip" do %>
+      <%= content_tag :span, class: 'tooltip-label', :'data-title' => options[:display_label], :'data-bs-toggle' => 'collapse', :'data-bs-target' => "##{field.to_s}_tooltip" do %>
          <%= options[:display_label] %><% if options[:required] %>*<% end %>
          <%= content_tag :span, '', class: 'fa fa-question-circle' %>
       <% end %>


### PR DESCRIPTION
Related issue: #6751 

This bug is a regression of the work done in https://github.com/avalonmediasystem/avalon/pull/6622. The previous work removed the `jQuery` click handler for the tooltip, instead of replacing it with a vanilla JS implementation.

The fix in this PR uses Bootstrap's `collapse` attributes `data-bs-toggle` and `data-bs-target` to show/hide the tooltip. And an additional event-listener on the tooltip 'click' event, to prevent it from bubbling up into the form-label, which focuses the input field and highlights the text inside the element.