### PR TITLE
Fix unit deletion and add auth checks on target unit/collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -225,7 +225,7 @@ class Admin::CollectionsController < ApplicationController
       if @source_collection.media_objects.all?(&:valid?)
         @target_collection = Admin::Collection.find(params[:target_collection_id])
         authorize! :update, @target_collection
-        Admin::Collection.reassign_media_objects( @source_collection.media_objects, @source_collection, @target_collection )
+        Admin::Collection.reassign_media_objects( @source_collection.media_objects, @target_collection )
         target_path = admin_collection_path(@target_collection)
         @source_collection.reload
       else

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -214,7 +214,7 @@ class Admin::CollectionsController < ApplicationController
     @collection = Admin::Collection.find(params['id'])
     authorize! :destroy, @collection
     @objects    = @collection.media_objects
-    @candidates = get_user_collections.reject { |c| c == @collection }
+    @candidates = get_user_collections.reject { |c| c.id == @collection.id }.sort_by { |c| c.name.downcase }
   end
 
   # DELETE /collections/1
@@ -224,6 +224,7 @@ class Admin::CollectionsController < ApplicationController
     if @source_collection.media_objects.count > 0
       if @source_collection.media_objects.all?(&:valid?)
         @target_collection = Admin::Collection.find(params[:target_collection_id])
+        authorize! :update, @target_collection
         Admin::Collection.reassign_media_objects( @source_collection.media_objects, @source_collection, @target_collection )
         target_path = admin_collection_path(@target_collection)
         @source_collection.reload

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -330,10 +330,10 @@ class Admin::UnitsController < ApplicationController
     fastimage.type == :png && fastimage.size == [700, 560] # [width, height]
   end
 
-  # Returns collections for current_user
-  # @return [Collection] Collections to which current_user has manage access
+  # Returns units for current_user
+  # @return [Unit] Units to which current_user has manage access
   def get_user_units
-    # return all collections to admin
+    # return all units to admin
     if can?(:manage, Admin::Unit)
       SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
     else

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -212,7 +212,7 @@ class Admin::UnitsController < ApplicationController
         @target_unit = Admin::Unit.find(params[:target_unit_id])
         # raise if user not admin of target unit
         authorize! :update, @target_unit
-        Admin::Unit.reassign_collections( @source_unit.collections, @source_unit, @target_unit )
+        Admin::Unit.reassign_collections( @source_unit.collections, @target_unit )
         target_path = admin_unit_path(@target_unit)
         @source_unit.reload
       else

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -106,7 +106,7 @@ class Admin::UnitsController < ApplicationController
       end
       respond_to do |format|
         format.html do
-          redirect_to @unit, notice: 'unit was successfully created.'
+          redirect_to @unit, notice: 'Unit was successfully created.'
         end
         format.json do
           render json: { id: @unit.id }, status: 200
@@ -200,6 +200,7 @@ class Admin::UnitsController < ApplicationController
     @unit = Admin::Unit.find(params['id'])
     authorize! :destroy, @unit
     @objects    = @unit.collections
+    @candidates = get_user_units.reject { |u| u.id == @unit.id }.sort_by { |u| u.name.downcase }
   end
 
   # DELETE /units/1
@@ -209,6 +210,8 @@ class Admin::UnitsController < ApplicationController
     if @source_unit.collections.count > 0
       if @source_unit.collections.all?(&:valid?)
         @target_unit = Admin::Unit.find(params[:target_unit_id])
+        # raise if user not admin of target unit
+        authorize! :update, @target_unit
         Admin::Unit.reassign_collections( @source_unit.collections, @source_unit, @target_unit )
         target_path = admin_unit_path(@target_unit)
         @source_unit.reload
@@ -325,5 +328,16 @@ class Admin::UnitsController < ApplicationController
     fastimage = FastImage.new(poster_path)
     # Size derived from width and aspect ratio from JS code, assets/javascript/crop_upload.js:60-63
     fastimage.type == :png && fastimage.size == [700, 560] # [width, height]
+  end
+
+  # Returns collections for current_user
+  # @return [Collection] Collections to which current_user has manage access
+  def get_user_units
+    # return all collections to admin
+    if can?(:manage, Admin::Unit)
+      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
+    else
+      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
+    end
   end
 end

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -161,7 +161,7 @@ class Admin::Collection < ActiveFedora::Base
     (users - inherited_edit_users).each { |u| add_edit_user(u) }
   end
 
-  def self.reassign_media_objects( media_objects, source_collection, target_collection)
+  def self.reassign_media_objects( media_objects, target_collection)
     media_objects.each do |media_object|
       media_object.collection = target_collection
       media_object.save

