### PR TITLE
Use SpeedyAF proxies for non-save actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -263,6 +263,12 @@ class ApplicationController < ActionController::Base
     obj || GlobalID::Locator.locate(id)
   end
 
+  def fetch_proxy(id)
+    SpeedyAF::Base.find(id)
+  rescue SpeedyAF::RecordNotFound
+    fetch_object(id)
+  end
+
   private
 
     def application_name

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -16,7 +16,7 @@ class ObjectsController < ApplicationController
   layout false, only: [:autocomplete]
 
   def show
-    obj = fetch_object params[:id]
+    obj = fetch_proxy params[:id]
     if obj.blank?
       redirect_to root_path
     else

--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -16,7 +16,8 @@
 class SupplementalFilesController < ApplicationController
   include Rails::Pagination
 
-  before_action :set_object
+  before_action :set_object, only: [:create, :update, :destroy]
+  before_action :set_proxy, except: [:create, :update, :destroy]
   before_action :authorize_object
 
   rescue_from Avalon::SaveError do |exception|
@@ -161,6 +162,10 @@ class SupplementalFilesController < ApplicationController
 
     def set_object
       @object = fetch_object params[:master_file_id] || params[:media_object_id]
+    end
+
+    def set_proxy
+      @object = fetch_proxy params[:master_file_id] || params[:media_object_id]
     end
 
     def validate_params

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -50,6 +50,20 @@ describe ObjectsController do
       get :show, params: { id: obj.id, urlappend: 'http://google.com' }
       expect(response).to redirect_to(media_object_path(obj))
     end
+
+    context 'read from solr' do
+      let(:obj) { FactoryBot.create(:media_object) }
+
+      before do
+        obj
+      end
+
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        get :show, params: { id: obj.id }
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe "#autocomplete" do

--- a/spec/controllers/supplemental_files_controller_spec.rb
+++ b/spec/controllers/supplemental_files_controller_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe SupplementalFilesController, type: :controller do
           expect(response.body).to eq SupplementalFile.convert_from_srt(File.read(file))
         end
       end
+
+      context 'read from solr' do
+        before do
+          master_file
+          supplemental_file
+        end
+
+        it 'should not read from fedora' do
+          WebMock.reset_executed_requests!
+          get :captions, params: { master_file_id: master_file.id, id: supplemental_file.id }, session: valid_session
+          expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+        end
+      end
     end
   end
 end

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -132,6 +132,18 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
       expect(subject.count).to eq 1
       expect(subject.first.symbolize_keys).to eq supplemental_file.as_json
     end
+
+    context 'read from solr' do
+      before do
+        object
+      end
+
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        get :index, params: { class_id => object.id, format: 'json' }, session: valid_session
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
   end
 
   describe "GET #show" do
@@ -149,6 +161,19 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
       it 'returns the supplemental file metadata' do
         get :show, params: { class_id => object.id, id: supplemental_file.id, format: 'json' }, session: valid_session
         expect(JSON.parse(response.body).symbolize_keys).to eq supplemental_file.as_json
+      end
+    end
+
+    context 'read from solr' do
+      before do
+        object
+        supplemental_file
+      end
+
+      it 'should not read from fedora' do
+        WebMock.reset_executed_requests!
+        get :show, params: { class_id => object.id, id: supplemental_file.id }, session: valid_session
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
       end
     end
   end


### PR DESCRIPTION
Related issue: #6081

Fedora requests were being made on all action types for supplemental file controller and the show action of the objects controller. This commit adds a `fetch_proxy` method so we can retrieve object proxies for any controller actions that do not require a save, reducing unnecessary calls to fedora.