### PR TITLE
Improve handling of unit in collection creation and editing

### DIFF
--- a/app/assets/javascripts/tom_select.js
+++ b/app/assets/javascripts/tom_select.js
@@ -1,0 +1,27 @@
+const tomSelectElements = queryAll('.tom-select');
+
+tomSelectElements.forEach((el) => {
+  new TomSelect(el, {
+    searchField: ['text'],
+    sortField: [
+      { field: '$order' },
+      { field: 'text', direction: 'asc' }
+    ],
+    hideSelected: false,
+    closeAfterSelect: true,
+    placeholder: 'Search units...',
+    // Prevent clearing selection with backspace/delete
+    onDelete: function () { return false; },
+    // Hide search in control and use plugin to show search in dropdown
+    controlInput: null,
+    // Use 'Drodown Input' to add search at the top of the list
+    plugins: ['dropdown_input'],
+    render: {
+      option: function (data, escape) {
+	const isSelected = this.items.indexOf(data.value) !== -1;
+	const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
+	return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
+      },
+    },
+  });
+});

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -64,7 +64,7 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1
   def show
-    @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+    @candidate_units = get_user_units
 
     respond_to do |format|
       format.json { render json: @collection.to_json }
@@ -90,7 +90,7 @@ class Admin::CollectionsController < ApplicationController
       @candidate_units = [unit]
       @collection.unit = unit
     else
-      @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+      @candidate_units = get_user_units
     end
 
     respond_to do |format|
@@ -101,7 +101,7 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1/edit
   def edit
-    @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+    @candidate_units = get_user_units
     respond_to do |format|
       format.js   { render json: modal_form_response(@collection) }
     end
@@ -141,7 +141,7 @@ class Admin::CollectionsController < ApplicationController
       respond_to do |format|
         format.html do
           flash.now[:error] = @collection.errors.full_messages.to_sentence
-          @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+          @candidate_units = get_user_units
           render action: 'new'
         end
         format.json do

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -190,7 +190,7 @@ class Admin::CollectionsController < ApplicationController
 
     # Update governing_policy_id if unit_id changes
     update_params = collection_params.to_h
-    if update_params['unit_id'].present? && @collection.unit.id != update_params['unit_id']
+    if update_params['unit_id'].present? && @collection.unit_id != update_params['unit_id']
       new_unit = Admin::Unit.find(update_params['unit_id']) rescue nil
       if new_unit.present? && can?(:update, new_unit)
         update_params = update_params.merge({ unit_id: new_unit.id})
@@ -206,8 +206,11 @@ class Admin::CollectionsController < ApplicationController
       end
     end
 
-    @collection.update_attributes update_params if !skip_save && update_params.present?
-    saved = @collection.save unless skip_save
+    unless skip_save
+      @collection.update_attributes update_params if update_params.present?
+      saved = @collection.save
+    end
+
     if saved
       if name_changed
         User.where(Devise.authentication_keys.first => [Avalon::RoleControls.users('administrator')].flatten).each do |admin_user|

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -64,6 +64,8 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1
   def show
