### PR TITLE
Ensure current unit is in list of candidate units

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -64,7 +64,8 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1
   def show
-    @candidate_units = get_user_units
+    # Make sure to include current unit even if current user is not unit admin on that unit
+    @candidate_units = get_user_units(with_ids: [@collection.unit_id])
 
     respond_to do |format|
       format.json { render json: @collection.to_json }
@@ -101,7 +102,8 @@ class Admin::CollectionsController < ApplicationController
 
   # GET /collections/1/edit
   def edit
-    @candidate_units = get_user_units
+    # Make sure to include current unit even if current user is not unit admin on that unit
+    @candidate_units = get_user_units(with_ids: [@collection.unit_id])
     respond_to do |format|
       format.js   { render json: modal_form_response(@collection) }
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -148,14 +148,17 @@ class ApplicationController < ActionController::Base
   helper_method :get_user_collections
 
   # Returns units for current_user
+  # @param [Array <String>] with_ids list of unit ids to be included in final list
+  # @param [boolean] sort sort return list by unit name (default: true)
   # @return [units] Units in which current_user is a unit admin
-  def get_user_units(sort: true)
+  def get_user_units(with_ids: [], sort: true)
     units = []
     # return all units to admin
     if can?(:manage, Admin::Unit)
       units = SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit")
     else
-      units = SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND unit_administrators_ssim: #{user_key}")
+      id_query = with_ids.collect { |id| "id:#{id}" }.join(" OR ")
+      units = SpeedyAF::Proxy::Admin::Unit.where("has_model_ssim: Admin\\:\\:Unit AND (#{["unit_administrators_ssim: #{user_key}", id_query].compact_blank.join(" OR ")})")
     end
     sort ? units.sort_by { |u| u.name.downcase } : units
   end

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -13,10 +13,6 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<% unless Avalon::ControlledVocabulary.vocabulary[:units] %>
-  <% raise Avalon::VocabularyNotFound.new "Units vocabulary not found." %>
-<% end %>
-
 <div id="new_collection" class="modal fade" role="dialog" data-bs-backdrop="true" data-submit_url="<%= 'create' %>">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -102,6 +102,14 @@ describe ApplicationController do
       login_as :user
       expect(controller.get_user_units).to be_empty
     end
+
+    context 'with additional unit ids' do
+      it 'returns relevant units for a unit admin and passed in units' do
+        login_user unit1.unit_admins.first
+        expect(controller.get_user_units(with_ids: [unit2.id])).to include(have_attributes(id: unit1.id))
+        expect(controller.get_user_units(with_ids: [unit2.id])).to include(have_attributes(id: unit2.id))
+      end
+    end
   end
 
   describe "exceptions handling" do


### PR DESCRIPTION
Fixes a case where a manager of a collection can change the unit of their collection but current unit would not appear in list if they were not a unit admin of that unit.