### PR TITLE
Manage content UI

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -188,7 +188,7 @@ input[name="admin_group[resources][]"] {
 .dashboard-action-icons {
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: flex-end;
   gap: 14px;
 }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -83,6 +83,10 @@ input[name="admin_group[resources][]"] {
 .devise-links span.devise-link:first-child {
   border-left: none;
 }
+.section-title,
+.section-create-button {
+  text-transform: capitalize;
+}
 
 /* ------------------------------ Admin Dashboard Tables ------------------------------ */
 
@@ -174,6 +178,7 @@ input[name="admin_group[resources][]"] {
   letter-spacing: 0.04em;
   color: $primary;
   text-decoration: none;
+  text-wrap: nowrap;
 
   &:hover {
     text-decoration: underline;
@@ -185,16 +190,16 @@ input[name="admin_group[resources][]"] {
   align-items: center;
   justify-content: space-around;
   gap: 14px;
+}
 
-  a {
-    font-size: 16px;
-    text-decoration: none;
-  }
+.dashboard-view-all-link {
+  font-size: 14px;
+  font-weight: 500;
+  color: $primary;
+  text-decoration: none;
+  text-wrap: nowrap;
 
-  .dashboard-action-edit {
-    color: #6b7280;
-    &:hover {
-      color: #111827;
-    }
+  &:hover {
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -24,19 +24,25 @@
  * A little quick and dirty but it can be cleaned up later. Use 18px or the defined
  * line height to keep things flowing nicely in the grid instead of arbitrary gaps
  */
-.admin .badge, .admin .label {
+.admin .badge,
+.admin .label {
   font-size: $font-size-base;
   font-weight: normal;
   margin-right: 4px;
 }
 
-.admin .icon-remove-sign, .admin .icon-ok-sign, .admin .icon-plus-sign {
+.admin .icon-remove-sign,
+.admin .icon-ok-sign,
+.admin .icon-plus-sign {
   font-size: $font-size-base*1.5;
   vertical-align: middle;
   cursor: pointer;
 }
 
-.admin .icon-remove-sign, .admin .icon-ok-sign, input[name="admin_group[users][]"], input[name="admin_group[resources][]"] {
+.admin .icon-remove-sign,
+.admin .icon-ok-sign,
+input[name="admin_group[users][]"],
+input[name="admin_group[resources][]"] {
   display: none;
 }
 
@@ -76,4 +82,119 @@
 }
 .devise-links span.devise-link:first-child {
   border-left: none;
+}
+
+/* ------------------------------ Admin Dashboard Tables ------------------------------ */
+
+.dashboard-table-container {
+  border: 1px solid $lightgray;
+  border-radius: 0.625em;
+  box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.1) 0px 1px 2px -1px;
+
+  // Hide "Search:" label in the search form
+  label[for^="search-"] {
+    display: none;
+  }
+
+  // Make the search span 50% width of the container
+  .d-flex.justify-content-between>.d-flex:has(input[id^="search-"]) {
+    width: 50%;
+  }
+  .d-flex.justify-content-between>.d-flex:has(input[id^="search-"])>.d-flex {
+    width: 100%;
+  }
+
+  input[id^="search-"] {
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid #d1d5db;
+    padding: 0.5rem 1rem 0.5rem 2.5rem;
+    font-size: 14px;
+    background-color: #fafafa;
+    // Set search icon in the placeholder using an SVG as a background image
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: 12px center;
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
+
+  td.invisible-actions-header {
+    background-color: #f9fafb !important;
+    border: none;
+  }
+
+  table.generic-table {
+    min-width: unset !important;
+    border: none;
+    margin-bottom: 1rem;
+
+    // Table header styles
+    thead tr th {
+      background-color: #f9fafb !important;
+      color: #6b7280 !important;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border-bottom: 1px solid #e5e7eb !important;
+      border-top: none !important;
+      padding: 1rem 1.5rem;
+    }
+
+    tbody>tr>td {
+      border-top: 1px solid #e5e7eb !important;
+      border-bottom: none !important;
+      padding: 16px 14px;
+      vertical-align: middle;
+      font-size: 14px;
+    }
+  }
+}
+
+.dashboard-unit-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border: 1px solid $dark;
+  border-radius: 0.625rem;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: $primary;
+  background-color: $greenBG;
+  white-space: nowrap;
+}
+
+.dashboard-unpublished-link {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: $primary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.dashboard-action-icons {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  gap: 14px;
+
+  a {
+    font-size: 16px;
+    text-decoration: none;
+  }
+
+  .dashboard-action-edit {
+    color: #6b7280;
+    &:hover {
+      color: #111827;
+    }
+  }
 }

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -64,7 +64,12 @@ class Admin::DashboardController < ApplicationController
   def index
     respond_to do |format|
       format.html
-      # TODO: Figure out a json response?
+      format.json do
+        render json: {
+          units: @units.map { |u| u.as_json(nil) },
+          collections: @collections.map { |c| c.as_json(nil) }
+        }
+      end
     end
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -66,8 +66,14 @@ class Admin::DashboardController < ApplicationController
       format.html
       format.json do
         render json: {
-          units: @units.map { |u| u.as_json(nil) },
-          collections: @collections.map { |c| c.as_json(nil) }
+          units: @units.map do |u|
+            hash = u.as_json(nil)
+            can?(:destroy, u) ? hash.merge(remove_url: remove_admin_unit_path(u.id)) : hash
+          end,
+          collections: @collections.map do |c|
+            hash = c.as_json(nil)
+            can?(:destroy, c) ? hash.merge(remove_url: remove_admin_collection_path(c.id)) : hash
+          end
         }
       end
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -29,6 +29,7 @@ import TimelinesTable from './components/tables/TimelinesTable';
 import EncodingJobsTable from './components/tables/EncodingJobsTable';
 import CheckoutsTable from './components/tables/CheckoutsTable';
 import UsersTable from './components/tables/UsersTable';
+import Dashboard from './components/dashboard/Dashboard';
 import './auto-complete-open.js';
 import '@github/auto-complete-element';
 
@@ -45,4 +46,5 @@ ReactOnRails.register({
   EncodingJobsTable,
   CheckoutsTable,
   UsersTable,
+  Dashboard
 });

--- a/app/javascript/components/dashboard/CollectionsTable.jsx
+++ b/app/javascript/components/dashboard/CollectionsTable.jsx
@@ -60,11 +60,11 @@ const CollectionsTable = ({ data, helpers }) => {
       unit: row.unit || '',
       collection_url: `/collections/${row.id}`,
       edit_url: `/admin/collections/${row.id}`,
-      remove_url: `/admin/collections/${row.id}/remove`,
+      // Collection remove_url = '' if the user doesn't have permission to destroy it
+      remove_url: row.remove_url || '',
       search_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}`,
       unpublished_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}&f[workflow_published_sim][]=Unpublished`,
       items: row.object_count?.total || 0,
-      total_items: row.object_count?.total || 0,
       unpublished_items: row.object_count?.unpublished || 0,
       description: row.description || '',
     }),
@@ -82,7 +82,7 @@ const CollectionsTable = ({ data, helpers }) => {
           return (
             <div>
               <a href={item.search_url} className="fw-bold text-decoration-none text-dark">
-                {item.total_items} {item.items === 1 ? 'item' : 'items'}
+                {item.items} {item.items === 1 ? 'item' : 'items'}
               </a>
               {item.unpublished_items > 0 && (
                 <div>

--- a/app/javascript/components/dashboard/CollectionsTable.jsx
+++ b/app/javascript/components/dashboard/CollectionsTable.jsx
@@ -20,19 +20,28 @@ import GenericTable from '../tables/GenericTable';
  * Render a table displaying all collection for the admin dashboard.
  * @param {Object} props
  * @param {Array}  props.data array of collection objects from the dashboard JSON endpoint
+ * @param {Object} props.helpers shared helpers for common utilities in dashboard tables
  */
-const CollectionsTable = ({ data }) => {
+const CollectionsTable = ({ data, helpers }) => {
+  const { truncateDescription, DashboardActionButtons } = helpers;
   const collectionConfig = {
+    // Table metadata
     tableType: 'collection',
     containerClass: 'dashboard-table-container',
     testId: 'collection-table',
     hasTagFilter: false,
+    isDashboardTable: true,
+
+    // Table column sorting and filtering config from parsed data
     initialSort: { columnKey: 'name', dataType: 'string', direction: 'asc' },
-    initPageSize: 5,
-    pageSizeOptions: [5, 10, 25, 50],
     searchableFields: ['name', 'unit', 'description'],
     searchPlaceholder: 'Search collections by name or unit...',
-    tableStyle: {},
+
+    // Table pagination customization
+    initPageSize: 5,
+    pageSizeOptions: [5, 10, 25, 50],
+
+    // Column definitions
     columns: [
       { key: 'name', label: 'Name', sortable: true, dataType: 'string', width: '22%' },
       { key: 'items', label: 'Items', sortable: true, dataType: 'number', width: '12%' },
@@ -41,6 +50,10 @@ const CollectionsTable = ({ data }) => {
       { key: 'actions', label: '', sortable: false, width: '8%' },
     ],
 
+    // View all link for collections
+    viewAllUrl: '/admin/collections',
+
+    // Parsing function to extract data from back-end
     parseDataRow: (row) => ({
       id: row.id,
       name: row.name || '',
@@ -50,16 +63,18 @@ const CollectionsTable = ({ data }) => {
       remove_url: `/admin/collections/${row.id}/remove`,
       search_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}`,
       unpublished_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}&f[workflow_published_sim][]=Unpublished`,
+      items: row.object_count?.total || 0,
       total_items: row.object_count?.total || 0,
       unpublished_items: row.object_count?.unpublished || 0,
       description: row.description || '',
     }),
 
+    // Cell rendering function for each column
     renderCell: (item, columnKey) => {
       switch (columnKey) {
         case 'name':
           return (
-            <a href={item.collection_url} className="fw-bold text-decoration-none text-dark">
+            <a href={item.collection_url} className="fw-bold text-decoration-none text-dark" data-testid="collection-name-table">
               {item.name}
             </a>
           );
@@ -67,7 +82,7 @@ const CollectionsTable = ({ data }) => {
           return (
             <div>
               <a href={item.search_url} className="fw-bold text-decoration-none text-dark">
-                {item.total_items} items
+                {item.total_items} {item.items === 1 ? 'item' : 'items'}
               </a>
               {item.unpublished_items > 0 && (
                 <div>
@@ -85,19 +100,18 @@ const CollectionsTable = ({ data }) => {
         case 'description':
           return (
             <span className="text-muted">
-              {item.description ? item.description.substring(0, 120) + (item.description.length > 120 ? '…' : '') : ''}
+              {truncateDescription(item.description)}
             </span>
           );
         case 'actions':
           return (
-            <div className="dashboard-action-icons">
-              <a href={item.edit_url} className="dashboard-action-edit btn btn-outline" title="Edit collection">
-                <i className="fa-regular fa-pen-to-square" />
-              </a>
-              <a href={item.remove_url} className="dashboard-action-delete btn btn-danger" title="Delete collection">
-                <i className="fa-regular fa-trash-can" />
-              </a>
-            </div>
+            <DashboardActionButtons
+              editUrl={item.edit_url}
+              removeUrl={item.remove_url}
+              editTitle="Edit collection"
+              deleteTitle="Delete collection"
+              deleteTestId="collection-delete-collection-btn"
+            />
           );
         default:
           return item[columnKey];

--- a/app/javascript/components/dashboard/CollectionsTable.jsx
+++ b/app/javascript/components/dashboard/CollectionsTable.jsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+ *   University.  Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ *   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ---  END LICENSE_HEADER BLOCK  ---
+*/
+
+import GenericTable from '../tables/GenericTable';
+
+/**
+ * Render a table displaying all collection for the admin dashboard.
+ * @param {Object} props
+ * @param {Array}  props.data array of collection objects from the dashboard JSON endpoint
+ */
+const CollectionsTable = ({ data }) => {
+  const collectionConfig = {
+    tableType: 'collection',
+    containerClass: 'dashboard-table-container',
+    testId: 'collection-table',
+    hasTagFilter: false,
+    initialSort: { columnKey: 'name', dataType: 'string', direction: 'asc' },
+    initPageSize: 5,
+    pageSizeOptions: [5, 10, 25, 50],
+    searchableFields: ['name', 'unit', 'description'],
+    searchPlaceholder: 'Search collections by name or unit...',
+    tableStyle: {},
+    columns: [
+      { key: 'name', label: 'Name', sortable: true, dataType: 'string', width: '22%' },
+      { key: 'items', label: 'Items', sortable: true, dataType: 'number', width: '12%' },
+      { key: 'unit', label: 'Unit', sortable: true, dataType: 'string', width: '18%' },
+      { key: 'description', label: 'Description', sortable: false, width: '40%' },
+      { key: 'actions', label: '', sortable: false, width: '8%' },
+    ],
+
+    parseDataRow: (row) => ({
+      id: row.id,
+      name: row.name || '',
+      unit: row.unit || '',
+      collection_url: `/collections/${row.id}`,
+      edit_url: `/admin/collections/${row.id}`,
+      remove_url: `/admin/collections/${row.id}/remove`,
+      search_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}`,
+      unpublished_url: `/catalog?f[collection_ssim][]=${encodeURIComponent(row.name || '')}&f[workflow_published_sim][]=Unpublished`,
+      total_items: row.object_count?.total || 0,
+      unpublished_items: row.object_count?.unpublished || 0,
+      description: row.description || '',
+    }),
+
+    renderCell: (item, columnKey) => {
+      switch (columnKey) {
+        case 'name':
+          return (
+            <a href={item.collection_url} className="fw-bold text-decoration-none text-dark">
+              {item.name}
+            </a>
+          );
+        case 'items':
+          return (
+            <div>
+              <a href={item.search_url} className="fw-bold text-decoration-none text-dark">
+                {item.total_items} items
+              </a>
+              {item.unpublished_items > 0 && (
+                <div>
+                  <a href={item.unpublished_url} className="dashboard-unpublished-link">
+                    {item.unpublished_items} UNPUBLISHED
+                  </a>
+                </div>
+              )}
+            </div>
+          );
+        case 'unit':
+          return item.unit
+            ? <span className="dashboard-unit-badge">{item.unit}</span>
+            : null;
+        case 'description':
+          return (
+            <span className="text-muted">
+              {item.description ? item.description.substring(0, 120) + (item.description.length > 120 ? '…' : '') : ''}
+            </span>
+          );
+        case 'actions':
+          return (
+            <div className="dashboard-action-icons">
+              <a href={item.edit_url} className="dashboard-action-edit btn btn-outline" title="Edit collection">
+                <i className="fa-regular fa-pen-to-square" />
+              </a>
+              <a href={item.remove_url} className="dashboard-action-delete btn btn-danger" title="Delete collection">
+                <i className="fa-regular fa-trash-can" />
+              </a>
+            </div>
+          );
+        default:
+          return item[columnKey];
+      }
+    },
+  };
+
+  return <GenericTable config={collectionConfig} data={data} />;
+};
+
+export default CollectionsTable;

--- a/app/javascript/components/dashboard/Dashboard.jsx
+++ b/app/javascript/components/dashboard/Dashboard.jsx
@@ -19,6 +19,88 @@ import UnitsTable from './UnitsTable';
 import CollectionsTable from './CollectionsTable';
 
 /**
+ * Truncate a description text to a maximum length and append an
+ * ellipsis at the end if truncated
+ * @param {String} text description text
+ * @param {Number} maxChars character limit (default 120)
+ * @returns {String}
+ */
+const truncateDescription = (text, maxChars = 120) =>
+  text ? text.substring(0, maxChars) + (text.length > maxChars ? '…' : '') : '';
+
+/**
+ * Shared edit/delete action button pair used by dashboard table rows
+ */
+const DashboardActionButtons = ({ editUrl, removeUrl, editTitle, deleteTitle, deleteTestId }) => (
+  <div className="dashboard-action-icons">
+    <a href={editUrl} className="dashboard-action-edit btn btn-outline" title={editTitle}>
+      <i className="fa-regular fa-pen-to-square" />
+    </a>
+    <a href={removeUrl} className="dashboard-action-delete btn btn-danger" title={deleteTitle} data-testid={deleteTestId}>
+      <i className="fa-regular fa-trash-can" />
+    </a>
+  </div>
+);
+
+/**
+ * Render dashboard section with either a table or a message for units or collections
+ * according to the provided data
+ * @param {Object} props
+ * @param {Array} props.data section data from the API
+ * @param {Boolean} props.canCreate whether the current user can create a unit/collection
+ * @param {String} props.createPath path for creating a new unit/collection
+ * @param {String} props.createLabel create button label
+ * @param {String} props.btnClass create button Bootstrap class name
+ * @param {String} props.sectionType section object type (unit/collection)
+ * @param {React.Component} props.TableComponent relevant React component for the data table
+ * @param {String} props.tableWrapperClass table wrapper Bootstrap class name
+ */
+const DashboardSection = ({ data, canCreate, createPath, btnClass, sectionType, TableComponent, tableWrapperClass }) => {
+  const helpers = { truncateDescription, DashboardActionButtons };
+
+  if (data.length > 0) {
+    return (
+      <>
+        <div className="d-flex justify-content-between page-title-wrapper mb-3">
+          <h1 className="page-title mb-0 section-title">{`My ${sectionType}s`}</h1>
+          {canCreate && (
+            <a href={createPath}>
+              <span className={`btn ${btnClass} btn-large section-create-button`} data-testid={`${sectionType}-create-${sectionType}-button`}>
+                <i className="fa fa-plus" aria-hidden="true"></i> {`Create ${sectionType}`}
+              </span>
+            </a>
+          )}
+        </div>
+        <div className={tableWrapperClass}>
+          <TableComponent data={data} helpers={helpers} />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className="mb-4">
+      <h2>You don&apos;t have any {sectionType}s yet</h2>
+      {canCreate
+        ? (
+          <div className="d-flex justify-content-between mt-4">
+            <p>Would you like to create one?</p>
+            <p>
+              <a href={createPath}>
+                <span className={`btn ${btnClass} btn-large section-create-button`} data-testid={`${sectionType}-create-${sectionType}-button`}>
+                  <i className="fa fa-plus" aria-hidden="true"></i> {`Create ${sectionType}`}
+                </span>
+              </a>
+            </p>
+          </div>
+        )
+        : <p>You&apos;ll need to be assigned to one</p>
+      }
+    </div>
+  );
+};
+
+/**
  * Admin dashboard component — fetches units, collections, and summary stats
  * from the dashboard JSON endpoint and composes the page layout.
  *
@@ -68,65 +150,24 @@ const Dashboard = ({ url, new_unit_path, new_collection_path, can_create_unit, c
 
   return (
     <div>
-      <div className="d-flex justify-content-between page-title-wrapper mb-3">
-        <h1 className="page-title mb-0">My Units</h1>
-        {can_create_unit && (
-          <div className="collection-btn">
-            <a href={new_unit_path}>
-              <span className="btn btn-primary btn-large" data-testid="unit-create-unit-button">
-                <i className="fa fa-plus" aria-hidden="true"></i> Create Unit
-              </span>
-            </a>
-          </div>
-        )}
-      </div>
-
-      {units.length === 0 ? (
-        <div className="hero-unit mb-4">
-          <h2>You don&apos;t have any units yet</h2>
-          {can_create_unit && (
-            <p>
-              <a href={new_unit_path}>
-                <span className="btn btn-primary btn-large"><i class="fa fa-plus" aria-hidden="true"></i> Create Unit</span>
-              </a>
-            </p>
-          )}
-        </div>
-      ) : (
-        <div className="mb-5">
-          <UnitsTable data={units} />
-        </div>
-      )}
-
-      <div className="d-flex justify-content-between page-title-wrapper mb-3">
-        <h1 className="page-title mb-0">My Collections</h1>
-        {can_create_collection && (
-          <div className="collection-btn">
-            <a href={new_collection_path}>
-              <span className="btn btn-outline btn-large" data-testid="collection-create-collection-button">
-                <i className="fa fa-plus" aria-hidden="true"></i> Create Collection
-              </span>
-            </a>
-          </div>
-        )}
-      </div>
-
-      {collections.length === 0 ? (
-        <div className="hero-unit">
-          <h2>You don&apos;t have any collections yet</h2>
-          {can_create_collection && (
-            <p>
-              <a href={new_collection_path}>
-                <span className="btn btn-outline btn-large">
-                  <i class="fa fa-plus" aria-hidden="true"></i> Create Collection
-                </span>
-              </a>
-            </p>
-          )}
-        </div>
-      ) : (
-        <CollectionsTable data={collections} />
-      )}
+      <DashboardSection
+        data={units}
+        canCreate={can_create_unit}
+        createPath={new_unit_path}
+        btnClass="btn-primary"
+        sectionType="unit"
+        TableComponent={UnitsTable}
+        tableWrapperClass="mb-5"
+      />
+      <DashboardSection
+        data={collections}
+        canCreate={can_create_collection}
+        createPath={new_collection_path}
+        btnClass="btn-outline"
+        sectionType="collection"
+        TableComponent={CollectionsTable}
+        tableWrapperClass=""
+      />
     </div>
   );
 };

--- a/app/javascript/components/dashboard/Dashboard.jsx
+++ b/app/javascript/components/dashboard/Dashboard.jsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+ *   University.  Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ *   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ---  END LICENSE_HEADER BLOCK  ---
+*/
+
+import { useEffect, useState } from 'react';
+import UnitsTable from './UnitsTable';
+import CollectionsTable from './CollectionsTable';
+
+/**
+ * Admin dashboard component — fetches units, collections, and summary stats
+ * from the dashboard JSON endpoint and composes the page layout.
+ *
+ * @param {Object} props
+ * @param {String}  props.url URL for the dashboard JSON endpoint
+ * @param {String}  props.new_unit_path Path for creating a new unit
+ * @param {String}  props.new_collection_path Path for creating a new collection
+ * @param {Boolean} props.can_create_unit Whether the current user can create units
+ * @param {Boolean} props.can_create_collection Whether the current user can create collections
+ */
+const Dashboard = ({ url, new_unit_path, new_collection_path, can_create_unit, can_create_collection }) => {
+  const [loading, setLoading] = useState(true);
+  const [units, setUnits] = useState([]);
+  const [collections, setCollections] = useState([]);
+
+  useEffect(() => {
+    const fetchDashboard = async () => {
+      try {
+        const response = await fetch(url, {
+          headers: {
+            'Accept': 'application/json',
+            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content'),
+          },
+        });
+        const data = await response.json();
+        setUnits(data.units || []);
+        setCollections(data.collections || []);
+      } catch (error) {
+        console.error('Error fetching dashboard data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDashboard();
+  }, [url]);
+
+  if (loading) {
+    return (
+      <div className="text-center py-5">
+        <div className="spinner-border" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="d-flex justify-content-between page-title-wrapper mb-3">
+        <h1 className="page-title mb-0">My Units</h1>
+        {can_create_unit && (
+          <div className="collection-btn">
+            <a href={new_unit_path}>
+              <span className="btn btn-primary btn-large" data-testid="unit-create-unit-button">
+                <i className="fa fa-plus" aria-hidden="true"></i> Create Unit
+              </span>
+            </a>
+          </div>
+        )}
+      </div>
+
+      {units.length === 0 ? (
+        <div className="hero-unit mb-4">
+          <h2>You don&apos;t have any units yet</h2>
+          {can_create_unit && (
+            <p>
+              <a href={new_unit_path}>
+                <span className="btn btn-primary btn-large"><i class="fa fa-plus" aria-hidden="true"></i> Create Unit</span>
+              </a>
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="mb-5">
+          <UnitsTable data={units} />
+        </div>
+      )}
+
+      <div className="d-flex justify-content-between page-title-wrapper mb-3">
+        <h1 className="page-title mb-0">My Collections</h1>
+        {can_create_collection && (
+          <div className="collection-btn">
+            <a href={new_collection_path}>
+              <span className="btn btn-outline btn-large" data-testid="collection-create-collection-button">
+                <i className="fa fa-plus" aria-hidden="true"></i> Create Collection
+              </span>
+            </a>
+          </div>
+        )}
+      </div>
+
+      {collections.length === 0 ? (
+        <div className="hero-unit">
+          <h2>You don&apos;t have any collections yet</h2>
+          {can_create_collection && (
+            <p>
+              <a href={new_collection_path}>
+                <span className="btn btn-outline btn-large">
+                  <i class="fa fa-plus" aria-hidden="true"></i> Create Collection
+                </span>
+              </a>
+            </p>
+          )}
+        </div>
+      ) : (
+        <CollectionsTable data={collections} />
+      )}
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/app/javascript/components/dashboard/Dashboard.jsx
+++ b/app/javascript/components/dashboard/Dashboard.jsx
@@ -33,12 +33,15 @@ const truncateDescription = (text, maxChars = 120) =>
  */
 const DashboardActionButtons = ({ editUrl, removeUrl, editTitle, deleteTitle, deleteTestId }) => (
   <div className="dashboard-action-icons">
-    <a href={editUrl} className="dashboard-action-edit btn btn-outline" title={editTitle}>
-      <i className="fa-regular fa-pen-to-square" />
+    <a href={editUrl} className="dashboard-action-edit btn btn-outline btn-sm text-nowrap" title={editTitle}>
+      <i className="fa-regular fa-pen-to-square me-1" />Edit
     </a>
-    <a href={removeUrl} className="dashboard-action-delete btn btn-danger" title={deleteTitle} data-testid={deleteTestId}>
-      <i className="fa-regular fa-trash-can" />
-    </a>
+    {/* Render the delete button only when the current user has permissions to destroy item */}
+    {removeUrl != '' && (
+      <a href={removeUrl} className="dashboard-action-delete btn btn-danger btn-sm text-nowrap" title={deleteTitle} data-testid={deleteTestId}>
+        <i className="fa-regular fa-trash-can me-1" />Delete
+      </a>
+    )}
   </div>
 );
 

--- a/app/javascript/components/dashboard/UnitsTable.jsx
+++ b/app/javascript/components/dashboard/UnitsTable.jsx
@@ -20,24 +20,40 @@ import GenericTable from '../tables/GenericTable';
  * Render a table displaying all units for the admin dashboard.
  * @param {Object} props
  * @param {Array}  props.data array of unit objects from the dashboard JSON endpoint
+ * @param {Object} props.helpers shared helpers for common utilities in dashboard tables
  */
-const UnitsTable = ({ data }) => {
+const UnitsTable = ({ data, helpers }) => {
+  const { truncateDescription, DashboardActionButtons } = helpers;
   const unitConfig = {
+    // Table metadata
     tableType: 'unit',
+    isDashboardTable: true,
     containerClass: 'dashboard-table-container',
     testId: 'unit-table',
     hasTagFilter: false,
+
+    // Table column sorting and filtering config from parsed data
     initialSort: { columnKey: 'name', dataType: 'string', direction: 'asc' },
     searchableFields: ['name', 'description'],
     searchPlaceholder: 'Search units by name...',
-    tableStyle: {},
+
+    // Table pagination customization
+    initPageSize: 5,
+    pageSizeOptions: [5, 10, 25, 50],
+
+    // Column definitions
     columns: [
-      { key: 'name', label: 'Name', sortable: true, dataType: 'string', width: '25%' },
-      { key: 'collections', label: 'Collections', sortable: true, dataType: 'number', width: '15%' },
-      { key: 'description', label: 'Description', sortable: false, width: '50%' },
+      { key: 'name', label: 'Name', sortable: true, dataType: 'string', width: '20%' },
+      { key: 'items', label: 'Items', sortable: true, dataType: 'number', width: '12%' },
+      { key: 'administrators', label: 'Unit Administrators', sortable: false, width: '23%' },
+      { key: 'description', label: 'Description', sortable: false, width: '35%' },
       { key: 'actions', label: '', sortable: false, width: '10%' },
     ],
 
+    // View all link for collections
+    viewAllUrl: '/admin/units',
+
+    // Parsing function to extract data from back-end
     parseDataRow: (row) => ({
       id: row.id,
       name: row.name || '',
@@ -45,40 +61,45 @@ const UnitsTable = ({ data }) => {
       unit_url: `/units/${row.id}`,
       edit_url: `/admin/units/${row.id}`,
       remove_url: `/admin/units/${row.id}/remove`,
-      collections: row.object_count?.total || 0,
+      items: row.object_count?.total || 0,
+      administrators: row.roles?.unit_admins?.length || 0,
       description: row.description || '',
     }),
 
+    // Cell rendering function for each column
     renderCell: (item, columnKey) => {
       switch (columnKey) {
         case 'name':
           return (
-            <a href={item.unit_url} className="fw-bold text-decoration-none text-dark">
+            <a href={item.unit_url} className="fw-bold text-decoration-none text-dark" data-testid="unit-name-table">
               {item.name}
             </a>
           );
-        case 'collections':
+        case 'items':
           return (
-            <a href={item.search_url} className="text-decoration-none">
-              {item.collections} {item.collections === 1 ? 'collection' : 'collections'}
+            <a href={item.search_url} className="text-decoration-none" data-testid="unit-collections-count">
+              {item.items} {item.items === 1 ? 'collection' : 'collections'}
             </a>
           );
+        case 'administrators':
+          return (<span className="text-muted">
+            {item.administrators}  {item.administrators === 1 ? 'administrator' : 'administrators'}
+          </span>);
         case 'description':
           return (
             <span className="text-muted">
-              {item.description ? item.description.substring(0, 120) + (item.description.length > 120 ? '…' : '') : ''}
+              {truncateDescription(item.description)}
             </span>
           );
         case 'actions':
           return (
-            <div className="dashboard-action-icons">
-              <a href={item.edit_url} className="dashboard-action-edit btn btn-outline" title="Edit unit">
-                <i className="fa-regular fa-pen-to-square" />
-              </a>
-              <a href={item.remove_url} className="dashboard-action-delete btn btn-danger" title="Delete unit">
-                <i className="fa-regular fa-trash-can" />
-              </a>
-            </div>
+            <DashboardActionButtons
+              editUrl={item.edit_url}
+              removeUrl={item.remove_url}
+              editTitle="Edit unit"
+              deleteTitle="Delete unit"
+              deleteTestId="unit-delete-unit-btn"
+            />
           );
         default:
           return item[columnKey];

--- a/app/javascript/components/dashboard/UnitsTable.jsx
+++ b/app/javascript/components/dashboard/UnitsTable.jsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2011-2025, The Trustees of Indiana University and Northwestern
+ *   University.  Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ *   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ---  END LICENSE_HEADER BLOCK  ---
+*/
+
+import GenericTable from '../tables/GenericTable';
+
+/**
+ * Render a table displaying all units for the admin dashboard.
+ * @param {Object} props
+ * @param {Array}  props.data array of unit objects from the dashboard JSON endpoint
+ */
+const UnitsTable = ({ data }) => {
+  const unitConfig = {
+    tableType: 'unit',
+    containerClass: 'dashboard-table-container',
+    testId: 'unit-table',
+    hasTagFilter: false,
+    initialSort: { columnKey: 'name', dataType: 'string', direction: 'asc' },
+    searchableFields: ['name', 'description'],
+    searchPlaceholder: 'Search units by name...',
+    tableStyle: {},
+    columns: [
+      { key: 'name', label: 'Name', sortable: true, dataType: 'string', width: '25%' },
+      { key: 'collections', label: 'Collections', sortable: true, dataType: 'number', width: '15%' },
+      { key: 'description', label: 'Description', sortable: false, width: '50%' },
+      { key: 'actions', label: '', sortable: false, width: '10%' },
+    ],
+
+    parseDataRow: (row) => ({
+      id: row.id,
+      name: row.name || '',
+      search_url: `/catalog?f[unit_ssim][]=${encodeURIComponent(row.name || '')}`,
+      unit_url: `/units/${row.id}`,
+      edit_url: `/admin/units/${row.id}`,
+      remove_url: `/admin/units/${row.id}/remove`,
+      collections: row.object_count?.total || 0,
+      description: row.description || '',
+    }),
+
+    renderCell: (item, columnKey) => {
+      switch (columnKey) {
+        case 'name':
+          return (
+            <a href={item.unit_url} className="fw-bold text-decoration-none text-dark">
+              {item.name}
+            </a>
+          );
+        case 'collections':
+          return (
+            <a href={item.search_url} className="text-decoration-none">
+              {item.collections} {item.collections === 1 ? 'collection' : 'collections'}
+            </a>
+          );
+        case 'description':
+          return (
+            <span className="text-muted">
+              {item.description ? item.description.substring(0, 120) + (item.description.length > 120 ? '…' : '') : ''}
+            </span>
+          );
+        case 'actions':
+          return (
+            <div className="dashboard-action-icons">
+              <a href={item.edit_url} className="dashboard-action-edit btn btn-outline" title="Edit unit">
+                <i className="fa-regular fa-pen-to-square" />
+              </a>
+              <a href={item.remove_url} className="dashboard-action-delete btn btn-danger" title="Delete unit">
+                <i className="fa-regular fa-trash-can" />
+              </a>
+            </div>
+          );
+        default:
+          return item[columnKey];
+      }
+    },
+  };
+
+  return <GenericTable config={unitConfig} data={data} />;
+};
+
+export default UnitsTable;

--- a/app/javascript/components/dashboard/UnitsTable.jsx
+++ b/app/javascript/components/dashboard/UnitsTable.jsx
@@ -50,7 +50,7 @@ const UnitsTable = ({ data, helpers }) => {
       { key: 'actions', label: '', sortable: false, width: '10%' },
     ],
 
-    // View all link for collections
+    // View all link for units
     viewAllUrl: '/admin/units',
 
     // Parsing function to extract data from back-end
@@ -60,7 +60,8 @@ const UnitsTable = ({ data, helpers }) => {
       search_url: `/catalog?f[unit_ssim][]=${encodeURIComponent(row.name || '')}`,
       unit_url: `/units/${row.id}`,
       edit_url: `/admin/units/${row.id}`,
-      remove_url: `/admin/units/${row.id}/remove`,
+      // Unit remove_url = '' if the user doesn't have permission to destroy it
+      remove_url: row.remove_url || '',
       items: row.object_count?.total || 0,
       administrators: row.roles?.unit_admins?.length || 0,
       description: row.description || '',

--- a/app/javascript/components/tables/CheckoutsTable.jsx
+++ b/app/javascript/components/tables/CheckoutsTable.jsx
@@ -44,7 +44,7 @@ const CheckoutsTable = ({ url, isAdmin, returnAll }) => {
   const checkoutsConfig = useMemo(() => {
     return {
       // Table metadata
-      tableType: 'checkouts',
+      tableType: 'checkout',
       containerClass: 'checkouts-table-container',
       testId: 'checkouts-table',
       hasTagFilter: false,

--- a/app/javascript/components/tables/EncodingJobsTable.jsx
+++ b/app/javascript/components/tables/EncodingJobsTable.jsx
@@ -64,7 +64,7 @@ const EncodingJobsTable = ({ url, progressUrl }) => {
 
   const encodingTableConfig = {
     // Table metadata and configuration
-    tableType: 'encoding_jobs',
+    tableType: 'encoding_job',
     containerClass: 'encoding_jobs-table-container',
     testId: 'encoding_jobs-table',
     hasTagFilter: false,

--- a/app/javascript/components/tables/GenericTable.jsx
+++ b/app/javascript/components/tables/GenericTable.jsx
@@ -21,7 +21,7 @@ import useTablePagination from './hooks/useTablePagination';
 
 const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => {
   const {
-    columns,
+    columns: rawColumns,
     containerClass,
     displayReturnedItemsHTML = null,
     hasTagFilter,
@@ -36,9 +36,18 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     tableStyle = { minWidth: '1024px' },
     tableType,
     testId,
+    viewAllUrl = null,
+    isDashboardTable = false,
   } = config;
 
-  // Initial setup of pagination and sorting
+  // Filter out any false/undefined entries from conditional column definitions
+  const columns = rawColumns.filter(Boolean);
+
+  /**
+   * Two-phase hook initialization: React requires hooks to be called unconditionally and in the
+   * same order on every render, so both hook pairs must be called before 'useTableData' returns data.
+   * Phase 1: empty-state instances to provide required function references to 'useTableData' hook
+   */
   const pagination = useTablePagination({ initPageSize });
   const sorting = useTableSortingAndFiltering({ columns, dataState: {}, initialSort, pagination, searchableFields });
 
@@ -48,7 +57,7 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
   );
   const { dataRows, rowsToShow, loading, totalRowCount, filteredRowCount, setRowsToShow, sortedRows } = dataState;
 
-  // Update pagination, sorting and filtering from parsed data
+  /* Phase 2: data-aware instances to retrieve actual data and drive all UI interactions */
   const paginationWithData = useTablePagination({ initPageSize, sortedRows, setRowsToShow, filteredRowCount });
   const sortingWithData = useTableSortingAndFiltering({ columns, dataState, initialSort, pagination: paginationWithData, searchableFields });
 
@@ -103,6 +112,11 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     }
   }, [loading, rowsToShow, tableType, url]);
 
+  const objectTypeString = useMemo(() => {
+    const cleanedTableType = tableType.replaceAll('_', ' ');
+    return filteredRowCount === 1 ? `${cleanedTableType}` : `${cleanedTableType}s`;
+  }, [filteredRowCount, tableType]);
+
   /**
    * Build search and filter for the header of the table
    */
@@ -110,14 +124,17 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     return (
       <>
         {displayReturnedItemsHTML}
-        <div className="d-flex justify-content-between align-items-center flex-sm-wrap p-4">
-          <div>
+        <div className={`d-flex justify-content-between align-items-center flex-sm-wrap${isDashboardTable ? ' p-4' : ''}`}>
+          <div className="text-muted">
             {(rowsToShow?.length === 0 && !loading)
-              ? 'Showing 0 to 0 of 0 entries'
-              : `Showing ${paginationState.pageIndex * paginationState.pageSize + 1} to${' '}
-          ${Math.min((paginationState.pageIndex + 1) * paginationState.pageSize, filteredRowCount)} of${' '}
-          ${filteredRowCount} entries`}
-            {filteredRowCount < totalRowCount && ` (filtered from ${totalRowCount} total entries)`}
+              ? <span>Showing<b >0</b> to <b>0</b> of <b>0</b> {objectTypeString}</span>
+              : <span>Showing
+                <b> {paginationState.pageIndex * paginationState.pageSize + 1} </b> to
+                <b> {Math.min((paginationState.pageIndex + 1) * paginationState.pageSize, filteredRowCount)}</b> of
+                <b> {filteredRowCount}</b>  {objectTypeString}
+              </span>
+            }
+            {filteredRowCount < totalRowCount && <span> (filtered from <b>{totalRowCount}</b> total {objectTypeString})</span>}
           </div>
           <div className='d-flex justify-content-end gap-2 flex-sm-wrap'>
             <div className="d-flex align-items-center">
@@ -154,7 +171,7 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     tagFilter, handleSearch, handleTagFilter, rowsToShow, loading]);
 
   return (
-    <div className={containerClass}>
+    <div key={`${tableType}-table`} className={containerClass}>
       {searchAndFilter}
       {loading ?
         (<div className="text-center py-3">
@@ -166,22 +183,24 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
         (<>
           <div className="table-responsive">
             {/* min-width is set to an arbitrary value of 1024px to get the table to not shrink for smaller view-ports */}
-            <table className={`table generic-table${tableType == 'unit' || tableType == 'collection' ? '' : ' table-striped'}`} style={tableStyle}>
+            <table className={`table generic-table${isDashboardTable ? '' : ' table-striped'}`} style={tableStyle}>
               <thead data-testid={`${testId}-head`}>
                 <tr>
                   {columns.map((column, index) => (
-                    <th
-                      key={column.key}
-                      className={`${column.sortable ? 'user-select-none' : ''} ${column.key === 'actions' ? 'text-end' : ''}`}
-                      style={{ cursor: column.sortable ? 'pointer' : 'default', width: column.width ? column.width : 'auto' }}
-                      onClick={() => handleSort(index)}
-                      colSpan={1}
-                      rowSpan={1}
-                      scope="col"
-                    >
-                      {column.label}
-                      {getSortIcon(index)}
-                    </th>
+                    column.key != 'actions'
+                      ? (<th
+                        key={column.key}
+                        className={`${column.sortable ? 'user-select-none' : ''}`}
+                        style={{ cursor: column.sortable ? 'pointer' : 'default', width: column.width ? column.width : 'auto' }}
+                        onClick={() => handleSort(index)}
+                        colSpan={1}
+                        rowSpan={1}
+                        scope="col"
+                      >
+                        {column.label}
+                        {getSortIcon(index)}
+                      </th>)
+                      : <td key={column.key} className="invisible-actions-header"></td>
                   ))}
                 </tr>
               </thead>
@@ -206,12 +225,12 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
               </tbody>
             </table>
           </div>
-          <div className="d-flex justify-content-between p-4">
+          <div className={`d-flex justify-content-between${isDashboardTable ? ' p-4' : ''}`}>
             <div>
-              <label className='d-flex align-items-center'>
+              <label className='d-flex align-items-center text-sm text-muted'>
                 Show
                 <select
-                  className="form-select mx-2"
+                  className="form-select mx-2 fw-bold"
                   value={paginationState.pageSize}
                   onChange={e => handlePageSizeChange(Number(e.target.value))}
                 >
@@ -222,40 +241,45 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
                 entries
               </label>
             </div>
-            <nav>
-              <ul className="pagination flex-nowrap mb-0">
-                <li className={`page-item ${paginationState.pageIndex === 0 ? 'disabled' : ''}`}>
-                  <button
-                    className="page-link"
-                    onClick={() => handlePageChange(paginationState.pageIndex - 1)}
-                    disabled={paginationState.pageIndex === 0}
-                  >
-                    Previous
-                  </button>
-                </li>
-                {getPaginationPages().map((page, idx) =>
-                  page === '...' ? (
-                    <li key={`ellipsis-${idx}`} className="page-item disabled">
-                      <span className="page-link">...</span>
-                    </li>
-                  ) : (
-                    <li key={page} className={`page-item ${currentPage === page ? 'active' : ''}`}
+            <div className="d-flex align-items-center gap-3">
+              <nav>
+                <ul className="pagination flex-nowrap mb-0">
+                  <li className={`page-item ${paginationState.pageIndex === 0 ? 'disabled' : ''}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => handlePageChange(paginationState.pageIndex - 1)}
+                      disabled={paginationState.pageIndex === 0}
                     >
-                      <button
-                        className="page-link"
-                        onClick={() => handlePageChange(page - 1)}
-                        disabled={currentPage === page}>{page}</button>
-                    </li>
-                  )
-                )}
-                <li className={`page-item ${paginationState.pageIndex >= totalPages - 1 ? 'disabled' : ''}`}>
-                  <button
-                    className="page-link"
-                    onClick={() => handlePageChange(paginationState.pageIndex + 1)}
-                    disabled={paginationState.pageIndex >= totalPages - 1}>Next</button>
-                </li>
-              </ul>
-            </nav>
+                      Previous
+                    </button>
+                  </li>
+                  {getPaginationPages().map((page, idx) =>
+                    page === '...' ? (
+                      <li key={`ellipsis-${idx}`} className="page-item disabled">
+                        <span className="page-link">...</span>
+                      </li>
+                    ) : (
+                      <li key={page} className={`page-item ${currentPage === page ? 'active' : ''}`}
+                      >
+                        <button
+                          className="page-link"
+                          onClick={() => handlePageChange(page - 1)}
+                          disabled={currentPage === page}>{page}</button>
+                      </li>
+                    )
+                  )}
+                  <li className={`page-item ${paginationState.pageIndex >= totalPages - 1 ? 'disabled' : ''}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => handlePageChange(paginationState.pageIndex + 1)}
+                      disabled={paginationState.pageIndex >= totalPages - 1}>Next</button>
+                  </li>
+                </ul>
+              </nav>
+              {viewAllUrl && (
+                <a href={viewAllUrl} className="dashboard-view-all-link fw-bold">View All  <i className="fa fa-chevron-right" /></a>
+              )}
+            </div>
           </div>
         </>)
       }

--- a/app/javascript/components/tables/GenericTable.jsx
+++ b/app/javascript/components/tables/GenericTable.jsx
@@ -19,7 +19,7 @@ import useTableData from './hooks/useTableData';
 import useTableSortingAndFiltering from './hooks/useTableSortingAndFiltering';
 import useTablePagination from './hooks/useTablePagination';
 
-const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
+const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => {
   const {
     columns,
     containerClass,
@@ -32,6 +32,8 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
     parseDataRow,
     renderCell,
     searchableFields = ['title'],
+    searchPlaceholder = '',
+    tableStyle = { minWidth: '1024px' },
     tableType,
     testId,
   } = config;
@@ -40,9 +42,9 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
   const pagination = useTablePagination({ initPageSize });
   const sorting = useTableSortingAndFiltering({ columns, dataState: {}, initialSort, pagination, searchableFields });
 
-  // Read and parse data from the server response
+  // Read and parse data from the server response or data prop (in dashboard)
   let dataState = useTableData(
-    { url, parseDataRow, pagination: pagination.pagination, sortRows: sorting.sortRows, initialSort, httpMethod }
+    { url, data, parseDataRow, pagination: pagination.pagination, sortRows: sorting.sortRows, initialSort, httpMethod }
   );
   const { dataRows, rowsToShow, loading, totalRowCount, filteredRowCount, setRowsToShow, sortedRows } = dataState;
 
@@ -108,7 +110,7 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
     return (
       <>
         {displayReturnedItemsHTML}
-        <div className="d-flex justify-content-between align-items-center mb-3 flex-sm-wrap">
+        <div className="d-flex justify-content-between align-items-center flex-sm-wrap p-4">
           <div>
             {(rowsToShow?.length === 0 && !loading)
               ? 'Showing 0 to 0 of 0 entries'
@@ -125,6 +127,7 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
                 type="text"
                 value={searchFilter}
                 className="form-control"
+                placeholder={searchPlaceholder}
                 data-testid={`${testId}-search-field`}
                 onChange={handleSearch}
               />
@@ -163,7 +166,7 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
         (<>
           <div className="table-responsive">
             {/* min-width is set to an arbitrary value of 1024px to get the table to not shrink for smaller view-ports */}
-            <table className="table table-striped generic-table" style={{ minWidth: '1024px' }}>
+            <table className={`table generic-table${tableType == 'unit' || tableType == 'collection' ? '' : ' table-striped'}`} style={tableStyle}>
               <thead data-testid={`${testId}-head`}>
                 <tr>
                   {columns.map((column, index) => (
@@ -174,6 +177,7 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
                       onClick={() => handleSort(index)}
                       colSpan={1}
                       rowSpan={1}
+                      scope="col"
                     >
                       {column.label}
                       {getSortIcon(index)}
@@ -202,7 +206,7 @@ const GenericTable = ({ config, url, tags = [], httpMethod = 'POST' }) => {
               </tbody>
             </table>
           </div>
-          <div className="d-flex justify-content-between">
+          <div className="d-flex justify-content-between p-4">
             <div>
               <label className='d-flex align-items-center'>
                 Show

--- a/app/javascript/components/tables/hooks/useTableData.js
+++ b/app/javascript/components/tables/hooks/useTableData.js
@@ -27,13 +27,27 @@ import { useState, useEffect } from 'react';
  * @param {String} params.httpMethod HTTP method to use for requests (default: 'POST')
  * @returns {Object} data state and functions
  */
-const useTableData = ({ url, parseDataRow, pagination, sortRows, initialSort, httpMethod = 'POST' }) => {
+const useTableData = ({ url, data: staticData, parseDataRow, pagination, sortRows, initialSort, httpMethod = 'POST' }) => {
   const [dataRows, setDataRows] = useState([]);
   const [sortedRows, setSortedRows] = useState([]);
   const [rowsToShow, setRowsToShow] = useState([]);
   const [loading, setLoading] = useState(false);
   const [totalRowCount, setTotalRowCount] = useState(0);
   const [filteredRowCount, setFilteredRowCount] = useState(0);
+
+  // Seed from static data prop when provided and skip network fetching
+  useEffect(() => {
+    if (!staticData) return;
+    const parsedData = staticData.map(parseDataRow);
+    setTotalRowCount(parsedData.length);
+    setFilteredRowCount(parsedData.length);
+    setDataRows(parsedData);
+    const { columnKey, dataType, direction } = initialSort;
+    const sortedData = sortRows(parsedData, columnKey, direction, dataType);
+    setSortedRows(sortedData);
+    const { pageSize } = pagination;
+    setRowsToShow(sortedData.slice(0, Math.min(pageSize, sortedData.length)));
+  }, [staticData]);
 
   const fetchData = async () => {
     setLoading(true);
@@ -74,9 +88,9 @@ const useTableData = ({ url, parseDataRow, pagination, sortRows, initialSort, ht
   };
 
   /**
-   * Fetch data when the URL changes
+   * Fetch data when the URL changes when static data is not provided (i.e. dashboard tables)
    */
-  useEffect(() => { fetchData(); }, [url]);
+  useEffect(() => { if (!staticData) fetchData(); }, [url]);
 
   return {
     // State

--- a/app/javascript/server-bundle.js
+++ b/app/javascript/server-bundle.js
@@ -31,6 +31,7 @@ import TimelinesTable from './components/tables/TimelinesTable';
 import EncodingJobsTable from './components/tables/EncodingJobsTable';
 import CheckoutsTable from './components/tables/CheckoutsTable';
 import UsersTable from './components/tables/UsersTable';
+import Dashboard from './components/dashboard/Dashboard';
 
 ReactOnRails.register({
   CollectionList,
@@ -46,4 +47,5 @@ ReactOnRails.register({
   EncodingJobsTable,
   CheckoutsTable,
   UsersTable,
+  Dashboard
 });

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -14,10 +14,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
-<%= render "modules/admin_table",
-      object: 'unit',
-      items: @units %>
-
-<%= render "modules/admin_table",
-      object: 'collection',
-      items: @collections %>
+<%= react_component("Dashboard", { props: {
+  url: admin_dashboard_url(format: :json),
+  new_unit_path: new_admin_unit_path,
+  new_collection_path: new_admin_collection_path,
+  can_create_unit: (can?(:create, Admin::Unit) ? true : false),
+  can_create_collection: (can?(:create, Admin::Collection) ? true : false)
+}}) %>

--- a/spec/features/capybara_admin_collection_spec.rb
+++ b/spec/features/capybara_admin_collection_spec.rb
@@ -20,27 +20,9 @@ describe 'Admin Collection' do
     @unit = FactoryBot.create(:unit)
   end
   after { Warden.test_reset! }
-  it 'checks navigation when create new collection is accessed' do
-    login_as @user, scope: :user
-    visit '/'
-    click_link('Manage Content')
-    expect(page).to have_current_path('/admin/dashboard')
-    expect(page).to have_link('Create Collection')
-    click_link('Create Collection')
-    expect(page).to have_current_path('/admin/collections/new')
-    expect(page).to have_content('Name')
-    expect(page).to have_content('Description')
-    expect(page).to have_content('Unit')
-    expect(page).to have_link('Cancel')
-  end
   it 'checks navigation when create new collection is accessed from unit page' do
     login_as @user, scope: :user
-    visit '/'
-    click_link('Manage Content')
-    expect(page).to have_current_path('/admin/dashboard')
-    expect(page).to have_link(@unit.name)
-    click_link(@unit.name)
-    expect(page).to have_current_path("/admin/units/#{@unit.id}")
+    visit "/admin/units/#{@unit.id}"
     expect(page).to have_link('Create A Collection')
     click_link('Create A Collection')
     expect(page).to have_current_path("/admin/collections/new?unit_id=#{@unit.id}")

--- a/spec/features/capybara_admin_unit_spec.rb
+++ b/spec/features/capybara_admin_unit_spec.rb
@@ -19,18 +19,6 @@ describe 'Admin Unit' do
     @user = FactoryBot.create(:administrator)
   end
   after { Warden.test_reset! }
-  it 'checks navigation when create new unit is accessed' do
-    login_as @user, scope: :user
-    visit '/'
-    click_link('Manage Content')
-    expect(page).to have_current_path('/admin/dashboard')
-    expect(page).to have_link('Create Unit')
-    click_link('Create Unit')
-    expect(page).to have_current_path('/admin/units/new')
-    expect(page).to have_content('Name')
-    expect(page).to have_content('Description')
-    expect(page).to have_link('Cancel')
-  end
   it 'is able to create a new unit' do
     login_as @user, scope: :user
     visit '/admin/units/'

--- a/spec/features/capybara_navigation_spec.rb
+++ b/spec/features/capybara_navigation_spec.rb
@@ -31,8 +31,6 @@ describe 'checks navigation after logging in' do
     expect(page).to have_current_path('/admin/dashboard')
     expect(page).to have_content('Skip to main content')
     expect(page).to have_link('Selected Items (0)')
-    expect(page).to have_link('Create Collection')
-    expect(page).to have_link('Create Unit')
   end
   it 'checks naviagtion to Manage Groups' do
     user = FactoryBot.create(:administrator)

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -46,25 +46,62 @@ RSpec.describe "/admin/dashboard", type: :request do
       context 'collection manager' do
         let(:user) { User.where(username: collection.managers.first).first }
 
-        it "renders the index partial and displays only collections" do
+        it "returns collection data and no unit data" do
           get admin_dashboard_url
           expect(response).to be_successful
           expect(response).to render_template(:index)
-          expect(response.body).to include 'Test Collection'
-          expect(response.body).to include 'You don\'t have any units yet'
-          expect(response.body).to_not include 'Test Unit'
+
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          expect(json['collections'].map { |c| c['name'] }).to include('Test Collection')
+          expect(json['units']).to be_empty
+        end
+
+        it "includes remove_url for collections the manager can destroy" do
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          test_collection = json['collections'].find { |c| c['name'] == 'Test Collection' }
+          expect(test_collection['remove_url']).to eq("/admin/collections/#{collection.id}/remove")
+        end
+      end
+
+      context 'collection editor' do
+        let(:user) { User.where(username: collection.editors.first).first }
+
+        it "omits remove_url for collections the editor cannot destroy" do
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          test_collection = json['collections'].find { |c| c['name'] == 'Test Collection' }
+          expect(test_collection['remove_url']).to be_nil
         end
       end
 
       context 'unit administrator' do
         let(:user) { User.where(username: unit.unit_admins.first).first }
 
-        it "renders the index partial and displays units and collections" do
+        it "returns both unit and collection data" do
           get admin_dashboard_url
           expect(response).to be_successful
           expect(response).to render_template(:index)
-          expect(response.body).to include 'Test Collection'
-          expect(response.body).to include 'Test Unit'
+
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          expect(json['collections'].map { |c| c['name'] }).to include('Test Collection')
+          expect(json['units'].map { |u| u['name'] }).to include('Test Unit')
+        end
+
+        it "includes remove_url for units the unit admin can destroy" do
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          test_unit = json['units'].find { |u| u['name'] == 'Test Unit' }
+          expect(test_unit['remove_url']).to eq("/admin/units/#{unit.id}/remove")
+        end
+
+        it "includes remove_url for collections inherited via unit admin role" do
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          test_collection = json['collections'].find { |c| c['name'] == 'Test Collection' }
+          expect(test_collection['remove_url']).to eq("/admin/collections/#{collection.id}/remove")
         end
       end
     end


### PR DESCRIPTION
Related issue: #6775

Changes in this PR:
- adds JSON endpoint to the dashboard index  that fetches units and collections for the current user
- adds `Dashboard` React component that fetches from the JSON endpoint and renders `Units` and `Collections` sections
- adds `UnitsTable` and `CollectionsTable` components backed by the existing `GenericTable` infrastructure, with column definitions, sort config, search, pagination, and edit/delete action buttons

<img width="1327" height="650" alt="units-table" src="https://github.com/user-attachments/assets/617ffb69-36c7-4102-8649-0f429bac1042" />
<img width="1327" height="662" alt="collections-table" src="https://github.com/user-attachments/assets/f81f167c-9ff5-4bb6-8731-b3ce0ce6a4c9" />