+    @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+
     respond_to do |format|
       format.json { render json: @collection.to_json }
       format.html {
@@ -82,6 +84,15 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/new
   def new
+    if params[:unit_id]
+      unit = Admin::Unit.find(params[:unit_id])
+      authorize! :update, unit
+      @candidate_units = [unit]
+      @collection.unit = unit
+    else
+      @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
+    end
+
     respond_to do |format|
       format.js   { render json: modal_form_response(@collection) }
       format.html { render 'new' }
@@ -90,6 +101,7 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1/edit
   def edit
+    @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
     respond_to do |format|
       format.js   { render json: modal_form_response(@collection) }
     end
@@ -103,9 +115,11 @@ class Admin::CollectionsController < ApplicationController
 
   # POST /collections
   def create
-    unit_id = collection_params['unit_id'].presence || convert_unit(collection_params["unit_name"])
-    @collection = Admin::Collection.create(collection_params.merge(unit_id: unit_id, governing_policy_id: unit_id))
-    if @collection.persisted?
+    unit = Admin::Unit.find(collection_params["unit_id"]) rescue nil
+    @collection = Admin::Collection.new(collection_params.merge(unit_id: unit&.id, governing_policy_id: unit&.id))
+    @collection.errors.add(:unit, "Owning unit for collection not found") unless unit.present?
+    @collection.errors.add(:unit, "You do not have sufficient rights to create a collection in unit #{unit.id}") unless can? :update, unit
+    if @collection.errors.blank? && @collection.save
       User.where(Devise.authentication_keys.first => [Avalon::RoleControls.users('administrator')].flatten).each do |admin_user|
         NotificationsMailer.new_collection(
           creator_id: current_user.id,
@@ -127,6 +141,7 @@ class Admin::CollectionsController < ApplicationController
       respond_to do |format|
         format.html do
           flash.now[:error] = @collection.errors.full_messages.to_sentence
+          @candidate_units = get_user_units.sort_by { |u| u.name.downcase }
           render action: 'new'
         end
         format.json do
@@ -175,10 +190,24 @@ class Admin::CollectionsController < ApplicationController
 
     # Update governing_policy_id if unit_id changes
     update_params = collection_params.to_h
-    update_params = update_params['unit_name'].present? ? update_params.merge({ unit_id: convert_unit(update_params['unit_name']) }) : update_params
-    update_params.merge!(governing_policy_id: update_params[:unit_id]) if update_params[:unit_id].present?
-    @collection.update_attributes update_params if update_params.present?
-    saved = @collection.save
+    if update_params['unit_id'].present? && @collection.unit.id != update_params['unit_id']
+      new_unit = Admin::Unit.find(update_params['unit_id']) rescue nil
+      if new_unit.present? && can?(:update, new_unit)
+        update_params = update_params.merge({ unit_id: new_unit.id})
+        update_params.merge!(governing_policy_id: new_unit.id)
+      elsif new_unit.present?
+        not_authed_msg = "You do not have sufficient privileges to move this collection to unit #{update_params['unit_id']}"
+        @collection.errors.add(:unit, not_authed_msg)
+        skip_save = true
+      else
+        not_found_msg = "Could not find unit #{update_params['unit_id']}"
+        @collection.errors.add(:unit, not_found_msg)
+        skip_save = true
+      end
+    end
+
+    @collection.update_attributes update_params if !skip_save && update_params.present?
+    saved = @collection.save unless skip_save
     if saved
       if name_changed
         User.where(Devise.authentication_keys.first => [Avalon::RoleControls.users('administrator')].flatten).each do |admin_user|
@@ -195,7 +224,7 @@ class Admin::CollectionsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        flash[:notice] = Array(flash[:notice]) + @collection.errors.full_messages unless @collection.valid?
+        flash[:notice] = Array(flash[:notice]) + @collection.errors.full_messages if @collection.errors.present? || !@collection.valid?
         redirect_to @collection
       end
       format.json do
@@ -387,9 +416,5 @@ class Admin::CollectionsController < ApplicationController
     fastimage = FastImage.new(poster_path)
     # Size derived from width and aspect ratio from JS code, assets/javascript/crop_upload.js:60-63
     fastimage.type == :png && fastimage.size == [700, 560] # [width, height]
-  end
-
-  def convert_unit(unit_name)
-    Admin::Unit.where(name_ssi: unit_name).first&.id
   end
 end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -329,15 +329,4 @@ class Admin::UnitsController < ApplicationController
     # Size derived from width and aspect ratio from JS code, assets/javascript/crop_upload.js:60-63
     fastimage.type == :png && fastimage.size == [700, 560] # [width, height]
   end
-
-  # Returns units for current_user
-  # @return [Unit] Units to which current_user has manage access
-  def get_user_units
-    # return all units to admin
-    if can?(:manage, Admin::Unit)
-      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
-    else
-      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
-    end
-  end
 end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -200,7 +200,7 @@ class Admin::UnitsController < ApplicationController
     @unit = Admin::Unit.find(params['id'])
     authorize! :destroy, @unit
     @objects    = @unit.collections
-    @candidates = get_user_units.reject { |u| u.id == @unit.id }.sort_by { |u| u.name.downcase }
+    @candidates = get_user_units.reject { |u| u.id == @unit.id }
   end
 
   # DELETE /units/1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,6 +147,18 @@ class ApplicationController < ActionController::Base
   end
   helper_method :get_user_collections
 
+  # Returns collections for current_user
+  # @return [Collection] Collections to which current_user has manage access
+  def get_user_units
+    # return all collections to admin
+    if can?(:manage, Admin::Unit)
+      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
+    else
+      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
+    end
+  end
+  helper_method :get_user_units
+
   # Returns milliseconds from a time string of format h:m:s.s or m:s.s or s.s
   # @param [String] The time string
   # @return [float] the time string converted to milliseconds

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,15 +147,17 @@ class ApplicationController < ActionController::Base
   end
   helper_method :get_user_collections
 
-  # Returns collections for current_user
-  # @return [Collection] Collections to which current_user has manage access
-  def get_user_units
-    # return all collections to admin
+  # Returns units for current_user
+  # @return [units] Units in which current_user is a unit admin
+  def get_user_units(sort: true)
+    units = []
+    # return all units to admin
     if can?(:manage, Admin::Unit)
-      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
+      units = SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
     else
-      SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
+      units = SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
     end
+    sort ? units.sort_by { |u| u.name.downcase } : units
   end
   helper_method :get_user_units
 

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -33,7 +33,7 @@ Unless required by applicable law or agreed to in writing, software distributed
             <%= select_tag 'admin_collection[unit_id]',
                            options_from_collection_for_select(@candidate_units, "id", "name", @collection.unit&.id),
                            data: { testid: 'collection-update-unit' },
-                           class: "form-control p-0",
+                           class: "form-control p-0 tom-select",
                            disabled: !can?(:update, @collection) %>
           </div>
         <% end %>
@@ -101,30 +101,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       }
     }
     resetButton('.btn-stateful-loading');
