### PR TITLE
Remove manager and unit administrator groups

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -117,15 +117,9 @@ class Admin::GroupsController < ApplicationController
 
   def update_users
     group_name = params[:id]
-    sole_managers = check_for_sole_managers if group_name == "manager"
-    if sole_managers.present?
-      flash[:error] = "Cannot remove users #{sole_managers.join(', ')} because they are sole managers of collections."
-    else
-      users = Avalon::RoleControls.users(group_name) - params[:user_ids]
-      Avalon::RoleControls.assign_users(users, group_name)
-      Avalon::RoleControls.save_changes
-      BulkActionJobs::RemoveManagers.perform_later(params[:user_ids])
-    end
+    users = Avalon::RoleControls.users(group_name) - params[:user_ids]
+    Avalon::RoleControls.assign_users(users, group_name)
+    Avalon::RoleControls.save_changes
     redirect_back(fallback_location: edit_admin_group_path(group_name))
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -64,12 +64,6 @@ class Ability
         can :manage, :all
       end
 
-      if @user_groups.include? "group_manager"
-        can :manage, Admin::Group do |group|
-           group.nil? or !['administrator','group_manager'].include?(group.name)
-        end
-      end
-
       if is_member_of_any_collection? || is_member_of_any_unit?
         can :create, MediaObject
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -74,15 +74,11 @@ class Ability
         can :create, MediaObject
       end
 
-      if is_manager?
+      if is_unit_admin_of_any_unit?
         can :create, Admin::Collection
       end
 
-      if is_manager_of_any_unit?
-        can :create, Admin::Collection
-      end
-
-      if is_unit_admin?
+      if is_administrator?
         can :create, Admin::Unit
       end
     end
@@ -352,14 +348,6 @@ class Ability
     @user_groups.include?("administrator")
   end
 
-  def is_manager?
-    @user_groups.include?("manager")
-  end
-
-  def is_unit_admin?
-    @user_groups.include?("unit_administrator")
-  end
-
   def is_admin_of?(unit)
     is_administrator? ||
       @user.in?(unit.unit_admins)
@@ -403,12 +391,16 @@ class Ability
     @user.id.present? && Admin::Collection.exists?("inheritable_edit_access_person_ssim" => @user.user_key)
   end
 
+  def is_manager_of_any_collection?
+    @user.id.present? && (Admin::Collection.exists?("collection_managers_ssim" => @user.user_key) || Admin::Unit.exists?("collection_managers_ssim" => @user.user_key))
+  end
+
   def is_member_of_any_unit?
     @user.id.present? && Admin::Unit.exists?("inheritable_edit_access_person_ssim" => @user.user_key)
   end
 
-  def is_manager_of_any_unit?
-    @user.id.present? && (Admin::Unit.exists?("unit_administrators_ssim" => @user.user_key) || Admin::Unit.exists?("collection_managers_ssim" => @user.user_key))
+  def is_unit_admin_of_any_unit?
+    @user.id.present? && Admin::Unit.exists?("unit_administrators_ssim" => @user.user_key)
   end
 
   def full_login?
@@ -424,6 +416,6 @@ class Ability
   end
 
   def has_administrative_access?
-    is_administrator? || is_unit_admin? || is_manager? || is_member_of_any_unit? || is_member_of_any_collection?
+    is_administrator? || is_unit_admin_of_any_unit? || is_manager_of_any_collection? || is_member_of_any_unit? || is_member_of_any_collection?
   end
 end

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -100,7 +100,6 @@ class Admin::Collection < ActiveFedora::Base
   end
 
   def add_manager user
-    raise ArgumentError, "User #{user} does not belong to the manager group." unless (Avalon::RoleControls.users("manager") + (Avalon::RoleControls.users("administrator") || []) ).include?(user)
     self.collection_managers += [user]
     self.edit_users += [user]
     self.inherited_edit_users += [user]
@@ -108,7 +107,6 @@ class Admin::Collection < ActiveFedora::Base
 
   def remove_manager user
     return unless managers.include? user
-    raise ArgumentError, "At least one manager is required." if self.managers.size == 1
 
     self.collection_managers = self.collection_managers.to_a - [user]
     self.edit_users -= [user]

--- a/app/models/admin/unit.rb
+++ b/app/models/admin/unit.rb
@@ -75,7 +75,6 @@ class Admin::Unit < ActiveFedora::Base
   end
 
   def add_unit_admin(user)
-    raise ArgumentError, "User #{user} does not belong to the unit administrator group." unless (Avalon::RoleControls.users("unit_administrator") + (Avalon::RoleControls.users("administrator") || [])).include?(user)
     self.unit_administrators += [user]
     self.edit_users += [user]
     self.inherited_edit_users += [user]
@@ -97,7 +96,6 @@ class Admin::Unit < ActiveFedora::Base
   end
 
   def add_manager user
-    raise ArgumentError, "User #{user} does not belong to the manager group." unless (Avalon::RoleControls.users("manager") + (Avalon::RoleControls.users("administrator") || []) ).include?(user)
     self.collection_managers += [user]
     self.edit_users += [user]
     self.inherited_edit_users += [user]
@@ -105,7 +103,6 @@ class Admin::Unit < ActiveFedora::Base
 
   def remove_manager user
     return unless managers.include? user
-    raise ArgumentError, "At least one manager is required." if self.managers.size == 1
 
     self.collection_managers = self.collection_managers.to_a - [user]
     self.edit_users -= [user]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,18 +175,16 @@ en:
       controls for individual items in the collection. Editors can also do
       anything a depositor can do.
     manager: |
-      Managers have overall accountability for the collection. Managers can
-      create collections and assign editor and depositor roles for those
-      collections. They set the default access controls for items added to
-      the collection, and they also step in when a published item needs
-      revising or deleting. Managers can also do anything an editor or
+      Managers have overall accountability for the collection. Managers assign 
+      editor and depositor roles for collections, set the default access controls
+      for items added to the collection, and they also step in when a published
+      item needs revising or deleting. Managers can also do anything an editor or
       depositor can do.
     unit_admin: |
-      Unit administrators have overall accountability for the unit. Unit
-      administrators can create units and assign all other roles for those 
-      units. They set the default access controls for collections added to
-      the unit. Unit administrators can also do anything a manager, editor
-      or depositor can do.
+      Unit administrators have overall accountability for the unit. They assign 
+      roles for those units, create collections in the unit, and set the default
+      access controls for collections added to the unit. Unit administrators can 
+      also do anything a manager, editor or depositor can do.
     user: |
       Enter a username to grant them access to an item or collection. Start and end dates are not required; if included, access for the specified user will start at the beginning of the start date and end at the beginning of the end date. Otherwise, access will be open ended for the specified user.
     group: |

--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -1,33 +1,12 @@
 development:
   administrator:
     - archivist1@example.com
-  manager:
-    - archivist1@example.com
-  group_manager:
-    - archivist1@example.com
-  unit_administrator:
-    - archivist1@example.com
 
 test:
   administrator:
