### PR TITLE
Make requested changes to the dashboard tables

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -83,12 +83,12 @@ input[name="admin_group[resources][]"] {
 .devise-links span.devise-link:first-child {
   border-left: none;
 }
-.section-title,
+
+/* ------------------------------ Admin Dashboard Tables ------------------------------ */
+
 .section-create-button {
   text-transform: capitalize;
 }
-
-/* ------------------------------ Admin Dashboard Tables ------------------------------ */
 
 .dashboard-table-container {
   border: 1px solid $lightgray;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -177,12 +177,7 @@ input[name="admin_group[resources][]"] {
   font-weight: 600;
   letter-spacing: 0.04em;
   color: $primary;
-  text-decoration: none;
   text-wrap: nowrap;
-
-  &:hover {
-    text-decoration: underline;
-  }
 }
 
 .dashboard-action-icons {

--- a/app/javascript/components/dashboard/CollectionsTable.jsx
+++ b/app/javascript/components/dashboard/CollectionsTable.jsx
@@ -20,12 +20,14 @@ import GenericTable from '../tables/GenericTable';
  * Render a table displaying all collection for the admin dashboard.
  * @param {Object} props
  * @param {Array}  props.data array of collection objects from the dashboard JSON endpoint
+ * @param {String} props.createPath create new collection end-point
  * @param {Object} props.helpers shared helpers for common utilities in dashboard tables
  */
-const CollectionsTable = ({ data, helpers }) => {
+const CollectionsTable = ({ data, createPath, helpers }) => {
   const { truncateDescription, DashboardActionButtons } = helpers;
   const collectionConfig = {
     // Table metadata
+    tableTitle: 'My Collections',
     tableType: 'collection',
     containerClass: 'dashboard-table-container',
     testId: 'collection-table',
@@ -38,8 +40,12 @@ const CollectionsTable = ({ data, helpers }) => {
     searchPlaceholder: 'Search collections by name or unit...',
 
     // Table pagination customization
-    initPageSize: 5,
-    pageSizeOptions: [5, 10, 25, 50],
+    initPageSize: 10,
+    pageSizeOptions: [10, 25, 50, 100],
+    storageKey: 'collectionTablePageSize',
+
+    // Table create button
+    createButton: { btnClass: 'btn-outline', createPath },
 
     // Column definitions
     columns: [
@@ -49,9 +55,6 @@ const CollectionsTable = ({ data, helpers }) => {
       { key: 'description', label: 'Description', sortable: false, width: '40%' },
       { key: 'actions', label: '', sortable: false, width: '8%' },
     ],
-
-    // View all link for collections
-    viewAllUrl: '/admin/collections',
 
     // Parsing function to extract data from back-end
     parseDataRow: (row) => ({
@@ -74,14 +77,14 @@ const CollectionsTable = ({ data, helpers }) => {
       switch (columnKey) {
         case 'name':
           return (
-            <a href={item.collection_url} className="fw-bold text-decoration-none text-dark" data-testid="collection-name-table">
+            <a href={item.collection_url} className="fw-bold text-dark" data-testid="collection-name-table">
               {item.name}
             </a>
           );
         case 'items':
           return (
             <div>
-              <a href={item.search_url} className="fw-bold text-decoration-none text-dark">
+              <a href={item.search_url} className="fw-bold text-dark">
                 {item.items} {item.items === 1 ? 'item' : 'items'}
               </a>
               {item.unpublished_items > 0 && (

--- a/app/javascript/components/dashboard/Dashboard.jsx
+++ b/app/javascript/components/dashboard/Dashboard.jsx
@@ -65,21 +65,9 @@ const DashboardSection = ({ data, canCreate, createPath, btnClass, sectionType, 
 
   if (data.length > 0) {
     return (
-      <>
-        <div className="d-flex justify-content-between page-title-wrapper mb-3">
-          <h1 className="page-title mb-0 section-title">{`My ${sectionType}s`}</h1>
-          {canCreate && (
-            <a href={createPath}>
-              <span className={`btn ${btnClass} btn-large section-create-button`} data-testid={`${sectionType}-create-${sectionType}-button`}>
-                <i className="fa fa-plus" aria-hidden="true"></i> {`Create ${sectionType}`}
-              </span>
-            </a>
-          )}
-        </div>
-        <div className={tableWrapperClass}>
-          <TableComponent data={data} helpers={helpers} />
-        </div>
-      </>
+      <div className={tableWrapperClass}>
+        <TableComponent data={data} createPath={createPath} helpers={helpers} />
+      </div>
     );
   }
 
@@ -162,7 +150,7 @@ const Dashboard = ({ url, new_unit_path, new_collection_path, can_create_unit, c
         btnClass="btn-outline"
         sectionType="unit"
         TableComponent={UnitsTable}
-        tableWrapperClass="mb-5"
+        tableWrapperClass="mb-4"
       />
       <DashboardSection
         data={collections}

--- a/app/javascript/components/dashboard/UnitsTable.jsx
+++ b/app/javascript/components/dashboard/UnitsTable.jsx
@@ -20,12 +20,14 @@ import GenericTable from '../tables/GenericTable';
  * Render a table displaying all units for the admin dashboard.
  * @param {Object} props
  * @param {Array}  props.data array of unit objects from the dashboard JSON endpoint
+ * @param {String} props.createPath create new unit end-point
  * @param {Object} props.helpers shared helpers for common utilities in dashboard tables
  */
-const UnitsTable = ({ data, helpers }) => {
+const UnitsTable = ({ data, createPath, helpers }) => {
   const { truncateDescription, DashboardActionButtons } = helpers;
   const unitConfig = {
     // Table metadata
+    tableTitle: 'My Units',
     tableType: 'unit',
     isDashboardTable: true,
     containerClass: 'dashboard-table-container',
@@ -40,6 +42,10 @@ const UnitsTable = ({ data, helpers }) => {
     // Table pagination customization
     initPageSize: 5,
     pageSizeOptions: [5, 10, 25, 50],
+    storageKey: 'unitTablePageSize',
+
+    // Table create button
+    createButton: { btnClass: 'btn-outline', createPath },
 
     // Column definitions
     columns: [
@@ -48,9 +54,6 @@ const UnitsTable = ({ data, helpers }) => {
       { key: 'description', label: 'Description', sortable: false, width: '45%' },
       { key: 'actions', label: '', sortable: false, width: '10%' },
     ],
-
-    // View all link for units
-    viewAllUrl: '/admin/units',
 
     // Parsing function to extract data from back-end
     parseDataRow: (row) => ({
@@ -71,13 +74,13 @@ const UnitsTable = ({ data, helpers }) => {
       switch (columnKey) {
         case 'name':
           return (
-            <a href={item.unit_url} className="fw-bold text-decoration-none text-dark" data-testid="unit-name-table">
+            <a href={item.unit_url} className="fw-bold text-dark" data-testid="unit-name-table">
               {item.name}
             </a>
           );
         case 'items':
           return (
-            <a href={item.search_url} className="text-decoration-none" data-testid="unit-collections-count">
+            <a href={item.search_url} data-testid="unit-collections-count">
               {item.items} {item.items === 1 ? 'collection' : 'collections'}
             </a>
           );

--- a/app/javascript/components/tables/GenericTable.jsx
+++ b/app/javascript/components/tables/GenericTable.jsx
@@ -138,9 +138,7 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
       <>
         {displayReturnedItemsHTML}
         <div className={`d-flex justify-content-between align-items-center flex-sm-wrap${isDashboardTable ? ' p-4' : ''}`}>
-          <div className="d-flex justify-content-between page-title-wrapper mb-3">
-            <h1 className="page-title mb-0 section-title">{tableTitle}</h1>
-          </div>
+          <h1 className="page-title mb-0">{tableTitle}</h1>
           <div className='d-flex justify-content-end gap-2 flex-sm-wrap'>
             <div className="d-flex align-items-center">
               <label htmlFor={`search-${tableType}`} className="me-2 mb-0">Search:</label>

--- a/app/javascript/components/tables/GenericTable.jsx
+++ b/app/javascript/components/tables/GenericTable.jsx
@@ -36,19 +36,26 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     tableStyle = { minWidth: '1024px' },
     tableType,
     testId,
-    viewAllUrl = null,
+    storageKey = null,
     isDashboardTable = false,
+    tableTitle = '',
+    createButton = { btnClass: '', createPath: '' },
   } = config;
 
   // Filter out any false/undefined entries from conditional column definitions
   const columns = rawColumns.filter(Boolean);
+
+  // Read persisted page size from localStorage or default to initPageSize from config
+  const currentPageSize = storageKey
+    ? (Number(localStorage.getItem(storageKey)) || initPageSize)
+    : initPageSize;
 
   /**
    * Two-phase hook initialization: React requires hooks to be called unconditionally and in the
    * same order on every render, so both hook pairs must be called before 'useTableData' returns data.
    * Phase 1: empty-state instances to provide required function references to 'useTableData' hook
    */
-  const pagination = useTablePagination({ initPageSize });
+  const pagination = useTablePagination({ initPageSize: currentPageSize });
   const sorting = useTableSortingAndFiltering({ columns, dataState: {}, initialSort, pagination, searchableFields });
 
   // Read and parse data from the server response or data prop (in dashboard)
@@ -58,7 +65,7 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
   const { dataRows, rowsToShow, loading, totalRowCount, filteredRowCount, setRowsToShow, sortedRows } = dataState;
 
   /* Phase 2: data-aware instances to retrieve actual data and drive all UI interactions */
-  const paginationWithData = useTablePagination({ initPageSize, sortedRows, setRowsToShow, filteredRowCount });
+  const paginationWithData = useTablePagination({ initPageSize: currentPageSize, sortedRows, setRowsToShow, filteredRowCount });
   const sortingWithData = useTableSortingAndFiltering({ columns, dataState, initialSort, pagination: paginationWithData, searchableFields });
 
   const {
@@ -66,9 +73,15 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
     totalPages,
     currentPage,
     handlePageChange,
-    handlePageSizeChange,
+    updatePageSize,
     getPaginationPages,
   } = paginationWithData;
+
+  const handlePageSizeChange = (newSize) => {
+    // Persist selected page size for dashboard tables in localStorage
+    if (storageKey) localStorage.setItem(storageKey, newSize);
+    updatePageSize(newSize);
+  };
 
   const { handleSort, getSortIcon, searchFilter, tagFilter, handleSearch, handleTagFilter } = sortingWithData;
 
@@ -125,16 +138,8 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
       <>
         {displayReturnedItemsHTML}
         <div className={`d-flex justify-content-between align-items-center flex-sm-wrap${isDashboardTable ? ' p-4' : ''}`}>
-          <div className="text-muted">
-            {(rowsToShow?.length === 0 && !loading)
-              ? <span>Showing<b >0</b> to <b>0</b> of <b>0</b> {objectTypeString}</span>
-              : <span>Showing
-                <b> {paginationState.pageIndex * paginationState.pageSize + 1} </b> to
-                <b> {Math.min((paginationState.pageIndex + 1) * paginationState.pageSize, filteredRowCount)}</b> of
-                <b> {filteredRowCount}</b>  {objectTypeString}
-              </span>
-            }
-            {filteredRowCount < totalRowCount && <span> (filtered from <b>{totalRowCount}</b> total {objectTypeString})</span>}
+          <div className="d-flex justify-content-between page-title-wrapper mb-3">
+            <h1 className="page-title mb-0 section-title">{tableTitle}</h1>
           </div>
           <div className='d-flex justify-content-end gap-2 flex-sm-wrap'>
             <div className="d-flex align-items-center">
@@ -164,6 +169,13 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
               </select>
             </div>)}
           </div>
+          {createButton.createPath != '' && (
+            <a href={createButton.createPath}>
+              <span className={`btn ${createButton.btnClass} btn-large section-create-button`} data-testid={`${tableType}-create-${tableType}-button`}>
+                <i className="fa fa-plus" aria-hidden="true"></i> {`Create ${tableType}`}
+              </span>
+            </a>
+          )}
         </div>
       </>
     );
@@ -241,44 +253,54 @@ const GenericTable = ({ config, url, data, tags = [], httpMethod = 'POST' }) => 
                 entries
               </label>
             </div>
-            <div className="d-flex align-items-center gap-3">
-              <nav>
-                <ul className="pagination flex-nowrap mb-0">
-                  <li className={`page-item ${paginationState.pageIndex === 0 ? 'disabled' : ''}`}>
-                    <button
-                      className="page-link"
-                      onClick={() => handlePageChange(paginationState.pageIndex - 1)}
-                      disabled={paginationState.pageIndex === 0}
-                    >
-                      Previous
-                    </button>
-                  </li>
-                  {getPaginationPages().map((page, idx) =>
-                    page === '...' ? (
-                      <li key={`ellipsis-${idx}`} className="page-item disabled">
-                        <span className="page-link">...</span>
-                      </li>
-                    ) : (
-                      <li key={page} className={`page-item ${currentPage === page ? 'active' : ''}`}
+            <div className="d-flex justify-content-between align-items-center gap-3">
+              <div className="text-muted">
+                {(rowsToShow?.length === 0 && !loading)
+                  ? <span>Showing<b >0</b> - <b>0</b> of <b>0</b> {objectTypeString}</span>
+                  : <span>Showing
+                    <b> {paginationState.pageIndex * paginationState.pageSize + 1} </b> -
+                    <b> {Math.min((paginationState.pageIndex + 1) * paginationState.pageSize, filteredRowCount)}</b> of
+                    <b> {filteredRowCount}</b>  {objectTypeString}
+                  </span>
+                }
+                {filteredRowCount < totalRowCount && <span> (filtered from <b>{totalRowCount}</b> total {objectTypeString})</span>}
+              </div>
+              <div className="d-flex align-items-center gap-3">
+                <nav>
+                  <ul className="pagination flex-nowrap mb-0">
+                    <li className={`page-item ${paginationState.pageIndex === 0 ? 'disabled' : ''}`}>
+                      <button
+                        className="page-link"
+                        onClick={() => handlePageChange(paginationState.pageIndex - 1)}
+                        disabled={paginationState.pageIndex === 0}
                       >
-                        <button
-                          className="page-link"
-                          onClick={() => handlePageChange(page - 1)}
-                          disabled={currentPage === page}>{page}</button>
-                      </li>
-                    )
-                  )}
-                  <li className={`page-item ${paginationState.pageIndex >= totalPages - 1 ? 'disabled' : ''}`}>
-                    <button
-                      className="page-link"
-                      onClick={() => handlePageChange(paginationState.pageIndex + 1)}
-                      disabled={paginationState.pageIndex >= totalPages - 1}>Next</button>
-                  </li>
-                </ul>
-              </nav>
-              {viewAllUrl && (
-                <a href={viewAllUrl} className="dashboard-view-all-link fw-bold">View All  <i className="fa fa-chevron-right" /></a>
-              )}
+                        Previous
+                      </button>
+                    </li>
+                    {getPaginationPages().map((page, idx) =>
+                      page === '...' ? (
+                        <li key={`ellipsis-${idx}`} className="page-item disabled">
+                          <span className="page-link">...</span>
+                        </li>
+                      ) : (
+                        <li key={page} className={`page-item ${currentPage === page ? 'active' : ''}`}
+                        >
+                          <button
+                            className="page-link"
+                            onClick={() => handlePageChange(page - 1)}
+                            disabled={currentPage === page}>{page}</button>
+                        </li>
+                      )
+                    )}
+                    <li className={`page-item ${paginationState.pageIndex >= totalPages - 1 ? 'disabled' : ''}`}>
+                      <button
+                        className="page-link"
+                        onClick={() => handlePageChange(paginationState.pageIndex + 1)}
+                        disabled={paginationState.pageIndex >= totalPages - 1}>Next</button>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
             </div>
           </div>
         </>)

--- a/app/javascript/components/tables/hooks/useTablePagination.js
+++ b/app/javascript/components/tables/hooks/useTablePagination.js
@@ -48,7 +48,7 @@ const useTablePagination = ({ initPageSize, sortedRows, setRowsToShow, filteredR
     setRowsToShow(sortedRows.slice(start, end));
   };
 
-  const handlePageSizeChange = (newPageSize) => {
+  const updatePageSize = (newPageSize) => {
     setRowsToShow(sortedRows.slice(0, newPageSize));
     setPagination({ pageIndex: 0, pageSize: newPageSize });
   };
@@ -86,7 +86,7 @@ const useTablePagination = ({ initPageSize, sortedRows, setRowsToShow, filteredR
 
     // Functions
     handlePageChange,
-    handlePageSizeChange,
+    updatePageSize,
     getPaginationPages
   };
 };


### PR DESCRIPTION
Related issue: #6795

Changes in this PR:
- Remove "View all" text and link
- Persist selected page size for unit and collection tables in localStorage for future page refreshes
- Updates page sizes for,
  - Units table: 5, 10, 25, 50
  - Collections table: 10, 25, 50, 100
- Moved table name inside the table boundaries
- Moved `Showing 1 - 5 of 10 collections` text to the bottom of the table (inspired by material-ui table designs: https://mui.com/material-ui/react-table/) to make space for search and table titles
- Add underlines for all links in the table

Dashboard with the changes;
<img width="1148" height="941" alt="dashboard-changes" src="https://github.com/user-attachments/assets/0ae6cf3d-ac50-4d36-ab81-2517113ad46e" />

The only change that affects the other tables is the placement of `Showing 1 - 5 of 10 ..` text as below;
<img width="1240" height="636" alt="dashboard-changes-playlists" src="https://github.com/user-attachments/assets/781334b8-2fa0-417d-b208-932776852434" />
