### PR TITLE
Make admin collection and unit page titles a little clearer

### DIFF
--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% @page_title = t('collections.show.title', :collection_name => @collection.name, :application_name => application_name) %>
 
 <div class="page-title-wrapper">
-  <h1 class="page-title">Manage Content</h1>
+  <h1 class="page-title">Manage Collection</h1>
 </div>
 <div class="modal fade" id="modal" data-bs-backdrop="static" tabindex="-1" role="dialog" aria-labelledby="modalLabel"
   aria-hidden="true">

--- a/app/views/admin/units/show.html.erb
+++ b/app/views/admin/units/show.html.erb
@@ -16,7 +16,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% @page_title = t('units.show.title', :unit_name => @unit.name, :application_name => application_name) %>
 
 <div class="page-title-wrapper">
-  <h1 class="page-title">Manage Units</h1>
+  <h1 class="page-title">Manage Unit</h1>
 </div>
 <div class="modal fade" id="modal" data-bs-backdrop="static" tabindex="-1" role="dialog" aria-labelledby="modalLabel"
   aria-hidden="true">


### PR DESCRIPTION
Was "Manage Units"; now...
<img width="1343" height="300" alt="image" src="https://github.com/user-attachments/assets/784686a0-2e75-4919-a124-e62c9d7a1b94" />
Was "Manage Content"; now...
<img width="1347" height="368" alt="image" src="https://github.com/user-attachments/assets/e8c855dd-de0b-4bb9-874d-2e7bd4d0bead" />