-  });
-
-  new TomSelect('#admin_collection_unit_id', {
-    searchField: ['text'],
-    sortField: [
-      { field: '$order' },
-      { field: 'text', direction: 'asc' }
-    ],
-    hideSelected: false,
-    closeAfterSelect: true,
-    placeholder: 'Search units...',
-    // Prevent clearing selection with backspace/delete
-    onDelete: function () { return false; },
-    // Hide search in control and use plugin to show search in dropdown
-    controlInput: null,
-    // Use 'Drodown Input' to add search at the top of the list
-    plugins: ['dropdown_input'],
-    render: {
-      option: function (data, escape) {
-        const isSelected = this.items.indexOf(data.value) !== -1;
-        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
-        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
-      },
-    },
   });
 </script>
 <% end %>

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -102,5 +102,29 @@ Unless required by applicable law or agreed to in writing, software distributed
     }
     resetButton('.btn-stateful-loading');
   });
+
+  new TomSelect('#admin_collection_unit_id', {
+    searchField: ['text'],
+    sortField: [
+      { field: '$order' },
+      { field: 'text', direction: 'asc' }
+    ],
+    hideSelected: false,
+    closeAfterSelect: true,
+    placeholder: 'Search units...',
+    // Prevent clearing selection with backspace/delete
+    onDelete: function () { return false; },
+    // Hide search in control and use plugin to show search in dropdown
+    controlInput: null,
+    // Use 'Drodown Input' to add search at the top of the list
+    plugins: ['dropdown_input'],
+    render: {
+      option: function (data, escape) {
+        const isSelected = this.items.indexOf(data.value) !== -1;
+        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
+        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
+      },
+    },
+  });
 </script>
 <% end %>

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -28,17 +28,14 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div class="modal-body">
         <%= f.text_field :name, 'data-testid': 'collection-update-name' %>
         <% if @collection.new_record? || can?(:update_unit, @collection) %>
-          <div class='mb-3'>
+          <div class="mb-3">
             <label class='form-label' for='admin_unit_typeahead'>Unit</label>
-            <%= render partial: 'modules/autocomplete_input', locals: { field_name: 'admin_collection[unit_name]',
-                                                                        field_id: 'admin_unit_typeahead',
-                                                                        value: @collection.unit&.name || '',
-                                                                        model: :"Admin::Unit",
-                                                                        data: { 
-                                                                                testid: 'collection-update-unit'
-                                                                              },
-                                                                        disabled: !can?(:update, @collection) } %>
-          <div>
+            <%= select_tag 'admin_collection[unit_id]',
+                           options_from_collection_for_select(@candidate_units, "id", "name", @collection.unit&.id),
+                           data: { testid: 'collection-update-unit' },
+                           class: "form-control p-0",
+                           disabled: !can?(:update, @collection) %>
+          </div>
         <% end %>
         <%= f.text_area :description, rows: 3 ,'data-testid':'collection-update-description' %>
         <%= f.text_field :contact_email, 'data-testid': 'collection-update-contact-email' %>

--- a/app/views/admin/collections/new.html.erb
+++ b/app/views/admin/collections/new.html.erb
@@ -13,34 +13,6 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :page_scripts do %>
-<script type="text/javascript">
-  new TomSelect('#admin_collection_unit_id', {
-    searchField: ['text'],
-    sortField: [
-      { field: '$order' },
-      { field: 'text', direction: 'asc' }
-    ],
-    hideSelected: false,
-    closeAfterSelect: true,
-    placeholder: 'Search units...',
-    // Prevent clearing selection with backspace/delete
-    onDelete: function () { return false; },
-    // Hide search in control and use plugin to show search in dropdown
-    controlInput: null,
-    // Use 'Drodown Input' to add search at the top of the list
-    plugins: ['dropdown_input'],
-    render: {
-      option: function (data, escape) {
-        const isSelected = this.items.indexOf(data.value) !== -1;
-        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
-        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
-      },
-    },
-  });
-</script>
-<% end %>
-
 <div class="page-title-wrapper">
   <h1 class="page-title">New collection</h1>
 </div>
