### PR TITLE
Limit external group autocomplete results to 10 LDAP and 10 course entries

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,7 +16,7 @@ class Course < ActiveRecord::Base
 #  attr_accessible :context_id, :label, :title
 
   def self.autocomplete(query, _id = nil)
-    self.where("label LIKE :q OR title LIKE :q", q: "%#{query}%").collect { |course|
+    self.where("label LIKE :q OR title LIKE :q", q: "%#{query}%").limit(10).collect { |course|
       { id: course.context_id, display: course.title }
     }
   end

--- a/app/models/external_group.rb
+++ b/app/models/external_group.rb
@@ -29,7 +29,7 @@ class ExternalGroup
 
   def self.ldap_autocomplete(query)
     #Only wildcard the tail of the query to avoid long running queries
-    self.ldap_lookup("#{query}*", size: 10)
+    self.ldap_lookup("#{query}*").first(10)
   end
 
   def self.autocomplete(query, _id = nil)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -39,4 +39,14 @@ describe Course do
     expect(first_media_object.read_groups).to include('sociology_101')
     expect(first_media_object.read_groups).to include('underwater_basketweaving_302')
   end
+
+  describe 'autocomplete' do
+    before do
+      10.times { Course.create(title: 'Test') }
+    end
+
+    it 'limits to 10 results' do
+      expect(Course.autocomplete('Test').size).to eq 10
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -42,7 +42,7 @@ describe Course do
 
   describe 'autocomplete' do
     before do
-      10.times { Course.create(title: 'Test') }
+      11.times { Course.create(title: 'Test') }
     end
 
     it 'limits to 10 results' do

--- a/spec/models/external_group_spec.rb
+++ b/spec/models/external_group_spec.rb
@@ -30,4 +30,9 @@ describe ExternalGroup do
     expect( ExternalGroup.ldap_lookup('Group') ).to eq( [{id:'Group1',display:'Group1'},{id:'Group2',display:'Group2'}] )
     expect( ExternalGroup.autocomplete('Group') ). to eq( ExternalGroup.ldap_lookup('Group') )
   end
+  it "autocomplete limits to 10 results" do
+    results = (1..15).collect { |i| {id:'Group#{i}',display:'Group#{i}'} }
+    allow(ExternalGroup).to receive(:ldap_lookup).and_return(results)
+    expect(ExternalGroup.autocomplete('Test').size).to eq 10
+  end
 end


### PR DESCRIPTION
LDAP lookups are not limited and can lead to autocomplete dropdowns and are really really long.
<img width="341" height="1092" alt="image" src="https://github.com/user-attachments/assets/ab5e99d7-1bb7-4ed4-8160-7fc731881143" />

This PR limits the LDAP lookup to 10 results and the course lookup to 10 results so the maximum number of results in the dropdown is 20.  We may want to limit this further.