-    - archivist1@example.com
-    -
-  manager:
-    - archivist1@example.com
-    -
-  group_manager:
-    - archivist1@example.com
-    -
-  unit_administrator:
     - archivist1@example.com
 
 production:
   # Add roles for users here.
   administrator:
-    - <%= Settings.initial_user %>
-  manager:
-    - <%= Settings.initial_user %>
-  group_manager:
-    - <%= Settings.initial_user %>
-  unit_administrator:
     - <%= Settings.initial_user %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,7 +70,7 @@ streaming:
 redis:
   url: 'redis://localhost:6379/0'
 groups:
-  system_groups: [administrator, group_manager]
+  system_groups: [administrator]
 master_file_management:
   strategy: 'none' #'delete', or 'move' (for move uncomment and configure next line)
   #path: '/path/to/move/to'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,7 +70,7 @@ streaming:
 redis:
   url: 'redis://localhost:6379/0'
 groups:
-  system_groups: [administrator, group_manager, manager, unit_administrator]
+  system_groups: [administrator, group_manager]
 master_file_management:
   strategy: 'none' #'delete', or 'move' (for move uncomment and configure next line)
   #path: '/path/to/move/to'

--- a/lib/tasks/avalon_migrations.rake
+++ b/lib/tasks/avalon_migrations.rake
@@ -131,7 +131,7 @@ namespace :avalon do
     desc "Migrate existing units to new Admin::Unit model and associate them with the appropriate Admin::Collections"
     task admin_units: :environment do
       if ENV['unit_admin_username'].nil?
-        abort "You must specify a username. This user must be part of the Unit Administrator group. Example: rake avalon:migration:admin_units unit_admin_username=user@example.edu"
+        abort "You must specify a username. Example: rake avalon:migration:admin_units unit_admin_username=user@example.edu"
       end
 
       units = {}

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -71,23 +71,14 @@ describe Admin::CollectionsController, type: :controller do
     end
 
     it "should add users to manager role" do
-      manager = FactoryBot.create(:manager)
+      manager = FactoryBot.create(:user)
       put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: manager.user_key }
       collection.reload
       expect(manager).to be_in(collection.managers)
     end
 
-    it "should not add users to manager role" do
-      user = FactoryBot.create(:user)
-      put 'update', params: { id: collection.id, submit_add_manager: 'Add', add_manager: user.user_key }
-      collection.reload
-      expect(user).not_to be_in(collection.managers)
-      expect(flash[:error]).not_to be_empty
-    end
-
     it "should remove users from manager role" do