@@ -52,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
        <%= select_tag 'admin_collection[unit_id]',
                       options_from_collection_for_select(@candidate_units, "id", "name", @collection.unit&.id),
                       data: { testid: 'collection-unit' },
-                      class: "form-control p-0",
+                      class: "form-control p-0 tom-select",
                       disabled: !can?(:update, @collection) %>
     </div>
   <% end %>

--- a/app/views/admin/collections/new.html.erb
+++ b/app/views/admin/collections/new.html.erb
@@ -13,6 +13,34 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+<% content_for :page_scripts do %>
+<script type="text/javascript">
+  new TomSelect('#admin_collection_unit_id', {
+    searchField: ['text'],
+    sortField: [
+      { field: '$order' },
+      { field: 'text', direction: 'asc' }
+    ],
+    hideSelected: false,
+    closeAfterSelect: true,
+    placeholder: 'Search units...',
+    // Prevent clearing selection with backspace/delete
+    onDelete: function () { return false; },
+    // Hide search in control and use plugin to show search in dropdown
+    controlInput: null,
+    // Use 'Drodown Input' to add search at the top of the list
+    plugins: ['dropdown_input'],
+    render: {
+      option: function (data, escape) {
+        const isSelected = this.items.indexOf(data.value) !== -1;
+        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
+        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
+      },
+    },
+  });
+</script>
+<% end %>
+
 <div class="page-title-wrapper">
   <h1 class="page-title">New collection</h1>
 </div>

--- a/app/views/admin/collections/new.html.erb
+++ b/app/views/admin/collections/new.html.erb
@@ -19,18 +19,16 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= bootstrap_form_for @collection, action: 'create' do |f| %>
   <%= f.text_field :name, 'data-testid': 'collection-name' %>
   <% if @collection.new_record? || can?(:update_unit, @collection)%>
-  <div class='mb-3'>
-    <label class='form-label' for='admin_unit_typeahead'>Unit</label>
-    <%= render partial: 'modules/autocomplete_input', locals: { field_name: 'admin_collection[unit_name]',
-                                                                field_id: 'admin_unit_typeahead',
-                                                                value: @collection.unit&.name || '',
-                                                                model: :"Admin::Unit",
-                                                                data: { 
-                                                                        testid: 'collection-unit'
-                                                                      }
-                                                              } %>
-  <div>
+    <div class="mb-3">
+       <label class='form-label' for='admin_unit_typeahead'>Unit</label>
+       <%= select_tag 'admin_collection[unit_id]',
+                      options_from_collection_for_select(@candidate_units, "id", "name", @collection.unit&.id),
+                      data: { testid: 'collection-unit' },
+                      class: "form-control p-0",
+                      disabled: !can?(:update, @collection) %>
+    </div>
   <% end %>
+
   <%= f.text_area :description, rows: 3, 'data-testid':'collection-description'  %>
   <%= f.text_field :contact_email, 'data-testid':'collection-contact-email' %>
   <%= f.text_field :website_url, 'data-testid': 'collection-website-url' %>

--- a/app/views/admin/collections/remove.html.erb
+++ b/app/views/admin/collections/remove.html.erb
@@ -13,34 +13,6 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :page_scripts do %>
-<script type="text/javascript">
-  new TomSelect(getById('target_collection_id'), {
-    searchField: ['text'],
-    sortField: [
-      { field: '$order' },
-      { field: 'text', direction: 'asc' }
-    ],
-    hideSelected: false,
-    closeAfterSelect: true,
-    placeholder: 'Search collections...',
-    // Prevent clearing selection with backspace/delete
-    onDelete: function () { return false; },
-    // Hide search in control and use plugin to show search in dropdown
-    controlInput: null,
-    // Use 'Drodown Input' to add search at the top of the list
-    plugins: ['dropdown_input'],
-    render: {
-      option: function (data, escape) {
-        const isSelected = this.items.indexOf(data.value) !== -1;
-        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
-        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
-      },
-    },
-  });
-</script>
-<% end %>
-
 <div class="row" style="padding-top: 3rem;">
   <div class="col-md-8 offset-2">
     <%
@@ -71,7 +43,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         into.
       </p>
       <div class="mb-3">
-        <%= select_tag :target_collection_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control p-0" %>
+        <%= select_tag :target_collection_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control p-0 tom-select" %>
       </div>
     <% end %>
 

