### PR TITLE
Fix and test issues with disable inheritance

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -211,7 +211,7 @@ class Ability
       # end
 
       cannot :read, [MediaObject, SpeedyAF::Proxy::MediaObject] do |media_object|
-        media_object.disable_inheritance? && is_exclusively_inherited_from_parent?(media_object)
+        media_object.disable_inheritance? && is_exclusively_inherited_from_parent?(media_object) && !is_member_of?(media_object.collection)
       end
 
       cannot :update, [MediaObject, SpeedyAF::Proxy::MediaObject] do |media_object|
@@ -381,8 +381,13 @@ class Ability
   end
 
   def is_exclusively_inherited_from_parent?(media_object)
-    (!@user.in?(media_object.read_users) && @user.in?(media_object.inherited_read_users)) ||
-      ((@user_groups & media_object.read_groups).empty? && !(@user_groups & media_object.inherited_read_groups).empty?)
+    # User isn't in item's read users or item's read groups (not explicitly granted access to item) AND
+    # User isn't in item's read users and is inherited from parent (exclusively inherited user) OR
+    # User isn't in item's read groups and is in a read group inherited from parent (exclusively inherited group)
+    # Short form: NOT explicitly granted access to item AND (explicitly inherited user OR explicitly inherited group)
+    !(@user.in?(media_object.read_users) || !(@user_groups & media_object.read_groups).empty?) &&
+    ((!@user.in?(media_object.read_users) && @user.in?(media_object.inherited_read_users)) ||
+      ((@user_groups & media_object.read_groups).empty? && !(@user_groups & media_object.inherited_read_groups).empty?))
   end
 
   def is_member_of_any_collection?

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -796,6 +796,32 @@ describe MediaObjectsController, type: :controller do
         end
       end
 
+      context 'inherited edit permissions' do
+        let!(:unpublished_media_object) { FactoryBot.create(:media_object, visibility: 'private', collection: collection) }
+        let!(:disabled_media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, disable_inheritance: true) }
+        let!(:inherited_media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection) }
+        let(:collection) { FactoryBot.create(:collection, managers: [user.username]) }
+
+        context 'for user' do
+          context 'from collection level' do
+            it "should return list of media_objects that the user is authorized to view" do
+              get 'index', format: 'json'
+              expect(json.count).to eq(4)
+            end
+          end
+
+          context 'from unit level' do
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            let(:unit) { FactoryBot.create(:unit, managers: [user.username]) }
+
+            it "should return list of media_objects that the user is authorized to view" do
+              get 'index', format: 'json'
+              expect(json.count).to eq(4)
+            end
+          end
+        end
+      end
+
       context 'inherited read permissions' do
         let!(:unpublished_media_object) { FactoryBot.create(:media_object, visibility: 'private', collection: collection) }
         let!(:disabled_media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, disable_inheritance: true) }
@@ -1025,10 +1051,79 @@ describe MediaObjectsController, type: :controller do
 
       context "inherited access" do
         context "for user" do
+          context 'inherited edit permissions' do
+            context "from collection" do
+              let(:user) { FactoryBot.create(:user) }
+              let(:media_object) { FactoryBot.create(:published_media_object, collection: collection) }
+              let(:collection) { FactoryBot.create(:collection, managers: [user.username]) }
+
+              it "should be available to an edit user granted access at collection level" do
+                login_user user.username
+                get 'show', params: { id: media_object.id }
+                expect(response.response_code).to eq(200)
+              end
+
+              context "when inheritance disabled" do
+                let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, disable_inheritance: true) }
+
+                it "should be available to an edit user granted access at collection level" do
+                  login_user user.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
+
+                context "and overridden visibility restricts from non-private to private" do
+                  let(:collection) { FactoryBot.create(:collection, default_visibility: 'public', managers: [user.username]) }
+                  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, disable_inheritance: true) }
+
+                  it "should be available to an edit user granted access at collection level" do
+                    login_user user.username
+                    get 'show', params: { id: media_object.id }
+                    expect(response.response_code).to eq(200)
+                  end
+                end
+              end
+            end
+
+            context "from unit" do
+              let(:user) { FactoryBot.create(:user) }
+              let(:media_object) { FactoryBot.create(:published_media_object, collection: collection) }
+              let(:collection) { FactoryBot.create(:collection, unit: unit) }
+              let(:unit) { FactoryBot.create(:unit, managers: [user.username]) }
+
+              it "should be available to an edit user granted access at unit level" do
+                login_user user.username
+                get 'show', params: { id: media_object.id }
+                expect(response.response_code).to eq(200)
+              end
+
+              context "when inheritance disabled" do
+                let(:media_object) { FactoryBot.create(:published_media_object, :with_master_file, collection: collection, disable_inheritance: true) }
+
+                it "should be available to an edit user granted access at unit level" do
+                  login_user user.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
+
+                context "and overridden visibility restricts from non-private to private" do
+                  let(:collection) { FactoryBot.create(:collection, default_visibility: 'public', unit: unit) }
+                  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, disable_inheritance: true) }
+
+                  it "should be available to an edit user granted access at collection level" do
+                    login_user user.username
+                    get 'show', params: { id: media_object.id }
+                    expect(response.response_code).to eq(200)
+                  end
+                end
+              end
+            end
+          end
+
           context "from collection" do
             let(:user) { FactoryBot.create(:user) }
             let(:mo_member) { FactoryBot.create(:user) }
