### PR TITLE
Bump resolv-replace to latest to ensure it can work with ruby 3+ kwargs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'sqlite3'
 gem 'mail', '> 2.8.0.1'
 gem 'puma', '>= 6.4.2'
 gem 'puma-status'
-gem 'resolv-replace'
+gem 'resolv-replace', '>= 0.2.0'
 gem 'csv'
 gem 'net-imap', '>= 0.6.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -750,7 +750,7 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     resolv (0.7.1)
-    resolv-replace (0.1.1)
+    resolv-replace (0.2.0)
       resolv
     responders (3.1.1)
       actionpack (>= 5.2)
@@ -1071,7 +1071,7 @@ DEPENDENCIES
   rdf-rdfxml
   react_on_rails
   recaptcha
-  resolv-replace
+  resolv-replace (>= 0.2.0)
   rest-client (~> 2.0)
   roo
   rsolr (~> 2.0)


### PR DESCRIPTION
needed by latest `prometheus_exporter`