--- a/app/views/admin/units/remove.html.erb
+++ b/app/views/admin/units/remove.html.erb
@@ -13,34 +13,6 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% content_for :page_scripts do %>
-<script type="text/javascript">
-  new TomSelect('#target_unit_id', {
-    searchField: ['text'],
-    sortField: [
-      { field: '$order' },
-      { field: 'text', direction: 'asc' }
-    ],
-    hideSelected: false,
-    closeAfterSelect: true,
-    placeholder: 'Search units...',
-    // Prevent clearing selection with backspace/delete
-    onDelete: function () { return false; },
-    // Hide search in control and use plugin to show search in dropdown
-    controlInput: null,
-    // Use 'Drodown Input' to add search at the top of the list
-    plugins: ['dropdown_input'],
-    render: {
-      option: function (data, escape) {
-        const isSelected = this.items.indexOf(data.value) !== -1;
-        const selectedClass = isSelected ? 'ts-option-custom selected-option' : 'ts-option-custom';
-        return `<div class="${selectedClass}" data-value="${escape(data.value)}">${escape(data.text)}</div>`;
-      },
-    },
-  });
-</script>
-<% end %>
-
 <div class="row" style="padding-top: 3rem;">
   <div class="col-md-8 offset-2">
     <%
@@ -64,7 +36,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         into.
       </p>
       <div class="mb-3">
-        <%= select_tag :target_unit_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control p-0" %>
+        <%= select_tag :target_unit_id, options_from_collection_for_select(@candidates, "id", "name"), class: "form-control p-0 tom-select" %>
       </div>
     <% end %>
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -324,100 +324,150 @@ describe Admin::CollectionsController, type: :controller do
     let(:collection) { FactoryBot.build(:collection, unit: unit) }
     let(:administrator) { FactoryBot.create(:administrator) }
 
-    before(:each) do
-      ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
-      request.headers['Avalon-Api-Key'] = 'secret_token'
-    end
-
-    it "should notify administrators" do
-      login_as(:administrator) #otherwise, there are no administrators to mail
-      # mock_email = double('email')
-      # allow(mock_email).to receive(:deliver_later)
-      # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
-      # FIXME: This delivers two instead of one for some reason
-      expect { post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, managers: collection.managers } } }.to have_enqueued_job(ActionMailer::MailDeliveryJob).twice
-      # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
-    end
-    it "should create a new collection with unit id provided" do
-      post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, contact_email: collection.contact_email, website_label: collection.website_label, website_url: collection.website_url, managers: collection.managers } }
-      expect(JSON.parse(response.body)['id'].class).to eq String
-      expect(JSON.parse(response.body)).not_to include('errors')
-      new_collection = Admin::Collection.find(JSON.parse(response.body)['id'])
-      expect(new_collection.contact_email).to eq collection.contact_email
-      expect(new_collection.website_label).to eq collection.website_label
-      expect(new_collection.website_url).to eq collection.website_url
-      expect(new_collection.unit_id).to eq collection.unit.id
-      expect(new_collection.governing_policy_id).to eq collection.unit.id
-    end
-    it "should create a new collection with unit name provided" do
-      post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_name: collection.unit.name, contact_email: collection.contact_email, website_label: collection.website_label, website_url: collection.website_url, managers: collection.managers } }
-      expect(JSON.parse(response.body)['id'].class).to eq String
-      expect(JSON.parse(response.body)).not_to include('errors')
-      new_collection = Admin::Collection.find(JSON.parse(response.body)['id'])
-      expect(new_collection.contact_email).to eq collection.contact_email
-      expect(new_collection.website_label).to eq collection.website_label
-      expect(new_collection.website_url).to eq collection.website_url
-      expect(new_collection.unit_id). to eq collection.unit.id
-      expect(new_collection.governing_policy_id).to eq collection.unit.id
-    end
-    it "should create a new collection with manager list empty" do
-      post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id } }
-      expect(JSON.parse(response.body)['id'].class).to eq String
-      collection = Admin::Collection.find(JSON.parse(response.body)['id'])
-      expect(collection.managers).to eq([])
-    end
-    it "should return 422 if collection creation failed" do
-      post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description } }
-      expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)).to include('errors')
-      expect(JSON.parse(response.body)["errors"].class).to eq Array
-      expect(JSON.parse(response.body)["errors"].first.class).to eq String
-    end
-  end
-
-  describe "#update" do
-    it "should notify administrators if name changed" do
-      login_as(:administrator) #otherwise, there are no administrators to mail
-      # mock_delay = double('mock_delay').as_null_object
-      # allow(NotificationsMailer).to receive(:deliver_later).and_return(mock_delay)
-      # expect(mock_delay).to receive(:update_collection)
-      @collection = FactoryBot.create(:collection)
-      # put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}
-      expect {put 'update', params: { id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit} }}.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
-    end
-
-    context "update REST API" do
-      let!(:collection) { FactoryBot.create(:collection)}
-      let(:unit) { FactoryBot.create(:unit)}
-      let(:contact_email) { Faker::Internet.email }
-      let(:website_label) { Faker::Lorem.words.join(' ') }
-      let(:website_url) { Faker::Internet.url }
-
-      before do
-        ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+    context 'as administrator' do
+      before(:each) do
+        ApiToken.create token: 'secret_token', username: administrator.username, email: administrator.email
         request.headers['Avalon-Api-Key'] = 'secret_token'
       end
 