-      #initial_manager = FactoryBot.create(:manager).user_key
-      collection.managers += [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+      collection.managers += [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
       collection.save!
       manager = User.where(Devise.authentication_keys.first => collection.managers.first).first
       put 'update', params: { id: collection.id, remove_manager: manager.user_key }
@@ -96,7 +87,7 @@ describe Admin::CollectionsController, type: :controller do
     end
 
     context 'with zero-width characters' do
-      let(:manager) { FactoryBot.create(:manager) }
+      let(:manager) { FactoryBot.create(:user) }
       let(:manager_key) { "#{manager.user_key}\u200B" }
 
       it "should add users to manager role" do
@@ -299,7 +290,7 @@ describe Admin::CollectionsController, type: :controller do
     end
 
     context 'user is a collection manager' do
-      let(:manager) { FactoryBot.create(:manager) }
+      let(:manager) { FactoryBot.create(:user) }
       before(:each) do
         ApiToken.create token: 'manager_token', username: manager.username, email: manager.email
         request.headers['Avalon-Api-Key'] = 'manager_token'

--- a/spec/controllers/admin_units_controller_spec.rb
+++ b/spec/controllers/admin_units_controller_spec.rb
@@ -71,23 +71,14 @@ describe Admin::UnitsController, type: :controller do
     end
 
     it "should add users to manager role" do
-      manager = FactoryBot.create(:manager)
+      manager = FactoryBot.create(:user)
       put 'update', params: { id: unit.id, submit_add_manager: 'Add', add_manager: manager.user_key }
       unit.reload
       expect(manager).to be_in(unit.managers)
     end
 
-    it "should not add users to manager role" do
-      user = FactoryBot.create(:user)
-      put 'update', params: { id: unit.id, submit_add_manager: 'Add', add_manager: user.user_key }
-      unit.reload
-      expect(user).not_to be_in(unit.managers)
-      expect(flash[:error]).not_to be_empty
-    end
-
     it "should remove users from manager role" do
-      # initial_manager = FactoryBot.create(:manager).user_key
-      unit.managers += [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+      unit.managers += [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
       unit.save!
       manager = User.where(Devise.authentication_keys.first => unit.managers.first).first
       put 'update', params: { id: unit.id, remove_manager: manager.user_key }
@@ -96,7 +87,7 @@ describe Admin::UnitsController, type: :controller do
     end
 
     context 'with zero-width characters' do
-      let(:manager) { FactoryBot.create(:manager) }
+      let(:manager) { FactoryBot.create(:user) }
       let(:manager_key) { "#{manager.user_key}\u200B" }
 
       it "should add users to manager role" do
@@ -272,7 +263,7 @@ describe Admin::UnitsController, type: :controller do
     end
 
     context 'user is a unit admin' do
-      let(:unit_admin) { FactoryBot.create(:unit_admin) }
+      let(:unit_admin) { FactoryBot.create(:user) }
       before(:each) do
         ApiToken.create token: 'manager_token', username: unit_admin.username, email: unit_admin.email
         request.headers['Avalon-Api-Key'] = 'manager_token'

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -133,7 +133,7 @@ describe BookmarksController, type: :controller do
         expect(response.body).to have_css('#deleteLink')
       end
       it 'are not displayed for unauthorized user' do
-        collection.managers = [FactoryBot.create(:manager).user_key]
+        collection.managers = [FactoryBot.create(:user).user_key]
         collection.save
         get 'index'
         expect(response.body).not_to have_css('#moveLink')

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -283,7 +283,7 @@ describe CatalogController do
       end
     end
     describe "as an lti user" do
-      let!(:user) { login_lti 'student' }
+      let!(:user) { login_lti 'user' }
       let!(:lti_group) { @controller.user_session[:virtual_groups].first }
       it "should show results for items visible to the lti virtual group" do
         mo = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
@@ -298,7 +298,7 @@ describe CatalogController do
 
     describe "as an unauthenticated user with a specific IP address" do
       before(:each) do
-        @user = login_as 'public'
+        @user = login_as 'user'
         @ip_address1 = Faker::Internet.ip_v4_address
         @mo = FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [@ip_address1])
         perform_enqueued_jobs(only: MediaObjectIndexingJob)

--- a/spec/controllers/dropbox_controller_spec.rb
+++ b/spec/controllers/dropbox_controller_spec.rb
@@ -42,11 +42,9 @@ describe DropboxController do
     expect(response.status).to be(200)
   end
 
-  [:group_manager, :user].each do |group|
-    it "should not allow #{group} to delete" do
-      login_as group
-      delete :bulk_delete, params: { :collection_id => @collection.id, :filenames => @temp_files.map{|f| f[:name]} }
-      expect(response).to render_template('errors/restricted_pid')
-    end
+  it "should not allow user to delete" do
+    login_as :user
+    delete :bulk_delete, params: { :collection_id => @collection.id, :filenames => @temp_files.map{|f| f[:name]} }
+    expect(response).to render_template('errors/restricted_pid')
   end
 end

--- a/spec/controllers/dropbox_controller_spec.rb
+++ b/spec/controllers/dropbox_controller_spec.rb
@@ -42,7 +42,7 @@ describe DropboxController do
     expect(response.status).to be(200)
   end
 
-  [:group_manager, :student].each do |group|
+  [:group_manager, :user].each do |group|
     it "should not allow #{group} to delete" do
       login_as group
       delete :bulk_delete, params: { :collection_id => @collection.id, :filenames => @temp_files.map{|f| f[:name]} }

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::GroupsController do
     end
 
     it "index new should redirect to restricted content page when authenticated but unauthorized" do
-      login_as('student')
+      login_as('user')
       get 'index'
       expect(response).to render_template('errors/restricted_pid')
     end
@@ -40,7 +40,7 @@ describe Admin::GroupsController do
   	end
 
     it "new should redirect to restricted content page when authenticated but unauthorized" do
-      login_as('student')
+      login_as('user')
       expect { get 'new' }.not_to change {Admin::Group.all.count}
       expect(response).to render_template('errors/restricted_pid')
     end
@@ -51,7 +51,7 @@ describe Admin::GroupsController do
     end
 
     it "create should redirect to restricted content page when authenticated but unauthorized" do
-      login_as('student')
+      login_as('user')
 
       expect { post 'create', params: { admin_group: test_group } }.not_to change {Admin::Group.all.count }
       expect(response).to render_template('errors/restricted_pid')
@@ -91,7 +91,7 @@ describe Admin::GroupsController do
       end
 
       it "edit should redirect to restricted content page when authenticated but unauthorized" do
-        login_as('student')
+        login_as('user')
 
         get 'edit', params: { id: group.name }
         expect(response).to render_template('errors/restricted_pid')
@@ -104,7 +104,7 @@ describe Admin::GroupsController do
       end
 
       it "update should redirect to restricted content page when authenticated but unauthorized" do
-        login_as('student')
+        login_as('user')
         new_user = FactoryBot.build(:user).user_key
 
         put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
@@ -139,9 +139,9 @@ describe Admin::GroupsController do
 
       it "should not be able to rename system groups" do
         login_as('administrator')
-        put 'update', params: { group_name: Faker::Lorem.word, id: 'manager' }
+        put 'update', params: { group_name: Faker::Lorem.word, id: 'administrator' }
 
-        expect(Admin::Group.find('manager')).not_to be_nil
+        expect(Admin::Group.find('administrator')).not_to be_nil
         expect(flash[:error]).not_to be_nil
       end
 
@@ -153,33 +153,6 @@ describe Admin::GroupsController do
 
         expect(Admin::Group.find(group.name).users).to be_empty
         expect(flash[:error]).to be_nil
-      end
-
-      context 'manager group' do
-        it "should not remove users from the group if they are sole managers of a collection" do
-          login_as('group_manager')
-          request.env["HTTP_REFERER"] = '/admin/groups/manager/edit'
-
-          collection = FactoryBot.create(:collection)
-          manager_name = collection.managers.first
-          put 'update_users', params: { id: 'manager', user_ids: [manager_name] }
-
-          expect(Admin::Group.find('manager').users).to include(manager_name)
-          expect(flash[:error]).not_to be_nil
-        end
-
-        it 'should enqueue BulkActionJobs::RemoveManagers' do
-          login_as('group_manager')
-          request.env['HTTP_REFERER'] = '/admin/groups/manager/edit'
-
-          users = FactoryBot.create_list(:manager, 2)
-          collection = FactoryBot.create(:collection, managers: users.map(&:user_key))
-          manager_name = collection.managers.first
-
-          expect {
-            put 'update_users', params: { id: 'manager', user_ids: [manager_name] }
-          }.to have_enqueued_job(BulkActionJobs::RemoveManagers).with([manager_name])
-        end
       end
 
       ['administrator','group_manager'].each do |g|
@@ -215,7 +188,7 @@ describe Admin::GroupsController do
       end
 
       it "should redirect to restricted content page when authenticated but unauthorized" do
-        login_as('student')
+        login_as('user')
 
         expect { put 'update_multiple', params: { group_ids: [group.name] } }.not_to change { Avalon::RoleControls.users(group.name) }
         expect(response).to render_template('errors/restricted_pid')

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -59,15 +59,15 @@ describe Admin::GroupsController do
 
     it "create should redirect to group index page with a notice when group name is already taken" do
       group = FactoryBot.create(:group)
-      login_as('group_manager')
+      login_as('administrator')
       expect { post 'create', params: { admin_group: group.name } }.not_to change {Admin::Group.all.count }
       expect(response).to redirect_to(admin_groups_path)
       expect(flash[:error]).not_to be_nil
     end
 
     context "Default permissions should be applied" do
-      it "should be create-able by the group_manager" do
-        login_as('group_manager')
+      it "should be create-able by the administrator" do
+        login_as('administrator')
         expect { post 'create', params: { admin_group: test_group } }.to change { Admin::Group.all.count }
         g = Admin::Group.find(test_group)
         expect(g).not_to be_nil
@@ -112,7 +112,7 @@ describe Admin::GroupsController do
       end
 
       it "should be able to change group users when authenticated and authorized" do
-        login_as('group_manager')
+        login_as('administrator')
         new_user = FactoryBot.build(:user).user_key
 
         put 'update', params: { group_name: group.name, id: group.name, new_user: new_user }
@@ -125,7 +125,7 @@ describe Admin::GroupsController do
       end
 
       it "should be able to change group name when authenticated and authorized" do
-        login_as('group_manager')
+        login_as('administrator')
         new_group_name = Faker::Lorem.word
 
         put 'update', params: { group_name: new_group_name, id: group.name }
@@ -146,7 +146,7 @@ describe Admin::GroupsController do
       end
 
       it "should be able to remove users from a group" do
-        login_as('group_manager')
+        login_as('administrator')
         request.env["HTTP_REFERER"] = '/admin/groups/manager/edit'
 
         put 'update_users', params: { id: group.name, user_ids: Admin::Group.find(group.name).users }
@@ -155,28 +155,15 @@ describe Admin::GroupsController do
         expect(flash[:error]).to be_nil
       end
 
-      ['administrator','group_manager'].each do |g|
-        it "should be able to manage #{g} group as an administrator" do
-          login_as('administrator')
-          new_user = FactoryBot.build(:user).user_key
+      it "should be able to manage administrator group as an administrator" do
+        login_as('administrator')
+        new_user = FactoryBot.build(:user).user_key
 
-          put 'update', params: { id: g, new_user: new_user }
-          group = Admin::Group.find(g)
-          expect(group.users).to include(new_user)
-          expect(flash[:success]).not_to be_nil
-          expect(response).to redirect_to(edit_admin_group_path(Admin::Group.find(group.name)))
-        end
-
-        it "should not be able to manage #{g} group as a group_manager" do
-          login_as('group_manager')
-          new_user = FactoryBot.build(:user).user_key
-
-          put 'update', params: { id: g, new_user: new_user }
-          group = Admin::Group.find(g)
-          expect(group.users).not_to include(new_user)
-          expect(flash[:error]).not_to be_nil
-          expect(response).to redirect_to(admin_groups_path)
-        end
+        put 'update', params: { id: 'administrator', new_user: new_user }
+        group = Admin::Group.find('administrator')
+        expect(group.users).to include(new_user)
+        expect(flash[:success]).not_to be_nil
+        expect(response).to redirect_to(edit_admin_group_path(Admin::Group.find(group.name)))
       end
     end
 
@@ -195,7 +182,7 @@ describe Admin::GroupsController do
       end
 
       it "should be able to change group users when authenticated and authorized" do
-        login_as('group_manager')
+        login_as('administrator')
 
         expect { put 'update_multiple', params: { group_ids: [group.name] } }.to change { Avalon::RoleControls.users(group.name) }
         expect(flash[:notice]).not_to be_nil

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -781,7 +781,7 @@ describe MasterFilesController do
       end
       context 'as an end user' do
         before do
-          login_as :student
+          login_as :user
         end
         it 'redirects to restricted content page' do
           post('move', params: { id: master_file.id, target: target_media_object.id })

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -524,7 +524,7 @@ describe MediaObjectsController, type: :controller do
         end
 
         context "as an authorized non-admin user" do
-          let(:user) { FactoryBot.create(:manager) }
+          let(:user) { FactoryBot.create(:user) }
           let(:collection) { FactoryBot.create(:collection, managers: [user.username]) }
           let(:media_object) { FactoryBot.create(:media_object, collection: collection) }
 
@@ -1295,7 +1295,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).to render_template(:_lti_url)
             end
             it "others: should include only lti" do
-              login_lti 'student'
+              login_lti 'user'
               lti_group = @controller.user_session[:virtual_groups].first
               FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
               FactoryBot.create(:checkout, media_object_id: media_object.id, user_id: controller.current_user.id)
@@ -1373,7 +1373,7 @@ describe MediaObjectsController, type: :controller do
               expect(response).to render_template(:_embed_checkout)
             end
             it "others: should render checkout button in player, NOT share" do
-              login_lti 'student'
+              login_lti 'user'
               lti_group = @controller.user_session[:virtual_groups].first
               FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
               get :show, params: { id: media_object.id }
@@ -1454,7 +1454,7 @@ describe MediaObjectsController, type: :controller do
             expect(response).to render_template(:_lti_url)
           end
           it "others: should include only lti" do
-            login_lti 'student'
+            login_lti 'user'
             lti_group = @controller.user_session[:virtual_groups].first
             FactoryBot.create(:published_media_object, visibility: 'private', read_groups: [lti_group])
             get :show, params: { id: media_object.id }
@@ -1923,7 +1923,7 @@ describe MediaObjectsController, type: :controller do
   describe "#save" do
     it 'removes bookmarks that are no longer viewable' do
       media_object = FactoryBot.create(:published_media_object)
-      user = FactoryBot.create(:public)
+      user = FactoryBot.create(:user)
       bookmark = Bookmark.create(document_id: media_object.id, user: user)
       login_user media_object.collection.managers.first
       request.env["HTTP_REFERER"] = '/'
@@ -2241,7 +2241,7 @@ describe MediaObjectsController, type: :controller do
 
     context 'as end user' do
       before do
-        login_as :student
+        login_as :user
       end
 
       let(:media_object) { FactoryBot.create(:published_media_object) }

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe PlaylistsController, type: :controller do
           expect(response).to render_template(:_lti_url)
         end
         it "others: should include only lti" do
-          login_lti 'student'
+          login_lti 'user'
           lti_group = @controller.user_session[:virtual_groups].first
           get :show, params: { id: playlist.id }
           expect(response).to_not render_template(:_share_resource)

--- a/spec/controllers/samvera/persona/user_controller_spec.rb
+++ b/spec/controllers/samvera/persona/user_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Samvera::Persona::UsersController, type: :controller do
 
     describe 'DELETE #destroy' do
       before :each do
-        new_hash = {"administrator"=>[user.username], "group_manager"=>[user.username, "alice.archivist@example.edu"], "registered"=>["bob.user@example.edu"]}
+        new_hash = {"administrator"=>[user.username], "another_group"=>[user.username, "alice.archivist@example.edu"], "registered"=>["bob.user@example.edu"]}
         RoleMap.replace_with!(new_hash)
       end
       before { delete :destroy, params: { id: user.to_param } }

--- a/spec/controllers/timelines_controller_spec.rb
+++ b/spec/controllers/timelines_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe TimelinesController, type: :controller do
   end
 
   describe "GET #show" do
-    let(:cataloger) { FactoryBot.create(:cataloger)}
+    let(:cataloger) { FactoryBot.create(:user)}
     let(:timeline) { FactoryBot.create(:timeline, user: cataloger) }
     let(:encoded_manifest_url) do
       [controller.default_url_options[:protocol],
@@ -189,7 +189,7 @@ RSpec.describe TimelinesController, type: :controller do
 
       context 'non-owner' do
         before do
-          login_as :student
+          login_as :user
         end
 
         it 'renders restricted content page' do

--- a/spec/cypress/integration/navigation_spec.js
+++ b/spec/cypress/integration/navigation_spec.js
@@ -46,9 +46,7 @@ context('Navigations', () => {
     cy.contains('System Groups');
     cy.contains('Additional Groups');
     cy.contains('Group Name');
-    cy.contains('group_manager');
     cy.contains('administrator');
-    cy.contains('manager');
   });
 
   // is able to sign out

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     contact_email { Faker::Internet.email }
     website_label { Faker::Lorem.words.join(' ') }
     website_url { Faker::Internet.url }
-    managers { [FactoryBot.create(:manager).user_key] }
+    managers { [FactoryBot.create(:user).user_key] }
     editors { [FactoryBot.create(:user).user_key] }
     depositors { [FactoryBot.create(:user).user_key] }
     default_visibility { 'private' }

--- a/spec/factories/units.rb
+++ b/spec/factories/units.rb
@@ -19,8 +19,8 @@ FactoryBot.define do
     contact_email { Faker::Internet.email }
     website_label { Faker::Lorem.words.join(' ') }
     website_url { Faker::Internet.url }
-    unit_admins { [FactoryBot.create(:unit_admin).user_key] }
-    managers { [FactoryBot.create(:manager).user_key] }
+    unit_admins { [FactoryBot.create(:user).user_key] }
+    managers { [FactoryBot.create(:user).user_key] }
     editors { [FactoryBot.create(:user).user_key] }
     depositors { [FactoryBot.create(:user).user_key] }
     collections { [] }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -26,14 +26,6 @@ FactoryBot.define do
         end
       end
     end
-    factory :group_manager do
-      after(:create) do |user|
-        begin
-          Avalon::RoleControls.add_user_role(user.user_key, 'group_manager')
-        rescue
-        end
-      end
-    end
     factory :user_lti do
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -26,22 +26,6 @@ FactoryBot.define do
         end
       end
     end
-    factory :unit_administrator, aliases: [:unit_admin] do
-      after(:create) do |user|
-        begin
-          Avalon::RoleControls.add_user_role(user.user_key, 'unit_administrator')
-        rescue
-        end
-      end
-    end
-    factory :manager do
-      after(:create) do |user|
-        begin
-          Avalon::RoleControls.add_user_role(user.user_key, 'manager')
-        rescue
-        end
-      end
-    end
     factory :group_manager do
       after(:create) do |user|
         begin
@@ -58,35 +42,5 @@ FactoryBot.define do
         Identity.create!(email: user.email, password: user.password)
       end
     end
-  end
-
-  factory :cataloger, class: User  do
-    sequence(:username) {|n| "archivist#{n}" }
-    sequence(:email)    {|n| "archivist#{n}@example.com" }
-    password            { 'testing123' }
-  end
-
-  factory :content_provider, class: User  do
-    sequence(:username) {|n| "archivist#{n}" }
-    sequence(:email)    {|n| "archivist#{n}@example.com" }
-    password            { 'testing123' }
-    after(:create) do |user|
-      begin
-        Avalon::RoleControls.add_user_role(user.user_key, 'manager')
-      rescue
-      end
-    end
-  end
-
-  factory :student, class: User  do
-    sequence(:username) {|n| "ann.e.student#{n}" }
-    sequence(:email)    {|n| "student#{n}@example.com" }
-    password            { 'testing123' }
-  end
-
-  factory :public, class: User  do
-    sequence(:username) {|n| "average.joe#{n}" }
-    sequence(:email)    {|n| "average.joe#{n}@example.com" }
-    password            { 'testing123' }
   end
 end

--- a/spec/features/capybara_catalog_spec.rb
+++ b/spec/features/capybara_catalog_spec.rb
@@ -63,7 +63,7 @@ describe 'item catalog' do
   end
 
   context 'user with collection manager permissions' do
-    let(:manager) { FactoryBot.create(:manager) }
+    let(:manager) { FactoryBot.create(:user) }
     let!(:collection) { FactoryBot.create(:collection, managers: [manager.user_key]) }
     let!(:media_object) { FactoryBot.create(:fully_searchable_media_object, :with_master_file, avalon_uploader: 'admin@example.edu', collection: collection) }
 

--- a/spec/features/capybara_navigation_spec.rb
+++ b/spec/features/capybara_navigation_spec.rb
@@ -43,9 +43,7 @@ describe 'checks navigation after logging in' do
     expect(page).to have_content('System Groups')
     expect(page).to have_content('Additional Groups')
     expect(page).to have_content('Group Name')
-    expect(page).to have_content('group_manager')
     expect(page).to have_content('administrator')
-    expect(page).to have_content('manager')
   end
   it 'checks naviagtion to Playlist' do
     user = FactoryBot.create(:administrator)

--- a/spec/jobs/bulk_action_job_spec.rb
+++ b/spec/jobs/bulk_action_job_spec.rb
@@ -151,7 +151,7 @@ describe BulkActionJobs::ReturnCheckouts do
 end
 
 describe BulkActionJobs::RemoveManagers do
-  let(:users) { FactoryBot.create_list(:manager, 2) }
+  let(:users) { FactoryBot.create_list(:user, 2) }
   let(:admin) { FactoryBot.create(:admin) }
   let!(:collection1) { FactoryBot.create(:collection, managers: users.map(&:user_key)) }
   let!(:collection2) { FactoryBot.create(:collection, managers: users.map(&:user_key) + [admin.user_key]) }
@@ -162,16 +162,5 @@ describe BulkActionJobs::RemoveManagers do
     collection2.reload
     expect(collection1.managers).to eq([users[1].user_key])
     expect(collection2.managers).to eq([users[1].user_key])
-  end
-
-  context 'sole manager' do
-    let!(:collection2) { FactoryBot.create(:collection, managers: [users.first.user_key]) }
-
-    it 'does not remove the manager' do
-      expect(Rails.logger).to receive(:error).with("At least one manager is required: #{collection2.id}")
-      BulkActionJobs::RemoveManagers.perform_now([users.first.user_key])
-      collection2.reload
-      expect(collection2.managers).to eq([users.first.user_key])
-    end
   end
 end

--- a/spec/jobs/ingest_batch_status_email_jobs_spec.rb
+++ b/spec/jobs/ingest_batch_status_email_jobs_spec.rb
@@ -18,7 +18,7 @@ describe IngestBatchStatusEmailJobs do
   describe IngestBatchStatusEmailJobs::IngestFinished do
     let(:batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id) }
     let(:completed_batch_registry) { FactoryBot.create(:batch_registries, user_id: manager.id, complete: true, completed_email_sent: true) }
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:batch_mailer) { double }
 
     before do

--- a/spec/lib/avalon/batch/package_spec.rb
+++ b/spec/lib/avalon/batch/package_spec.rb
@@ -15,7 +15,7 @@
 require 'rails_helper'
 
 describe Avalon::Batch::Ingest do
-  let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+  let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
   let(:collection) { FactoryBot.build(:collection, managers: [manager.user_key]) }
   let(:manifest_file) { File.new('spec/fixtures/dropbox/example_batch_ingest/batch_manifest.xlsx') }
   let(:package) { Avalon::Batch::Package.new(manifest_file, collection) }

--- a/spec/lib/avalon/batch_ingest_spec.rb
+++ b/spec/lib/avalon/batch_ingest_spec.rb
@@ -31,16 +31,12 @@ describe Avalon::Batch::Ingest do
 
     FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com')
     FactoryBot.create(:user, username: 'jay@krajcik.org', email: 'jay@krajcik.org')
-    Avalon::RoleControls.add_user_role('frances.dickens@reichel.com','manager')
-    Avalon::RoleControls.add_user_role('jay@krajcik.org','manager')
     allow(IngestBatchEntryJob).to receive(:perform_later).and_return(nil)
   end
 
   after :each do
     Settings.dropbox.path = @saved_dropbox_path
     Dir['spec/fixtures/**/*.xlsx.process*','spec/fixtures/**/*.xlsx.error'].each { |file| File.delete(file) }
-    Avalon::RoleControls.remove_user_role('frances.dickens@reichel.com','manager')
-    Avalon::RoleControls.remove_user_role('jay@krajcik.org','manager')
 
     # this is a test environment, we don't want to kick off
     # generation jobs if possible

--- a/spec/lib/avalon/dropbox_spec.rb
+++ b/spec/lib/avalon/dropbox_spec.rb
@@ -21,7 +21,6 @@ describe Avalon::Dropbox do
   describe "#delete" do
     before :each do
       FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com')
-      Avalon::RoleControls.add_user_role('frances.dickens@reichel.com','manager')
     end
 
     let(:collection) { FactoryBot.create(:collection, name: 'Ut minus ut accusantium odio autem odit.', managers: ['frances.dickens@reichel.com']) }

--- a/spec/mailers/batch_registries_mailer_spec.rb
+++ b/spec/mailers/batch_registries_mailer_spec.rb
@@ -16,7 +16,7 @@ require "rails_helper"
 
 RSpec.describe BatchRegistriesMailer, type: :mailer do
   describe 'batch_ingest_validation_error' do
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:collection) { FactoryBot.create(:collection, managers: [manager.user_key]) }
     let(:manifest_file) { File.new('spec/fixtures/dropbox/example_batch_ingest/batch_manifest.xlsx') }
     let(:package) { Avalon::Batch::Package.new(manifest_file, collection) }