-            let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username]) }
+            let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [mo_member.username]) }
             let(:collection) { FactoryBot.create(:collection, default_read_users: [user.username]) }
 
             it "should be available to a user granted access at collection level" do
@@ -1039,7 +1134,7 @@ describe MediaObjectsController, type: :controller do
 
             context "when inheritance disabled" do
               let(:multi_user) { FactoryBot.create(:user) }
-              let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username, multi_user.username], disable_inheritance: true) }
+              let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [mo_member.username, multi_user.username], disable_inheritance: true) }
               let(:collection) { FactoryBot.create(:collection, default_read_users: [user.username, multi_user.username]) }
 
               it "should block access to inherited user" do
@@ -1059,13 +1154,24 @@ describe MediaObjectsController, type: :controller do
                 get 'show', params: { id: media_object.id }
                 expect(response.response_code).to eq(200)
               end
-            end
+
+              context "and overridden visibility restricts from non-private to private" do
+                let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+                let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username], disable_inheritance: true) }
+
+                it "should not block access to non-inherited user" do
+                  login_user mo_member.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
+              end
+          end
           end
 
           context "from unit" do
             let(:user) { FactoryBot.create(:user) }
             let(:mo_member) { FactoryBot.create(:user) }
-            let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username]) }
+            let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [mo_member.username]) }
             let(:collection) { FactoryBot.create(:collection, unit: unit) }
             let(:unit) { FactoryBot.create(:unit, default_read_users: [user.username]) }
 
@@ -1077,7 +1183,7 @@ describe MediaObjectsController, type: :controller do
 
             context "when inheritance disabled" do
               let(:multi_user) { FactoryBot.create(:user) }
-              let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username, multi_user.username], disable_inheritance: true) }
+              let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [mo_member.username, multi_user.username], disable_inheritance: true) }
               let(:collection) { FactoryBot.create(:collection, unit: unit) }
               let(:unit) { FactoryBot.create(:unit, default_read_users: [user.username, multi_user.username]) }
 
@@ -1097,6 +1203,17 @@ describe MediaObjectsController, type: :controller do
                 login_user multi_user.username
                 get 'show', params: { id: media_object.id }
                 expect(response.response_code).to eq(200)
+              end
+
+              context "and overridden visibility restricts from non-private to private" do
+                let(:collection) { FactoryBot.create(:collection, default_visibility: 'public', unit: unit) }
+                let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_users: [mo_member.username], disable_inheritance: true) }
+
+                it "should not block access to non-inherited user" do
+                  login_user mo_member.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
               end
             end
           end
@@ -1150,6 +1267,19 @@ describe MediaObjectsController, type: :controller do
                 get 'show', params: { id: media_object.id }
                 expect(response.response_code).to eq(200)
               end
+
+              context "and overridden visibility restricts from non-private to private" do
+                let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+                let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_groups: [group.name], disable_inheritance: true) }
+
+                it "should not block access to non-inherited group" do
+                  allow(controller).to receive(:current_user).and_return(group_member)
+                  allow(group_member).to receive(:groups).and_return([group.name])
+                  login_user group_member.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
+              end
             end
           end
 
@@ -1195,6 +1325,19 @@ describe MediaObjectsController, type: :controller do
                 login_user multi_user.username
                 get 'show', params: { id: media_object.id }
                 expect(response.response_code).to eq(200)
+              end
+
+              context "and overridden visibility restricts from non-private to private" do
+                let(:collection) { FactoryBot.create(:collection, default_visibility: 'public', unit: unit) }
+                let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection, read_groups: [group.name], disable_inheritance: true) }
+
+                it "should not block access to non-inherited group" do
+                  allow(controller).to receive(:current_user).and_return(group_member)
+                  allow(group_member).to receive(:groups).and_return([group.name])
+                  login_user group_member.username
+                  get 'show', params: { id: media_object.id }
+                  expect(response.response_code).to eq(200)
+                end
               end
             end
           end


### PR DESCRIPTION
Inherited non-admin roles and restricting visibility from non-private to private would return true in `is_exclusively_inherited_from_parent?` leading to inherited managers/editors/depositors being able to discover and edit but not view items as well as end users being able to discover but not view items.

The problem with restricting visibility from non-private to private with disabled inheritance is that non-private visibility is encoded using a read_group while private is the absence of a read_group.  While this isn't wrong in this case the current logic wasn't able to handle cases where a user was explicitly added to an item's special access because the group exclusive inheritance check would always return true.

For example if the parent collection is `public` and the item is `private` then:
- `(@user_groups & media_object.read_groups).empty?` is true  because `media_object.read_groups` is empty when private
- `!(@user_groups & media_object.inherited_read_groups).empty?` is true because `@user_groups` will always include `public` (and `registered` when logged in) and the collection includes `public`