--- a/app/models/admin/unit.rb
+++ b/app/models/admin/unit.rb
@@ -219,7 +219,7 @@ class Admin::Unit < ActiveFedora::Base
     search_array.map { |value| { id: value[:id], display: value[:name_ssi] } }
   end
 
-  def self.reassign_collections(collections, source_unit, target_unit)
+  def self.reassign_collections(collections, target_unit)
     collections.each do |collection|
       collection.unit = target_unit
       collection.save

--- a/app/models/admin/unit.rb
+++ b/app/models/admin/unit.rb
@@ -219,6 +219,13 @@ class Admin::Unit < ActiveFedora::Base
     search_array.map { |value| { id: value[:id], display: value[:name_ssi] } }
   end
 
+  def self.reassign_collections(collections, source_unit, target_unit)
+    collections.each do |collection|
+      collection.unit = target_unit
+      collection.save
+    end
+  end
+
   private
 
   def remove_edit_user(name)

--- a/app/views/admin/units/remove.html.erb
+++ b/app/views/admin/units/remove.html.erb
@@ -57,7 +57,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= bootstrap_form_for @unit, method: :delete do |f| %>
       <% if @objects.count > 0 %>
 
-      <h2>Reassign Existing collections</h2>
+      <h2>Reassign Existing Collections</h2>
       <p>
         <b><%=@unit.name%></b> currently contains <%=collection_count%>. Before you can
         delete it, you must select a new unit to move <%=content_pronoun%>

--- a/app/views/admin/units/remove.html.erb
+++ b/app/views/admin/units/remove.html.erb
@@ -44,7 +44,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <div class="row" style="padding-top: 3rem;">
   <div class="col-md-8 offset-2">
     <%
-    item_count = "#{@objects.count} #{'item'.pluralize(@objects.count)}"
+    collection_count = "#{@objects.count} #{'collection'.pluralize(@objects.count)}"
     content_pronoun = @objects.count > 1 ? 'them' : 'it'
     %>
 
@@ -57,14 +57,14 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= bootstrap_form_for @unit, method: :delete do |f| %>
       <% if @objects.count > 0 %>
 
-      <h2>Reassign Existing Items</h2>
+      <h2>Reassign Existing collections</h2>
       <p>
-        <b><%=@unit.name%></b> currently contains <%=item_count%>. Before you can
+        <b><%=@unit.name%></b> currently contains <%=collection_count%>. Before you can
         delete it, you must select a new unit to move <%=content_pronoun%>
         into.
       </p>
       <div class="mb-3">
-        <%= select_tag :target_unit_id, options_from_unit_for_select(@candidates, "id", "name"), class: "form-control p-0" %>
+        <%= select_tag :target_unit_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control p-0" %>
       </div>
     <% end %>
 
@@ -75,7 +75,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
     <% else %>
     <div class="alert alert-danger">
-      The unit "<%=@unit.name%>" cannot be deleted. It contains <%=item_count%>,
+      The unit "<%=@unit.name%>" cannot be deleted. It contains <%=collection_count%>,
       but you do not have sufficient rights to any other units to reassign <%=content_pronoun%>.
     </div>
     <%= link_to 'Go back', :back, class: 'btn btn-primary' %>

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -594,7 +594,7 @@ describe Admin::CollectionsController, type: :controller do
     context 'when not unit admin of target unit' do
       let!(:target_collection) { FactoryBot.create(:collection) }
 
-      it "destroys collection and reassigns items to target collection" do
+      it "redirects to restricted content page" do
         login_user collection.managers.first
         expect(controller.current_ability.can? :destroy, collection).to eq true
         expect(controller.current_ability.can? :update, target_collection).to eq false

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -562,6 +562,7 @@ describe Admin::CollectionsController, type: :controller do
 
   describe "#remove" do
     let!(:collection) { FactoryBot.create(:collection) }
+    let!(:media_object) { FactoryBot.create(:media_object, collection: collection) }
 
     it "redirects to restricted content page when user does not have ability to delete collection" do
       login_as :user
@@ -572,6 +573,36 @@ describe Admin::CollectionsController, type: :controller do
       login_user collection.managers.first
       expect(controller.current_ability.can? :destroy, collection).to be_truthy
       expect(get :remove, params: { id: collection.id }).to render_template(:remove)