-      it "should update a collection via API" do
-        old_description = collection.description
-        put 'update', params: { format: 'json', id: collection.id, admin_collection: { description: collection.description+'new', contact_email: contact_email, website_label: website_label, website_url: website_url, unit_id: unit.id }}
+      it "should notify administrators" do
+        login_as(:administrator) #otherwise, there are no administrators to mail
+        # mock_email = double('email')
+        # allow(mock_email).to receive(:deliver_later)
+        # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
+        # FIXME: This delivers two instead of one for some reason
+        expect { post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, managers: collection.managers } } }.to have_enqueued_job(ActionMailer::MailDeliveryJob).twice
+        # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
+      end
+      it "should create a new collection with unit id provided" do
+        post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, contact_email: collection.contact_email, website_label: collection.website_label, website_url: collection.website_url, managers: collection.managers } }
         expect(JSON.parse(response.body)['id'].class).to eq String
         expect(JSON.parse(response.body)).not_to include('errors')
-        collection.reload
-        expect(collection.description).to eq old_description+'new'
-        expect(collection.contact_email).to eq contact_email
-        expect(collection.website_label).to eq website_label
-        expect(collection.website_url).to eq website_url
-        expect(collection.unit_id).to eq unit.id
-        expect(collection.governing_policy_id).to eq unit.id
+        new_collection = Admin::Collection.find(JSON.parse(response.body)['id'])
+        expect(new_collection.contact_email).to eq collection.contact_email
+        expect(new_collection.website_label).to eq collection.website_label
+        expect(new_collection.website_url).to eq collection.website_url
+        expect(new_collection.unit_id).to eq collection.unit.id
+        expect(new_collection.governing_policy_id).to eq collection.unit.id
       end
-      it "should return 422 if collection update via API failed" do
-        allow_any_instance_of(Admin::Collection).to receive(:save).and_return false
-        put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
+      it "should create a new collection with manager list empty" do
+        post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id } }
+        expect(JSON.parse(response.body)['id'].class).to eq String
+        collection = Admin::Collection.find(JSON.parse(response.body)['id'])
+        expect(collection.managers).to eq([])
+      end
+      it "should return 422 if collection creation failed" do
+        post 'create', params: { format:'json', admin_collection: { name: collection.name, description: collection.description } }
         expect(response.status).to eq(422)
         expect(JSON.parse(response.body)).to include('errors')
         expect(JSON.parse(response.body)["errors"].class).to eq Array
         expect(JSON.parse(response.body)["errors"].first.class).to eq String
