### PR TITLE
Refactor SupplementalFile#attach_file

### DIFF
--- a/app/models/supplemental_file.rb
+++ b/app/models/supplemental_file.rb
@@ -34,10 +34,11 @@ class SupplementalFile < ApplicationRecord
   after_destroy_commit :remove_from_index
   before_save :default_label
 
+  # If using io: true, new_file MUST be a FileLocator instance initialized with the filename opt
   def attach_file(new_file, io: false)
     if io
-      file.attach(io: File.open(new_file), filename: File.basename(new_file))
-      extension = File.extname(new_file)
+      file.attach(io: new_file.reader, filename: new_file.filename)
+      extension = File.extname(new_file.filename)
     else
       file.attach(new_file)
       extension = File.extname(new_file.original_filename)

--- a/app/models/watched_encode.rb
+++ b/app/models/watched_encode.rb
@@ -44,7 +44,7 @@ class WatchedEncode < ActiveEncode::Base
               new_file.language = nil
             end
           end
-          new_file.attach_file(FileLocator.new(output.url).location, io: true)
+          new_file.attach_file(FileLocator.new(output.url, filename: File.basename(output.url)), io: true)
           new_file.save
           output.url = if Settings.active_storage.bucket.present?
                       "s3://#{Settings.active_storage.bucket}/#{new_file.file.blob.key}"

--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -297,7 +297,7 @@ module Avalon
         machine_generated = Avalon::Batch.true_field?(datastream[:machine_generated]) ? 'machine_generated' : nil
         # Create SupplementalFile
         supplemental_file = SupplementalFile.new(label: label, tags: [type, treat_as_transcript, machine_generated].uniq.compact, language: language, parent_id: parent_id)
-        supplemental_file.attach_file(FileLocator.new(datastream[file_key]).reader, io: true)
+        supplemental_file.attach_file(FileLocator.new(datastream[file_key], filename: File.basename(datastream[file_key])), io: true)
         supplemental_file.save ? supplemental_file : nil
       end
       private_class_method :process_datastream

--- a/spec/models/supplemental_file_spec.rb
+++ b/spec/models/supplemental_file_spec.rb
@@ -94,8 +94,8 @@ describe SupplementalFile do
     end
 
     context 'via io attachment' do
-      let(:io_file) { Rails.root.join('spec', 'fixtures', 'meow.wav') }
-      before { subject.attach_file(io_file, io: true) }
+      let(:io_file) { Rails.root.join('spec', 'fixtures', 'meow.wav').to_s }
+      before { subject.attach_file(FileLocator.new(io_file, filename: 'meow.wav'), io: true) }
 
       it 'attaches the file and assigns metadata' do
         expect(subject.file).to be_attached


### PR DESCRIPTION
Related issue: #6820

A bug was introduced in commit 079b20e when the `io` option was added to the #attach_file method. This involved us passing the wrong type to the method in the case of batch processing, causing batches containing captions/transcripts to error out.

This commit refactors the `io` mode to utilize a FileLocator instance with filename provided. This should allow us to be more intentional, clear, and consistent with how the method is used.