+      expect(response.body).to include "contains 1 item"
+    end
+  end
+
+  describe '#destroy' do
+    let!(:collection) { FactoryBot.create(:collection) }
+    let!(:target_collection) { FactoryBot.create(:collection, managers: [collection.managers.first]) }
+    let!(:media_object) { FactoryBot.create(:media_object, collection: collection) }
+
+    it "destroys collection and reassigns items to target collection" do
+      login_user collection.managers.first
+      expect(controller.current_ability.can? :destroy, collection).to eq true
+      expect(controller.current_ability.can? :update, target_collection).to eq true
+      expect { delete :destroy, params: { id: collection.id, target_collection_id: target_collection.id } }.to change { Admin::Collection.count }.by(-1)
+      expect(Admin::Collection.exists?(collection.id)).to eq false
+      expect(target_collection.reload.media_objects).to include media_object
+    end
+
+    context 'when not unit admin of target unit' do
+      let!(:target_collection) { FactoryBot.create(:collection) }
+
+      it "destroys collection and reassigns items to target collection" do
+        login_user collection.managers.first
+        expect(controller.current_ability.can? :destroy, collection).to eq true
+        expect(controller.current_ability.can? :update, target_collection).to eq false
+        expect { delete :destroy, params: { id: collection.id, target_collection_id: target_collection.id } }.not_to change { Admin::Collection.count }
+        expect(Admin::Collection.exists?(collection.id)).to eq true
+        expect(target_collection.reload.media_objects).not_to include media_object
+        expect(response).to have_rendered('errors/restricted_pid')
+      end
     end
   end
 

--- a/spec/controllers/admin_units_controller_spec.rb
+++ b/spec/controllers/admin_units_controller_spec.rb
@@ -439,6 +439,7 @@ describe Admin::UnitsController, type: :controller do
 
   describe "#remove" do
     let!(:unit) { FactoryBot.create(:unit) }
+    let!(:collection) { FactoryBot.create(:collection, unit: unit) }
 
     it "redirects to restricted content page when user does not have ability to delete unit" do
       login_as :user
@@ -449,6 +450,36 @@ describe Admin::UnitsController, type: :controller do
       login_user unit.unit_admins.first
       expect(controller.current_ability.can? :destroy, unit).to be_truthy
       expect(get :remove, params: { id: unit.id }).to render_template(:remove)
+      expect(response.body).to include "contains 1 collection"
+    end
+  end
+
+  describe '#destroy' do
+    let!(:unit) { FactoryBot.create(:unit) }
+    let!(:target_unit) { FactoryBot.create(:unit, unit_admins: [unit.unit_admins.first]) }
+    let!(:collection) { FactoryBot.create(:collection, unit: unit) }
+
+    it "destroys unit and reassigns collections to target unit" do
+      login_user unit.unit_admins.first
+      expect(controller.current_ability.can? :destroy, unit).to eq true
+      expect(controller.current_ability.can? :update, target_unit).to eq true
+      expect { delete :destroy, params: { id: unit.id, target_unit_id: target_unit.id } }.to change { Admin::Unit.count }.by(-1)
+      expect(Admin::Unit.exists?(unit.id)).to eq false
+      expect(target_unit.reload.collections).to include collection
+    end
+
+    context 'when not unit admin of target unit' do
+      let!(:target_unit) { FactoryBot.create(:unit) }
+
+      it 'redirects to restricted content page' do
+        login_user unit.unit_admins.first
+        expect(controller.current_ability.can? :destroy, unit).to eq true
+        expect(controller.current_ability.can? :update, target_unit).to eq false
+        expect { delete :destroy, params: { id: unit.id, target_unit_id: target_unit.id } }.not_to change { Admin::Unit.count }
+        expect(Admin::Unit.exists?(unit.id)).to eq true
+        expect(target_unit.reload.collections).not_to include collection
+        expect(response).to have_rendered('errors/restricted_pid')
+      end
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -527,7 +527,7 @@ describe Admin::Collection do
       # @media_objects << incomplete_object
       @media_objects.map { |mo| mo.save }
       @target_collection = FactoryBot.create(:collection)
-      Admin::Collection.reassign_media_objects(@media_objects, @source_collection, @target_collection)
+      Admin::Collection.reassign_media_objects(@media_objects, @target_collection)
     end
 
     it 'sets the new collection on media_object' do


### PR DESCRIPTION
This PR builds out the unit deletion workflow and does some other smaller fixes:
- Implement auth checks on destroy for units/collections (`can? :update, @object`)
- Remove unit/collection being destroyed from target list
- Sort unit/collection target list
- Fix language on unit remove page

I made the permission requirement for target units to move collections to be that the current user is either admin or a unit admin.  This might be more restrictive than when deleting collections but I think matches the ability check (`can? :update, unit` is tied to `is_admin_of? unit`).  Should we expand this?