+      end
+    end
+
+    context 'when user does not have permissions for unit' do
+      let(:other_unit) { FactoryBot.create(:unit) }
+      let(:user) { User.find_by_username(other_unit.unit_admins.first) }
+
+      context 'json' do
+        before(:each) do
+          ApiToken.create token: 'secret_token', username: user.username, email: user.email
+          request.headers['Avalon-Api-Key'] = 'secret_token'
+        end
+
+        it "should return 422 if collection creation failed" do
+          post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id } }
+          expect(response.status).to eq(422)
+          expect(JSON.parse(response.body)).to include('errors')
+          expect(JSON.parse(response.body)["errors"].class).to eq Array
+          expect(JSON.parse(response.body)["errors"].first.class).to eq String
+        end
+      end
+
+      context 'html' do
+        it 'redirects to restricted content page' do
+          login_user user.username
+          expect { post 'create', params: { admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id } } }.not_to change { Admin::Collection.count }
+          expect(response).to have_rendered('new')
+          expect(flash[:error]).to be_present
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    let!(:collection) { FactoryBot.create(:collection, unit: unit)}
+    let(:unit) { FactoryBot.create(:unit)}
+    let(:contact_email) { Faker::Internet.email }
+    let(:website_label) { Faker::Lorem.words.join(' ') }
+    let(:website_url) { Faker::Internet.url }
+
+    it "should notify administrators if name changed" do
+      login_as(:administrator) #otherwise, there are no administrators to mail
+      expect {put 'update', params: { id: collection.id, admin_collection: {name: "#{collection.name}-new", description: collection.description } }}.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
+    end
+
+    context 'when user does not have permissions for unit' do
+      let(:other_unit) { FactoryBot.create(:unit) }
+      let(:user) { User.find_by_username(unit.unit_admins.first) }
+
+      it 'redirects to restricted content page' do
+        login_user user.username
+        expect { post 'update', params: { id: collection.id, admin_collection: { unit_id: other_unit.id } } }.not_to change { Admin::Collection.count }
+        expect(response).to have_http_status(302)
+        expect(response.location).to eq admin_collection_url(collection)
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    context "update REST API" do
+      context 'as administrator' do
+        before do
+          ApiToken.create token: 'secret_token', username: 'archivist1@example.com', email: 'archivist1@example.com'
+          request.headers['Avalon-Api-Key'] = 'secret_token'
+        end
+
+        it "should update a collection via API" do
+          old_description = collection.description
+          put 'update', params: { format: 'json', id: collection.id, admin_collection: { description: collection.description+'new', contact_email: contact_email, website_label: website_label, website_url: website_url, unit_id: unit.id }}
+          expect(JSON.parse(response.body)['id'].class).to eq String
+          expect(JSON.parse(response.body)).not_to include('errors')
+          collection.reload
+          expect(collection.description).to eq old_description+'new'
+          expect(collection.contact_email).to eq contact_email
+          expect(collection.website_label).to eq website_label
+          expect(collection.website_url).to eq website_url
+          expect(collection.unit_id).to eq unit.id
+          expect(collection.governing_policy_id).to eq unit.id
+        end
+        it "should return 422 if collection update via API failed" do
+          allow_any_instance_of(Admin::Collection).to receive(:save).and_return false
+          put 'update', params: { format: 'json', id: collection.id, admin_collection: {description: collection.description+'new'} }
+          expect(response.status).to eq(422)
+          expect(JSON.parse(response.body)).to include('errors')
+          expect(JSON.parse(response.body)["errors"].class).to eq Array
+          expect(JSON.parse(response.body)["errors"].first.class).to eq String
+        end
+      end
+
+      context 'when user does not have permissions for unit' do
+        let(:other_unit) { FactoryBot.create(:unit) }
+        let(:user) { User.find_by_username(unit.unit_admins.first) }
+
+        context 'json' do
+          before(:each) do
+            ApiToken.create token: 'secret_token', username: user.username, email: user.email
+            request.headers['Avalon-Api-Key'] = 'secret_token'
+          end
+
+          it "should return 422 if collection update via API failed" do
+            post 'update', params: { format: 'json', id: collection.id, admin_collection: { unit_id: other_unit.id } }
+            expect(response.status).to eq(422)
+            expect(JSON.parse(response.body)).to include('errors')
+            expect(JSON.parse(response.body)["errors"].class).to eq Array
+            expect(JSON.parse(response.body)["errors"].first.class).to eq String
+          end
+        end
       end
     end
   end

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -331,13 +331,8 @@ describe Admin::CollectionsController, type: :controller do
       end
 
       it "should notify administrators" do
-        login_as(:administrator) #otherwise, there are no administrators to mail
-        # mock_email = double('email')
-        # allow(mock_email).to receive(:deliver_later)
-        # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
-        # FIXME: This delivers two instead of one for some reason
+        login_as(:administrator)
         expect { post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, managers: collection.managers } } }.to have_enqueued_job(ActionMailer::MailDeliveryJob).twice
-        # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
       end
       it "should create a new collection with unit id provided" do
         post 'create', params: { format: 'json', admin_collection: { name: collection.name, description: collection.description, unit_id: collection.unit.id, contact_email: collection.contact_email, website_label: collection.website_label, website_url: collection.website_url, managers: collection.managers } }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -75,6 +75,25 @@ describe ApplicationController do
     end
   end
 
+  describe '#get_user_units' do
+    let!(:unit1) { FactoryBot.create(:unit) }
+    let!(:unit2) { FactoryBot.create(:unit) }
+
+    it 'returns all units for an administrator' do
+      login_as :administrator
+      expect(controller.get_user_units).to include(have_attributes(id: unit1.id), have_attributes(id: unit2.id))
+    end
+    it 'returns only relevant units for a unit admin' do
+      login_user unit1.unit_admins.first
+      expect(controller.get_user_units).to include(have_attributes(id: unit1.id))
+      expect(controller.get_user_units).not_to include(have_attributes(id: unit2.id))
+    end
+    it 'returns no collections for other users' do
+      login_as :user
+      expect(controller.get_user_units).to be_empty
+    end
+  end
+
   describe "exceptions handling" do
     it "renders deleted_pid template" do
       get :show, params: { id: 'deleted-id' }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -76,12 +76,22 @@ describe ApplicationController do
   end
 
   describe '#get_user_units' do