@@ -42,7 +42,7 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
   end
 
   describe 'batch_ingest_validation_success' do
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:collection) { FactoryBot.build(:collection, managers: [manager.user_key]) }
     let(:manifest_file) { File.new('spec/fixtures/dropbox/example_batch_ingest/batch_manifest.xlsx') }
     let(:package) { Avalon::Batch::Package.new(manifest_file, collection) }
@@ -59,7 +59,7 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
 
   describe 'batch_registration_finished_mailer' do
     let(:batch_registries) { FactoryBot.create(:batch_registries, user_id: manager.id, collection: collection.id) }
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:collection) { FactoryBot.create(:collection) }
     let!(:batch_entries) { FactoryBot.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
     let(:media_object) { FactoryBot.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }
@@ -112,7 +112,7 @@ RSpec.describe BatchRegistriesMailer, type: :mailer do
 
   describe 'batch_encoding_finished' do
     let(:batch_registries) { FactoryBot.create(:batch_registries, user_id: manager.id, collection: collection.id) }
-    let(:manager) { FactoryBot.create(:manager, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
+    let(:manager) { FactoryBot.create(:user, username: 'frances.dickens@reichel.com', email: 'frances.dickens@reichel.com') }
     let(:collection) { FactoryBot.create(:collection) }
     let!(:batch_entries) { FactoryBot.create(:batch_entries, batch_registries: batch_registries, media_object_pid: media_object.id, complete: true) }
     let(:media_object) { FactoryBot.create(:media_object, collection: collection, permalink: "http://localhost:3000/media_objects/kfd39dnw") }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -30,12 +30,33 @@ describe Admin::Collection do
       end
     end
 
+    context 'when unit admin' do
+      let(:ability) { Ability.new(user) }
+
+      context 'inherited from unit' do
+        let(:user) { User.where(Devise.authentication_keys.first => collection.inherited_managers.first).first }
+
+        it "can perform all actions on collections" do
+          expect(ability).to be_able_to(:create, Admin::Collection)
+          expect(ability).to be_able_to(:read, Admin::Collection)
+          expect(ability).to be_able_to(:read, collection)
+          expect(ability).to be_able_to(:update, collection)
+          expect(ability).to be_able_to(:update_unit, collection)
+          expect(ability).to be_able_to(:update_managers, collection)
+          expect(ability).to be_able_to(:update_editors, collection)
+          expect(ability).to be_able_to(:update_depositors, collection)
+          expect(ability).to be_able_to(:update_access_control, collection)
+          expect(ability).to be_able_to(:destroy, collection)
+        end
+      end
+    end
+
     context 'when manager' do
       let(:ability) { Ability.new(user) }
       let(:user) { User.where(Devise.authentication_keys.first => collection.managers.first).first }
 
-      it "can perform all actions on collection" do
-        expect(ability).to be_able_to(:create, Admin::Collection)
+      it "can perform all actions on existing collections" do
+        expect(ability).not_to be_able_to(:create, Admin::Collection)
         expect(ability).to be_able_to(:read, Admin::Collection)
         expect(ability).to be_able_to(:read, collection)
         expect(ability).to be_able_to(:update, collection)
@@ -48,10 +69,10 @@ describe Admin::Collection do
       end
 
       context 'inherited from unit' do
-        let(:user) { User.where(Devise.authentication_keys.first => collection.inherited_managers.first).first }
+        let(:user) { User.where(Devise.authentication_keys.first => collection.unit.collection_managers.first).first }
 
-        it "can perform all actions on collection" do
-          expect(ability).to be_able_to(:create, Admin::Collection)
+        it "can perform all actions on existing collections" do
+          expect(ability).not_to be_able_to(:create, Admin::Collection)
           expect(ability).to be_able_to(:read, Admin::Collection)
           expect(ability).to be_able_to(:read, collection)
           expect(ability).to be_able_to(:update, collection)
@@ -181,7 +202,7 @@ describe Admin::Collection do
                         contact_email: contact_email, website_url: website_url, website_label: website_label)
     end
     let(:unit) { FactoryBot.create(:unit) }
-    let(:manager) {FactoryBot.create(:manager)}
+    let(:manager) {FactoryBot.create(:user)}
     let(:editor) {FactoryBot.create(:user)}
     let(:depositor) {FactoryBot.create(:user)}
     let(:contact_email) { Faker::Internet.email }
@@ -243,7 +264,7 @@ describe Admin::Collection do
   end
 
   describe "managers" do
-    let!(:user) { FactoryBot.create(:manager) }
+    let!(:user) { FactoryBot.create(:user) }
     let!(:collection) { Admin::Collection.new(unit: FactoryBot.create(:unit)) }
 
     describe "#managers" do
@@ -255,18 +276,18 @@ describe Admin::Collection do
     end
     describe "#managers=" do
       it "should add managers to the collection" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         collection.managers = manager_list
         expect(collection.managers).to match_array(manager_list)
       end
       it "should call add_manager" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         expect(collection).to receive("add_manager").with(manager_list[0])
         expect(collection).to receive("add_manager").with(manager_list[1])
         collection.managers = manager_list
       end
       it "should remove managers from the collection" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         collection.managers = manager_list
         expect(collection.managers).to match_array(manager_list)
         collection.managers -= [manager_list[1]]
@@ -275,13 +296,7 @@ describe Admin::Collection do
       it "should call remove_manager" do
         collection.managers = [user.user_key]
         expect(collection).to receive("remove_manager").with(user.user_key)
-        collection.managers = [FactoryBot.create(:manager).user_key]
-      end
-      it "should fail to remove only manager" do
-        manager_list = [FactoryBot.create(:manager).user_key]
-        collection.managers = manager_list
-        expect(collection.managers).to match_array(manager_list)
-        expect{collection.managers=[]}.to raise_error(ArgumentError)
+        collection.managers = [FactoryBot.create(:user).user_key]
       end
     end
     describe "#add_manager" do
@@ -303,10 +318,10 @@ describe Admin::Collection do
         collection.add_manager(administrator.user_key)
         expect(collection.editors).not_to include(administrator.user_key)
       end
-      it "should not add users who do not have the manager role" do
+      it "should add users who do not have the manager role" do
         not_manager = FactoryBot.create(:user)
-        expect {collection.add_manager(not_manager.user_key)}.to raise_error(ArgumentError)
-        expect(collection.managers).not_to include(not_manager.user_key)
+        expect {collection.add_manager(not_manager.user_key)}.not_to raise_error(ArgumentError)
+        expect(collection.managers).to include(not_manager.user_key)
       end
     end
     describe "#remove_manager" do
@@ -332,7 +347,7 @@ describe Admin::Collection do
 
     describe "#editors" do
       it "should not return managers" do
-        manager = FactoryBot.create(:manager)
+        manager = FactoryBot.create(:user)
         collection.edit_users = [user.user_key, manager.user_key]
         collection.collection_managers = [manager.user_key]
         expect(collection.editors).to eq([user.user_key])
@@ -362,12 +377,6 @@ describe Admin::Collection do
         expect(collection).to receive("remove_editor").with(user.user_key)
         collection.editors = [FactoryBot.create(:user).user_key]
       end
-      it "can add users who belong to manager group" do
-        manager = FactoryBot.create(:manager)
-        collection.editors = [manager.user_key]
-        expect(collection.editors).to include(manager.user_key)
-        expect(collection.managers).not_to include(manager.user_key)
-      end
       it "can add users who belong to administrator group" do
         admin = FactoryBot.create(:administrator)
         collection.editors = [admin.user_key]
@@ -393,7 +402,7 @@ describe Admin::Collection do
         expect(collection.editors).not_to include(user.user_key)
       end
       it "should not remove users who do not have the editor role" do
-        not_editor = FactoryBot.create(:manager)
+        not_editor = FactoryBot.create(:user)
         collection.collection_managers = [not_editor.user_key]
         collection.edit_users = [not_editor.user_key]
         collection.inherited_edit_users = [not_editor.user_key]
@@ -463,7 +472,7 @@ describe Admin::Collection do
         expect(collection.depositors).not_to include(user.user_key)
       end
       it "should not remove users who do not have the depositor role" do
-        not_depositor = FactoryBot.create(:manager)
+        not_depositor = FactoryBot.create(:user)
         collection.inherited_edit_users = [not_depositor.user_key]
         collection.remove_depositor(not_depositor.user_key)
         expect(collection.inherited_edit_users).to include(not_depositor.user_key)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -502,7 +502,7 @@ describe Admin::Collection do
     let(:unit) { collection.unit }
     before do
       unit.default_read_users = ['test']
-      unit.default_read_groups = ['123.234.211.1', 'virtual', 'group_manager']
+      unit.default_read_groups = ['123.234.211.1', 'virtual', 'another_group']
       unit.save!
     end
 

--- a/spec/models/role_map_spec.rb
+++ b/spec/models/role_map_spec.rb
@@ -24,7 +24,7 @@ describe RoleMap do
       RoleMap.all.each(&:destroy)
     end
 
-    let(:expected_role_map) { { "administrator" => ["archivist1@example.com"], "group_manager" => ["archivist1@example.com"], "manager" => ["archivist1@example.com"], "unit_administrator" => ["archivist1@example.com"] } }
+    let(:expected_role_map) { { "administrator" => ["archivist1@example.com"] } }
 
     it "should properly initialize the map" do
       expect(RoleMapper.map).to eq expected_role_map

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SearchBuilder do
 
   let(:processor_chain) { [] }
   let(:scope) { CatalogController.new }
-  let(:manager) { FactoryBot.create(:manager) }
+  let(:manager) { FactoryBot.create(:user) }
   let(:ability) { Ability.new(manager) }
 
   describe "#only_published_items" do

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -34,7 +34,7 @@ describe Admin::Unit do
       let(:user) { User.where(Devise.authentication_keys.first => unit.unit_administrators.first).first }
 
       it "can perform all actions on the unit" do
-        expect(ability).to be_able_to(:create, Admin::Unit)
+        expect(ability).not_to be_able_to(:create, Admin::Unit)
         expect(ability).to be_able_to(:read, Admin::Unit)
         expect(ability).to be_able_to(:read, unit)
         expect(ability).to be_able_to(:update, unit)
@@ -147,7 +147,7 @@ describe Admin::Unit do
                         unit_admins: [unit_admin.user_key], editors: [editor.user_key], depositors: [depositor.user_key],
                         contact_email: contact_email, website_url: website_url, website_label: website_label)
     end
-    let(:unit_admin) { FactoryBot.create(:unit_admin) }
+    let(:unit_admin) { FactoryBot.create(:user) }
     let(:editor) { FactoryBot.create(:user) }
     let(:depositor) { FactoryBot.create(:user) }
     let(:contact_email) { Faker::Internet.email }
@@ -207,7 +207,7 @@ describe Admin::Unit do
   end
 
   describe "managers" do
-    let!(:user) { FactoryBot.create(:manager) }
+    let!(:user) { FactoryBot.create(:user) }
     let!(:unit) { Admin::Unit.new }
 
     describe "#managers" do
@@ -219,18 +219,18 @@ describe Admin::Unit do
     end
     describe "#managers=" do
       it "should add managers to the unit" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         unit.managers = manager_list
         expect(unit.managers).to eq(manager_list)
       end
       it "should call add_manager" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         expect(unit).to receive("add_manager").with(manager_list[0])
         expect(unit).to receive("add_manager").with(manager_list[1])
         unit.managers = manager_list
       end
       it "should remove managers from the unit" do
-        manager_list = [FactoryBot.create(:manager).user_key, FactoryBot.create(:manager).user_key]
+        manager_list = [FactoryBot.create(:user).user_key, FactoryBot.create(:user).user_key]
         unit.managers = manager_list
         expect(unit.managers).to eq(manager_list)
         unit.managers -= [manager_list[1]]
@@ -239,13 +239,7 @@ describe Admin::Unit do
       it "should call remove_manager" do
         unit.managers = [user.user_key]
         expect(unit).to receive("remove_manager").with(user.user_key)
-        unit.managers = [FactoryBot.create(:manager).user_key]
-      end
-      it "should fail to remove only manager" do
-        manager_list = [FactoryBot.create(:manager).user_key]
-        unit.managers = manager_list
-        expect(unit.managers).to eq(manager_list)
-        expect { unit.managers = [] }.to raise_error(ArgumentError)
+        unit.managers = [FactoryBot.create(:user).user_key]
       end
     end
     describe "#add_manager" do
@@ -267,10 +261,10 @@ describe Admin::Unit do
         unit.add_manager(administrator.user_key)
         expect(unit.editors).not_to include(administrator.user_key)
       end
-      it "should not add users who do not have the manager role" do
+      it "should add users who do not have the manager role" do
         not_manager = FactoryBot.create(:user)
-        expect { unit.add_manager(not_manager.user_key) }.to raise_error(ArgumentError)
-        expect(unit.managers).not_to include(not_manager.user_key)
+        expect { unit.add_manager(not_manager.user_key) }.not_to raise_error(ArgumentError)
+        expect(unit.managers).to include(not_manager.user_key)
       end
     end
     describe "#remove_manager" do
@@ -296,7 +290,7 @@ describe Admin::Unit do
 
     describe "#editors" do
       it "should not return managers" do
-        unit_admin = FactoryBot.create(:unit_admin)
+        unit_admin = FactoryBot.create(:user)
         unit.edit_users = [user.user_key, unit_admin.user_key]
         unit.unit_administrators = [unit_admin.user_key]
         expect(unit.editors).to eq([user.user_key])
@@ -326,12 +320,6 @@ describe Admin::Unit do
         expect(unit).to receive("remove_editor").with(user.user_key)
         unit.editors = [FactoryBot.create(:user).user_key]
       end
-      # it "can add users who belong to manager group" do
-      #   manager = FactoryBot.create(:manager)
-      #   unit.editors = [manager.user_key]
-      #   expect(unit.editors).to include(manager.user_key)
-      #   expect(unit.managers).not_to include(manager.user_key)
-      # end
       it "can add users who belong to administrator group" do
         admin = FactoryBot.create(:administrator)
         unit.editors = [admin.user_key]
@@ -357,7 +345,7 @@ describe Admin::Unit do
         expect(unit.editors).not_to include(user.user_key)
       end
       it "should not remove users who do not have the editor role" do
-        not_editor = FactoryBot.create(:unit_admin)
+        not_editor = FactoryBot.create(:user)
         unit.unit_admins = [not_editor.user_key]
         unit.edit_users = [not_editor.user_key]
         unit.inherited_edit_users = [not_editor.user_key]
@@ -369,7 +357,7 @@ describe Admin::Unit do
     describe "#editors_managers_and_unit_admins" do
       it "should return all unit editors, managers, and unit admins" do
         editor = FactoryBot.create(:user)
-        manager = FactoryBot.create(:manager)
+        manager = FactoryBot.create(:user)
         unit.edit_users = [user.user_key, manager, editor.user_key]
         unit.unit_administrators = [user.user_key]
         unit.managers = [manager.user_key]
@@ -431,7 +419,7 @@ describe Admin::Unit do
         expect(unit.depositors).not_to include(user.user_key)
       end
       it "should not remove users who do not have the depositor role" do
-        not_depositor = FactoryBot.create(:unit_admin)
+        not_depositor = FactoryBot.create(:user)
         unit.inherited_edit_users = [not_depositor.user_key]
         unit.remove_depositor(not_depositor.user_key)
         expect(unit.inherited_edit_users).to include(not_depositor.user_key)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -148,30 +148,30 @@ describe User do
 
   describe "#destroy" do
     it 'removes bookmarks for user' do
-      user = FactoryBot.create(:public)
+      user = FactoryBot.create(:user)
       bookmark = Bookmark.create(document_id: Faker::Number.digit, user: user)
       expect { user.destroy }.to change { Bookmark.exists? bookmark.id }.from( true ).to( false )
     end
     it 'removes checkouts for user' do
-      user = FactoryBot.create(:public)
+      user = FactoryBot.create(:user)
       active_checkout = FactoryBot.create(:checkout, user_id: user.id)
       returned_checkout = FactoryBot.create(:checkout, user_id: user.id, return_time: DateTime.current - 1.day)
       expect { user.destroy }.to change { Checkout.all.count }.from(2).to(0)
     end
     it 'removes playlists for user' do
-      user = FactoryBot.create(:public)
+      user = FactoryBot.create(:user)
       playlist = FactoryBot.create(:playlist, user_id: user.id)
       expect { user.destroy }.to change { Playlist.exists? playlist.id }.from( true ).to( false )
     end
     it 'removes timelines for user' do
-      user = FactoryBot.create(:public)
+      user = FactoryBot.create(:user)
       timeline = FactoryBot.create(:timeline, user_id: user.id)
       expect { user.destroy }.to change { Timeline.exists? timeline.id }.from( true ).to( false )
     end
   end
 
   describe '#timeline_tags' do
-    let(:user) { FactoryBot.create(:public) }
+    let(:user) { FactoryBot.create(:user) }
 
     it 'is empty when the user has no timeline tags' do
       expect(user.timeline_tags).to be_empty

--- a/spec/presenters/admin_collection_presenter_spec.rb
+++ b/spec/presenters/admin_collection_presenter_spec.rb
@@ -21,9 +21,9 @@ describe Admin::CollectionPresenter do
   let(:unit_name) { "Default Unit" }
   let(:description) { "The long form description of this collection." }
   let(:managers) { [manager.to_s] }
-  let(:editors) { [editor.to_s, FactoryBot.create(:manager).to_s] }
+  let(:editors) { [editor.to_s, FactoryBot.create(:user).to_s] }
   let(:depositors) { [depositor.to_s] }
-  let(:manager) { FactoryBot.create(:manager) }
+  let(:manager) { FactoryBot.create(:user) }
   let(:editor) { FactoryBot.create(:user) }
   let(:depositor) { FactoryBot.create(:user) }
   let(:unit) { FactoryBot.create(:unit, name: unit_name) }

--- a/spec/presenters/admin_unit_presenter_spec.rb
+++ b/spec/presenters/admin_unit_presenter_spec.rb
@@ -21,10 +21,10 @@ describe Admin::UnitPresenter do
   let(:description) { "The long form description of this unit." }
   let(:unit_admins) { [unit_admin.to_s] }
   let(:managers) { [manager.to_s] }
-  let(:editors) { [editor.to_s, FactoryBot.create(:manager), FactoryBot.create(:unit_admin)] }
+  let(:editors) { [editor.to_s, FactoryBot.create(:user), FactoryBot.create(:user)] }
   let(:depositors) { [depositor.to_s] }
-  let(:unit_admin) { FactoryBot.create(:unit_admin) }
-  let(:manager) { FactoryBot.create(:manager) }
+  let(:unit_admin) { FactoryBot.create(:user) }
+  let(:manager) { FactoryBot.create(:user) }
   let(:editor) { FactoryBot.create(:user) }
   let(:depositor) { FactoryBot.create(:user) }
   let(:solr_doc) do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -13,7 +13,7 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 module ControllerMacros
-  def login_as(factory_model = 'student', options = {})
+  def login_as(factory_model = 'user', options = {})
     user = FactoryBot.create(factory_model, options)
     @request.env["devise.mapping"] = Devise.mappings[:user]
     Rails.logger.debug "Attempting to sign in user: #{user}"
@@ -28,7 +28,7 @@ module ControllerMacros
     sign_in user
     user
   end
-  def login_lti(factory_model = 'student', lti_class = Faker::Lorem.word, options = {})
+  def login_lti(factory_model = 'user', lti_class = Faker::Lorem.word, options = {})
     user = FactoryBot.create(factory_model, options)
     @request.env["devise.mapping"] = Devise.mappings[:user]
     Rails.logger.debug "Attempting to sign in user: #{user}"


### PR DESCRIPTION
Resolves #6158 and #6674

With these changes `unit_administrator`, `manager`, and `group_manager` would no longer be system groups and would not get created with new avalon instances.  The groups would continue to live on in existing avalon instances but would not have any special permissions.