### PR TITLE
Set minimum date in end-date picker if a begin date exists

### DIFF
--- a/app/assets/javascripts/access_control_step.js
+++ b/app/assets/javascripts/access_control_step.js
@@ -43,6 +43,17 @@ window.initializeDatepickers = function (container) {
             };
             break;
           case false:
+            // When opening the end-date picker, set the minimum date to the selected begin date if it exists
+            pickerOptions.onShow = function (instance) {
+              if (pairedInput.value) {
+                const parts = pairedInput.value.split('-');
+                const beginDate = new Date(+parts[0], +parts[1] - 1, +parts[2]);
+                if (!isNaN(beginDate)) {
+                  instance.minDate = beginDate;
+                  instance.navigate(instance.dateSelected || beginDate);
+                }
+              }
+            };
             pickerOptions.onSelect = function (instance, date) {
               pairedInput.datepicker?.setMax(date);
             };


### PR DESCRIPTION
When selecting a date range using begin and end date-pickers, in access controls the end date picker always shows up from today's date onward. So, when the user has already selected a future begin date they have to navigate the end date picker a date past the begin date to select a valid end date. Setting the selected begin date as the minimum date in the end date picker allows the user to easily select an end date.