### PR TITLE
Prevent publication of API media object without masterfile

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -647,6 +647,8 @@ class MediaObjectsController < ApplicationController
     note = mo_parameters.delete(:note) || []
     note_type = mo_parameters.delete(:note_type) || []
     mo_parameters[:note] = note.zip(note_type).map{|a|{note: a[0],type: a[1]}}
+    # Publisher should not be a valid field during object creation
+    mo_parameters.delete(:avalon_publisher) if params[:action] == "create"
 
     mo_parameters
   end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -327,6 +327,31 @@ describe MediaObjectsController, type: :controller do
           expect(new_media_object.sections.first.derivatives.first.location_url).to eq(absolute_location)
           expect(new_media_object.workflow.last_completed_step).to eq([HYDRANT_STEPS.last.step])
         end
+        context "without files" do
+          it "should create a new media_object" do
+            media_object = FactoryBot.create(:media_object)
+            fields = {other_identifier_type: []}
+            descMetadata_fields.each {|f| fields[f] = media_object.send(f) }
+            post 'create', params: { format: 'json', fields: fields, collection_id: collection.id }
+            expect(response.status).to eq(200)
+            new_media_object = MediaObject.find(JSON.parse(response.body)['id'])
+            expect(new_media_object.title).to eq media_object.title
+            expect(new_media_object.creator).to eq media_object.creator
+            expect(new_media_object.date_issued).to eq media_object.date_issued
+            expect(new_media_object.section_ids.size).to eq 0
+            expect(new_media_object.workflow.last_completed_step).to eq([HYDRANT_STEPS.last.step])
+          end
+          it 'should not publish new media object' do
+            media_object = FactoryBot.create(:media_object)
+            fields = {}
+            descMetadata_fields.each {|f| fields[f] = media_object.send(f) }
+            fields.merge!({ avalon_publisher: administrator.user_key })
+            post 'create', params: { format: 'json', fields: fields, collection_id: collection.id, publish: true }
+            expect(response.status).to eq(200)
+            new_media_object = MediaObject.find(JSON.parse(response.body)['id'])
+            expect(new_media_object.published?).to be_falsey
+          end
+        end
         context "accessibility enforcement disabled" do
           before { allow(Settings.accessibility_compliance).to receive(:enforce).and_return(false) }
           it "should create a new published media_object" do


### PR DESCRIPTION
This is a tie in to #6767. It turned out that we already had everything in place for that ticket and did not need to make any code changes, we just need to update documentation. 

However, I did find an edge case where `avalon_publisher` can be passed in as part of the metadata payload for object creation. When that is passed in and no master files are provided, none of the regular API publishing workflow is touched and so the empty object gets published. This does not seem like behavior we want, so I made a change to strip that metadata field when performing the 'create' action.