### PR TITLE
Fix AJAX save for master file form in file-upload step

### DIFF
--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -124,7 +124,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 </div>
               </div>
               <div class="collapse" id="<%="collapseExample#{section.id}"%>">
-                <%= form_with model: section, class: "master-file-form" do |form| %>
+                <%= form_with model: section, class: "master-file-form", local: false do |form| %>
                   <div class="row">
                     <div class="col-sm-4">
                       <div class="mb-3">


### PR DESCRIPTION
This PR restores the AJAX save in the master file form in the file upload step. I think this broke during the `jQuery` removal work, which made the save button click to reload the entire page.