-    let!(:unit1) { FactoryBot.create(:unit) }
-    let!(:unit2) { FactoryBot.create(:unit) }
+    let!(:unit1) { FactoryBot.create(:unit, name: 'Zelda') }
+    let!(:unit2) { FactoryBot.create(:unit, name: 'Battletoads') }
 
-    it 'returns all units for an administrator' do
+    it 'returns all units for an administrator (sorted by default)' do
       login_as :administrator
-      expect(controller.get_user_units).to include(have_attributes(id: unit1.id), have_attributes(id: unit2.id))
+      units = controller.get_user_units
+      expect(units).to include(have_attributes(id: unit1.id), have_attributes(id: unit2.id))
+      expect(units[0].id).to eq unit2.id
+      expect(units[1].id).to eq unit1.id
+    end
+    it 'returns all units for an administrator (unsorted)' do
+      login_as :administrator
+      units = controller.get_user_units(sort: false)
+      expect(units).to include(have_attributes(id: unit1.id), have_attributes(id: unit2.id))
+      expect(units[0].id).to eq unit1.id
+      expect(units[1].id).to eq unit2.id
     end
     it 'returns only relevant units for a unit admin' do
       login_user unit1.unit_admins.first

--- a/spec/features/capybara_admin_collection_spec.rb
+++ b/spec/features/capybara_admin_collection_spec.rb
@@ -31,7 +31,23 @@ describe 'Admin Collection' do
     expect(page).to have_content('Name')
     expect(page).to have_content('Description')
     expect(page).to have_content('Unit')
-    expect(page).to_not have_content(@unit.name)
+    expect(page).to have_link('Cancel')
+  end
+  it 'checks navigation when create new collection is accessed from unit page' do
+    login_as @user, scope: :user
+    visit '/'
+    click_link('Manage Content')
+    expect(page).to have_current_path('/admin/dashboard')
+    expect(page).to have_link(@unit.name)
+    click_link(@unit.name)
+    expect(page).to have_current_path("/admin/units/#{@unit.id}")
+    expect(page).to have_link('Create A Collection')
+    click_link('Create A Collection')
+    expect(page).to have_current_path("/admin/collections/new?unit_id=#{@unit.id}")
+    expect(page).to have_content('Name')
+    expect(page).to have_content('Description')
+    expect(page).to have_content('Unit')
+    expect(page).to have_content(@unit.name)
     expect(page).to have_link('Cancel')
   end
   it 'is able to create a new collection' do
@@ -39,7 +55,7 @@ describe 'Admin Collection' do
     visit '/admin/collections/'
     click_link('Create Collection')
     fill_in('admin_collection_name', with: 'Test Collection')
-    fill_in('admin_collection[unit_name]', with: @unit.name)
+    select(@unit.name, from: 'admin_collection[unit_id]')
     click_on('Create Collection')
     visit '/admin/collections'
     expect(page).to have_content('Test Collection')
@@ -54,7 +70,7 @@ describe 'Admin Collection' do
     visit '/admin/collections'
     click_link('Create Collection')
     fill_in('admin_collection_name', with: 'Test Collection')
-    fill_in('admin_collection[unit_name]', with: @unit.name)
+    select(@unit.name, from: 'admin_collection[unit_id]')
     click_on('Create Collection')
     visit '/admin/collections'
     click_on('Test Collection')
@@ -69,7 +85,7 @@ describe 'Admin Collection' do
     visit '/admin/collections'
     click_link('Create Collection')
     fill_in('admin_collection_name', with: 'Test Collection')
-    fill_in('admin_collection[unit_name]', with: @unit.name)
+    select(@unit.name, from: 'admin_collection[unit_id]')
     click_on('Create Collection')
     visit '/admin/collections'
     click_link('Delete')


### PR DESCRIPTION
This PR builds on #6778 

Changes in this PR:
- Change unit input from autocomplete to drop-down select (using TomSelect to match unit/collection deletion pages)
- Only have one option for unit on /new if unit_id param present
- /new (without unit_id param) and edit collection dialog have units for which the user is unit admin
- Administrators have all units (except for /new if unit_id param present)
- Require that creating/updating user is unit admin of unit being assigned to collection
- Move get_user_units into ApplicationController and make helper method
- Skip attmpting update if unit not present or user does not have permissions
- Attempt to start unifying different approaches to error messages in json vs. html responses