### PR TITLE
Allow collection managers to create collections

### DIFF
--- a/app/views/admin/collections/new.html.erb
+++ b/app/views/admin/collections/new.html.erb
@@ -27,8 +27,8 @@ Unless required by applicable law or agreed to in writing, software distributed
                                                                 model: :"Admin::Unit",
                                                                 data: { 
                                                                         testid: 'collection-unit'
-                                                                      },
-                                                                disabled: !can?(:update, @collection) } %>
+                                                                      }
+                                                              } %>
   <div>
   <% end %>
   <%= f.text_area :description, rows: 3, 'data-testid':'collection-description'  %>


### PR DESCRIPTION
Related issue: #6740

The issue arose from an ability check that we had for rendering part of the view partial. When building the new collection page there was an ability check for disabling the Unit field if a user cannot update collections. Because there is not a Unit assigned to the collection at that point, this caused an error when looking for inherited permissions on the collection when doing the ability check. Since there are other ability checks in place, we can remove this disabling because anyone who can access the new collection page at all should have minimum permissions to update a collection.