### PR TITLE
Fix CDL message styling and bug in access controls

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1001,7 +1001,6 @@ h5.card-title {
       height: 25px;
     }
 
-    
     div.supplemental-file-data.is-editing:last-child {
       margin-bottom: 2rem;
     }
@@ -1279,18 +1278,18 @@ h5.card-title {
     margin: 0 auto;
   }
 
-  .centered {
-    margin: auto;
-    position: absolute;
-    width: 50%;
-    left: 25%;
-  }
-
   .centered.video {
     top: 50%;
+    left: 25%;
     position: absolute;
     margin: 0;
     transform: translateY(-50%);
+  }
+
+  .centered {
+    width: 50%;
+    margin: 0 auto;
+    text-align: center;
   }
 }
 

--- a/app/views/media_objects/_access_control.html.erb
+++ b/app/views/media_objects/_access_control.html.erb
@@ -41,7 +41,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div class="mb-3">
         <% if @media_object.disable_inheritance? %>
         <%=  render partial: "modules/tooltip", locals: { form: vid, field: :lending_period, tooltip: t("access_control.#{:lending_period}"), options: {display_label: (t("access_control.#{:lending_period}label")+'*').html_safe} } %><br />
-        <% d, h = (@media_object.lending_period/3600).divmod(24) %>
+        <% d, h = ((@media_object.lending_period || 0)/3600).divmod(24) %>
         <div class='row'>
           <div class="col-1">
             <label class="col-form-label" for="add_lending_period_days">


### PR DESCRIPTION
Changes in this PR:
- guard against `nil` for `@media_object.lending_period` when parent permissions is disabled in item's access controls with CDL turned ON at the collection level
- center the CDL message in audio containers

Before: 
<img width="753" height="128" alt="before" src="https://github.com/user-attachments/assets/96683c22-c308-4d18-8527-692faf0b97f6" />
After:
<img width="753" height="128" alt="after" src="https://github.com/user-attachments/assets/dbe4dc7e-d641-4efd-8748-5b3bc939892c" />
