### PR TITLE
Override active item color in blacklight pagination

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -75,3 +75,8 @@ img.no-icon {
 .page-item span.page-link {
   color: $dark !important;
 }
+
+// Active page item in pagination
+li.page-item.active a.page-link {
+  color: #6e6e6e; // Suggestion from ANDI a11y testing tool
+}


### PR DESCRIPTION
Related issue: #6777

<img width="258" height="57" alt="Screenshot 2026-04-07 at 10 01 26 AM" src="https://github.com/user-attachments/assets/9f6403ea-497c-4169-b411-fe507c1007d3" />
