### PR TITLE
Initial baseline changes for IIIF auth 2.0

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -249,8 +249,8 @@ class MasterFilesController < ApplicationController
         return head :unauthorized
       end
     elsif auth_token.present?
-      return iiif_auth_probe_resp(success: false) unless StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
-      iiif_auth_probe_resp(success: true)
+      return render json: iiif_auth_probe_resp(success: false), status: :unauthorized unless StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
+      render json: iiif_auth_probe_resp(success: true), status: :ok
     else
       return head :unauthorized if cannot?(:read, @master_file)
       @hls_streams = if quality == "auto"
@@ -285,10 +285,12 @@ class MasterFilesController < ApplicationController
   end
 
   def iiif_auth_token
+    message_id = params[:messageId]
+    origin = params[:origin]
+
     if cannot? :read, @master_file
-      render 'iiif_auth_token_error', layout: false, locals: { message_id: message_id }
+      render 'iiif_auth_token_error', layout: false, locals: { message_id: message_id }, status: :unauthorized
     else
-      message_id = params[:messageId]
       access_token = StreamToken.find_or_create_session_token(session, @master_file.id)
       expires = (StreamToken.find_by(token: access_token).expires - Time.now.utc).to_i
       render 'iiif_auth_token', layout: false, locals: { message_id: message_id, origin: origin, access_token: access_token, expires: expires }
@@ -299,9 +301,9 @@ class MasterFilesController < ApplicationController
     {
       "@context": "http://iiif.io/api/auth/2/context.json",
       "type": "AuthProbeResult2",
-      "status": success ? 200 : 403,
-      "header": success ? { "en": [I18n.t('iiif.auth.failureHeader')] } : nil,
-      "note": success ? { "en": [I18n.t('iiif.auth.failureDescription')] } : nil
+      "status": success ? 200 : 401,
+      "header": success ? nil : { "en": [I18n.t('iiif.auth.failureHeader')] },
+      "note": success ? nil : { "en": [I18n.t('iiif.auth.failureDescription')] }
     }.compact
   end
 

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -241,8 +241,14 @@ class MasterFilesController < ApplicationController
 
   def hls_manifest
     quality = params[:quality]
+    auth_token = request.headers['Authorization']&.sub('Bearer ', '')
     if request.head?
-      auth_token = request.headers['Authorization']&.sub('Bearer ', '')
+      if StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
+        return head :ok
+      else
+        return head :unauthorized
+      end
+    elsif auth_token.present?
       return iiif_auth_probe_resp(success: false) unless StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
       iiif_auth_probe_resp(success: true)
     else

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -243,11 +243,8 @@ class MasterFilesController < ApplicationController
     quality = params[:quality]
     if request.head?
       auth_token = request.headers['Authorization']&.sub('Bearer ', '')
-      if StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
-        return head :ok
-      else
-        return head :unauthorized
-      end
+      return iiif_auth_probe_resp(success: false) unless StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
+      iiif_auth_probe_resp(success: true)
     else
       return head :unauthorized if cannot?(:read, @master_file)
       @hls_streams = if quality == "auto"
@@ -283,14 +280,23 @@ class MasterFilesController < ApplicationController
 
   def iiif_auth_token
     if cannot? :read, @master_file
-      head :unauthorized
+      render 'iiif_auth_token_error', layout: false, locals: { message_id: message_id }
     else
       message_id = params[:messageId]
-      origin = params[:origin]
       access_token = StreamToken.find_or_create_session_token(session, @master_file.id)
       expires = (StreamToken.find_by(token: access_token).expires - Time.now.utc).to_i
       render 'iiif_auth_token', layout: false, locals: { message_id: message_id, origin: origin, access_token: access_token, expires: expires }
     end
+  end
+
+  def iiif_auth_probe_resp(success: false)
+    {
+      "@context": "http://iiif.io/api/auth/2/context.json",
+      "type": "AuthProbeResult2",
+      "status": success ? 200 : 403,
+      "header": success ? { "en": [I18n.t('iiif.auth.failureHeader')] } : nil,
+      "note": success ? { "en": [I18n.t('iiif.auth.failureDescription')] } : nil
+    }.compact
   end
 
   def move

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -519,6 +519,9 @@ class MediaObjectsController < ApplicationController
       manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
       # TODO: implement thumbnail in iiif_manifest
       manifest["thumbnail"] = [{ "id" => presenter.thumbnail, "type" => 'Image' }] if presenter.thumbnail
+      # Auth 2.0 requires the auth context to be in the top level manifest context, before the
+      # presentation context
+      manifest["@context"] = manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
 
       manifest
     end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -241,6 +241,9 @@ class PlaylistsController < ApplicationController
     can_edit_playlist = can? :edit, @playlist
     presenter = IiifPlaylistManifestPresenter.new(playlist: @playlist, items: canvas_presenters, can_edit_playlist: can_edit_playlist)
     manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
+    # Auth 2.0 requires the auth context to be in the top level manifest context, before the
+    # presentation context
+    manifest["@context"] = manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
 
     respond_to do |wants|
       wants.json { render json: manifest.to_json }

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -286,37 +286,69 @@ class IiifCanvasPresenter
   end
 
   def auth_service(quality)
-    {
-      "id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
-      "type": "AuthProbeService2",
-      "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
-      "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] },
-      "service": [
-        {
-          "id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
-          "type": "AuthAccessService2",
-          "confirmLabel": { "en": [I18n.t('iiif.auth.confirmLabel')] },
-          "note": { "en": [I18n.t('iiif.auth.description')] },
-          "heading": { "en": [I18n.t('iiif.auth.header')] },
-          "label": { "en": [I18n.t('iiif.auth.label')] },
-          "profile": "active",
-          "service": [
-            {
-              "id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
-              "type": "AuthAccessTokenService2",
-              "profile": "http://iiif.io/api/auth/1/token",
-              "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
-              "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] }
-            },
-            {
-              "id": Rails.application.routes.url_helpers.destroy_user_session_url,
-              "type": "AuthLogoutService2",
-              "label": { "en": [I18n.t('iiif.auth.logoutLabel')] }
-            }
-          ]
-        }
-      ]
-    }
+    [
+      {
+        "@context": "http://iiif.io/api/auth/1/context.json",
+        "@id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
+        "@type": "AuthCookieService1",
+        "confirmLabel": I18n.t('iiif.auth.confirmLabel'),
+        "description": I18n.t('iiif.auth.description'),
+        "failureDescription": I18n.t('iiif.auth.failureDescription'),
+        "failureHeader": I18n.t('iiif.auth.failureHeader'),
+        "header": I18n.t('iiif.auth.header'),
+        "label": I18n.t('iiif.auth.label'),
+        "profile": "http://iiif.io/api/auth/1/login",
+        "service": [
+          {
+            "@id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
+            "@type": "AuthProbeService1",
+            "profile": "http://iiif.io/api/auth/1/probe"
+          },
+          {
+            "@id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
+            "@type": "AuthTokenService1",
+            "profile": "http://iiif.io/api/auth/1/token"
+          },
+          {
+            "@id": Rails.application.routes.url_helpers.destroy_user_session_url,
+            "@type": "AuthLogoutService1",
+            "label": I18n.t('iiif.auth.logoutLabel'),
+            "profile": "http://iiif.io/api/auth/1/logout"
+          }
+        ]
+      },
+      {
+        "id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
+        "type": "AuthProbeService2",
+        "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+        "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] },
+        "service": [
+          {
+            "id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
+            "type": "AuthAccessService2",
+            "confirmLabel": { "en": [I18n.t('iiif.auth.confirmLabel')] },
+            "note": { "en": [I18n.t('iiif.auth.description')] },
+            "heading": { "en": [I18n.t('iiif.auth.header')] },
+            "label": { "en": [I18n.t('iiif.auth.label')] },
+            "profile": "active",
+            "service": [
+              {
+                "id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
+                "type": "AuthAccessTokenService2",
+                "profile": "http://iiif.io/api/auth/1/token",
+                "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+                "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] }
+              },
+              {
+                "id": Rails.application.routes.url_helpers.destroy_user_session_url,
+                "type": "AuthLogoutService2",
+                "label": { "en": [I18n.t('iiif.auth.logoutLabel')] }
+              }
+            ]
+          }
+        ]
+      }
+    ]
   end
 
   def thumbnail_url

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -287,32 +287,33 @@ class IiifCanvasPresenter
 
   def auth_service(quality)
     {
-      "context": "http://iiif.io/api/auth/1/context.json",
-      "@id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
-      "@type": "AuthCookieService1",
-      "confirmLabel": I18n.t('iiif.auth.confirmLabel'),
-      "description": I18n.t('iiif.auth.description'),
-      "failureDescription": I18n.t('iiif.auth.failureDescription'),
-      "failureHeader": I18n.t('iiif.auth.failureHeader'),
-      "header": I18n.t('iiif.auth.header'),
-      "label": I18n.t('iiif.auth.label'),
-      "profile": "http://iiif.io/api/auth/1/login",
+      "id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
+      "type": "AuthProbeService2",
+      "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+      "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] },
       "service": [
         {
-          "@id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
-          "@type": "AuthProbeService1",
-          "profile": "http://iiif.io/api/auth/1/probe"
-        },
-        {
-          "@id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
-          "@type": "AuthTokenService1",
-          "profile": "http://iiif.io/api/auth/1/token"
-        },
-        {
-          "@id": Rails.application.routes.url_helpers.destroy_user_session_url,
-          "@type": "AuthLogoutService1",
-          "label": I18n.t('iiif.auth.logoutLabel'),
-          "profile": "http://iiif.io/api/auth/1/logout"
+          "id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
+          "type": "AuthAccessService2",
+          "confirmLabel": { "en": [I18n.t('iiif.auth.confirmLabel')] },
+          "note": { "en": [I18n.t('iiif.auth.description')] },
+          "heading": { "en": [I18n.t('iiif.auth.header')] },
+          "label": { "en": [I18n.t('iiif.auth.label')] },
+          "profile": "active",
+          "service": [
+            {
+              "id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
+              "type": "AuthAccessTokenService2",
+              "profile": "http://iiif.io/api/auth/1/token",
+              "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+              "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] }
+            },
+            {
+              "id": Rails.application.routes.url_helpers.destroy_user_session_url,
+              "type": "AuthLogoutService2",
+              "label": { "en": [I18n.t('iiif.auth.logoutLabel')] }
+            }
+          ]
         }
       ]
     }

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -235,7 +235,7 @@ class IiifPlaylistCanvasPresenter
     def auth_service(quality)
       [
         {
-          "context": "http://iiif.io/api/auth/1/context.json",
+          "@context": "http://iiif.io/api/auth/1/context.json",
           "@id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
           "@type": "AuthCookieService1",
           "confirmLabel": I18n.t('iiif.auth.confirmLabel'),

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -233,36 +233,69 @@ class IiifPlaylistCanvasPresenter
     end
 
     def auth_service(quality)
-      {
-        "context": "http://iiif.io/api/auth/1/context.json",
-        "@id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
-        "@type": "AuthCookieService1",
-        "confirmLabel": I18n.t('iiif.auth.confirmLabel'),
-        "description": I18n.t('iiif.auth.description'),
-        "failureDescription": I18n.t('iiif.auth.failureDescription'),
-        "failureHeader": I18n.t('iiif.auth.failureHeader'),
-        "header": I18n.t('iiif.auth.header'),
-        "label": I18n.t('iiif.auth.label'),
-        "profile": "http://iiif.io/api/auth/1/login",
-        "service": [
-          {
-            "@id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
-            "@type": "AuthProbeService1",
-            "profile": "http://iiif.io/api/auth/1/probe"
-          },
-          {
-            "@id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
-            "@type": "AuthTokenService1",
-            "profile": "http://iiif.io/api/auth/1/token"
-          },
-          {
-            "@id": Rails.application.routes.url_helpers.destroy_user_session_url,
-            "@type": "AuthLogoutService1",
-            "label": I18n.t('iiif.auth.logoutLabel'),
-            "profile": "http://iiif.io/api/auth/1/logout"
-          }
-        ]
-      }
+      [
+        {
+          "context": "http://iiif.io/api/auth/1/context.json",
+          "@id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
+          "@type": "AuthCookieService1",
+          "confirmLabel": I18n.t('iiif.auth.confirmLabel'),
+          "description": I18n.t('iiif.auth.description'),
+          "failureDescription": I18n.t('iiif.auth.failureDescription'),
+          "failureHeader": I18n.t('iiif.auth.failureHeader'),
+          "header": I18n.t('iiif.auth.header'),
+          "label": I18n.t('iiif.auth.label'),
+          "profile": "http://iiif.io/api/auth/1/login",
+          "service": [
+            {
+              "@id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
+              "@type": "AuthProbeService1",
+              "profile": "http://iiif.io/api/auth/1/probe"
+            },
+            {
+              "@id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
+              "@type": "AuthTokenService1",
+              "profile": "http://iiif.io/api/auth/1/token"
+            },
+            {
+              "@id": Rails.application.routes.url_helpers.destroy_user_session_url,
+              "@type": "AuthLogoutService1",
+              "label": I18n.t('iiif.auth.logoutLabel'),
+              "profile": "http://iiif.io/api/auth/1/logout"
+            }
+          ]
+        },
+        {
+          "id": Rails.application.routes.url_helpers.hls_manifest_master_file_url(master_file.id, quality: quality),
+          "type": "AuthProbeService2",
+          "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+          "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] },
+          "service": [
+            {
+              "id": Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1),
+              "type": "AuthAccessService2",
+              "confirmLabel": { "en": [I18n.t('iiif.auth.confirmLabel')] },
+              "note": { "en": [I18n.t('iiif.auth.description')] },
+              "heading": { "en": [I18n.t('iiif.auth.header')] },
+              "label": { "en": [I18n.t('iiif.auth.label')] },
+              "profile": "active",
+              "service": [
+                {
+                  "id": Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id),
+                  "type": "AuthAccessTokenService2",
+                  "profile": "http://iiif.io/api/auth/1/token",
+                  "errorNote": { "en": [I18n.t('iiif.auth.failureDescription')] },
+                  "errorHeading": { "en": [I18n.t('iiif.auth.failureHeader')] }
+                },
+                {
+                  "id": Rails.application.routes.url_helpers.destroy_user_session_url,
+                  "type": "AuthLogoutService2",
+                  "label": { "en": [I18n.t('iiif.auth.logoutLabel')] }
+                }
+              ]
+            }
+          ]
+        }
+      ]
     end
 
     def thumbnail_url

--- a/app/views/master_files/iiif_auth_token.html.erb
+++ b/app/views/master_files/iiif_auth_token.html.erb
@@ -18,6 +18,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <script>
     window.parent.postMessage(
       {
+        <%# TODO: Determine if context and type cause issue with the auth 1 flow or
+              if clients ignore the extra data %>
         "@context": "http://iiif.io/api/auth/2/context.json", 
         "type": "AuthAccessToken2",
         "accessToken": "<%= access_token %>",

--- a/app/views/master_files/iiif_auth_token_error.html.erb
+++ b/app/views/master_files/iiif_auth_token_error.html.erb
@@ -19,12 +19,11 @@ Unless required by applicable law or agreed to in writing, software distributed
     window.parent.postMessage(
       {
         "@context": "http://iiif.io/api/auth/2/context.json", 
-        "type": "AuthAccessToken2",
-        "accessToken": "<%= access_token %>",
-        "expiresIn": <%= expires %>,  
-        "messageId": "<%= message_id %>" 
-      },
-      "<%= origin %>"
+        "type": "AuthAccessTokenError2",
+        "profile": "missingAspect",
+        "heading": { "en": ["<%= I18n.t('iiif.auth.failureHeader') %>"]},  
+        "messageId": "<%= message_id %>"
+      }
     );
     </script>
   </body>

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -698,7 +698,7 @@ describe MasterFilesController do
       login_as :administrator
       get(:iiif_auth_token, params: { id: master_file.id, messageId: 1, origin: "https://example.com" })
       expect(response).to have_http_status(:ok)
-      expect(response.body.gsub(/\s+/,'')).to match /window.parent.postMessage\({"expiresIn":\d+,"accessToken":".+","messageId":"1"},"https:\/\/example.com"\);/
+      expect(response.body.gsub(/\s+/, '')).to match /window.parent.postMessage\({"@context":"http:\/\/iiif.io\/api\/auth\/2\/context.json","type":"AuthAccessToken2","accessToken":".+","expiresIn":\d+,"messageId":"1"},"https:\/\/example.com"\);/
     end
   end
 
@@ -722,6 +722,33 @@ describe MasterFilesController do
 
       it 'returns ok (200) if public' do
         expect(head('hls_manifest', params: { id: public_master_file.id, quality: 'auto' })).to have_http_status(:ok)
+      end
+    end
+
+    context 'with auth token' do
+      it 'returns unauthorized probe response (401) with invalid auth token' do
+        request.headers['Authorization'] = "Bearer bad-token"
+        expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:unauthorized)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["@context"]).to eq "http://iiif.io/api/auth/2/context.json"
+        expect(parsed_response["type"]).to eq "AuthProbeResult2"
+        expect(parsed_response["status"]).to eq 401
+        expect(parsed_response["header"]).to eq({ "en" => [I18n.t('iiif.auth.failureHeader')] })
+        expect(parsed_response["note"]).to eq({ "en" => [I18n.t('iiif.auth.failureDescription')] })
+      end
+
+      it 'returns successful probe response (200) with valid auth token' do
+        token = StreamToken.find_or_create_session_token(session, master_file.id)
+        request.headers['Authorization'] = "Bearer #{token.to_s}"
+        expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:ok)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["@context"]).to eq "http://iiif.io/api/auth/2/context.json"
+        expect(parsed_response["type"]).to eq "AuthProbeResult2"
+        expect(parsed_response["status"]).to eq 200
+      end
+
+      it 'returns ok (200) if public' do
+        expect(get('hls_manifest', params: { id: public_master_file.id, quality: 'auto' })).to have_http_status(:ok)
       end
     end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -2451,8 +2451,19 @@ describe MediaObjectsController, type: :controller do
   end
 
   describe '#manifest' do
+    let(:media_object) { FactoryBot.create(:published_media_object, :with_master_file) }
     before do
       login_as :administrator
+    end
+
+    it "returns a IIIF manifest" do
+      get :manifest, format: 'json', params: { id: media_object.id }
+      expect(response).to have_http_status(200)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['@context']).to include "http://iiif.io/api/presentation/3/context.json"
+      expect(parsed_response['@context']).to include "http://iiif.io/api/auth/2/context.json"
+      expect(parsed_response['type']).to eq 'Manifest'
+      expect(parsed_response['items']).not_to be_empty
     end
 
     context 'with supplemental files' do
@@ -2478,7 +2489,7 @@ describe MediaObjectsController, type: :controller do
         expect(mf_rendering['id']).to eq Rails.application.routes.url_helpers.master_file_supplemental_file_url(id: mf_supplemental_file.id, master_file_id: master_file.id)
       end
     end
- 
+
     context 'read from solr' do
       let!(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
       let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
@@ -2501,6 +2512,7 @@ describe MediaObjectsController, type: :controller do
         allow_any_instance_of(IIIFManifest::V3::ManifestBuilder::RangeBuilder).to receive(:path).and_return('range')
         presenter = IiifManifestPresenter.new(media_object: media_object, master_files: [])
         @manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
+        @manifest["@context"] = @manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
       end
 
       after do
@@ -2519,12 +2531,13 @@ describe MediaObjectsController, type: :controller do
         media_object.title = 'Test'
         media_object.save!
         new_presenter = IiifManifestPresenter.new(media_object: media_object, master_files: [])
-        new_manifest = IIIFManifest::V3::ManifestFactory.new(new_presenter).to_h.to_json
+        new_manifest = IIIFManifest::V3::ManifestFactory.new(new_presenter).to_h
+        new_manifest["@context"] = new_manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
         get 'manifest', params: { id: media_object.id, format: 'json' }
         new_cache = Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/iiif_manifest")
         expect(new_cache).to be_a(IIIFManifest::V3::ManifestBuilder::IIIFManifest)
         expect(new_cache.to_json).to_not eq(old_manifest)
-        expect(new_cache.to_json).to eq(new_manifest)
+        expect(new_cache.to_json).to eq(new_manifest.to_json)
       end
     end
   end

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -521,6 +521,7 @@ RSpec.describe PlaylistsController, type: :controller do
         expect(response).to have_http_status(200)
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['@context']).to include "http://iiif.io/api/presentation/3/context.json"
+        expect(parsed_response['@context']).to include "http://iiif.io/api/auth/2/context.json"
         expect(parsed_response['type']).to eq 'Manifest'
         expect(parsed_response['items']).not_to be_empty
       end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -22,27 +22,59 @@ describe IiifCanvasPresenter do
   let(:presenter) { described_class.new(master_file: master_file, stream_info: stream_info) }
 
   context 'auth_service' do
-    subject { presenter.display_content.first.auth_service }
+    context '1.0' do
+      subject { presenter.display_content.first.auth_service.first }
 
-    it 'provides a cookie auth service' do
-      expect(subject[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
+      it 'provides a cookie auth service' do
+        expect(subject[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
+      end
+
+      it 'provides a token service' do
+        token_service = subject[:service].find { |s| s[:@type] == "AuthTokenService1"}
+        expect(token_service[:@id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
+      end
+
+      it 'provides a logout service' do
+        logout_service = subject[:service].find { |s| s[:@type] == "AuthLogoutService1"}
+        expect(logout_service[:@id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
+      end
+
+      context 'when public media object' do
+        let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+
+        it "does not provide an auth service" do
+          expect(presenter.display_content.first.auth_service).to be_nil
+        end
+      end
     end
 
-    it 'provides a token service' do
-      token_service = subject[:service].find { |s| s[:@type] == "AuthTokenService1"}
-      expect(token_service[:@id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
-    end
+    context '2.0' do
+      subject { presenter.display_content.first.auth_service&.second }
 
-    it 'provides a logout service' do
-      logout_service = subject[:service].find { |s| s[:@type] == "AuthLogoutService1"}
-      expect(logout_service[:@id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
-    end
+      before do
+        @auth_service = subject[:service].find { |s| s[:type] == 'AuthAccessService2' } if subject.present?
+      end
 
-    context 'when public media object' do
-      let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+      it 'provides an auth service' do
+        expect(@auth_service[:id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
+      end
 
-      it "does not provide an auth service" do
-        expect(presenter.display_content.first.auth_service).to be_nil
+      it 'provides a token service' do
+        token_service = @auth_service[:service].find { |s| s[:type] == "AuthAccessTokenService2" }
+        expect(token_service[:id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
+      end
+
+      it 'provides a logout service' do
+        logout_service = @auth_service[:service].find { |s| s[:type] == "AuthLogoutService2" }
+        expect(logout_service[:id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
+      end
+
+      context 'when public media object' do
+        let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+
+        it "does not provide an auth service" do
+          expect(presenter.display_content.first.auth_service).to be_nil
+        end
       end
     end
   end

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -47,27 +47,61 @@ describe IiifPlaylistCanvasPresenter do
   end
 
   describe '#auth_service' do
-    subject { presenter.display_content.first.auth_service }
+    context 'auth_service' do
+      context '1.0' do
+        subject { presenter.display_content.first.auth_service.first }
 
-    it 'provides a cookie auth service' do
-      expect(subject[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
-    end
+        it 'provides a cookie auth service' do
+          expect(subject[:@id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
+        end
 
-    it 'provides a token service' do
-      token_service = subject[:service].find { |s| s[:@type] == "AuthTokenService1"}
-      expect(token_service[:@id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
-    end
+        it 'provides a token service' do
+          token_service = subject[:service].find { |s| s[:@type] == "AuthTokenService1"}
+          expect(token_service[:@id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
+        end
 
-    it 'provides a logout service' do
-      logout_service = subject[:service].find { |s| s[:@type] == "AuthLogoutService1"}
-      expect(logout_service[:@id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
-    end
+        it 'provides a logout service' do
+          logout_service = subject[:service].find { |s| s[:@type] == "AuthLogoutService1"}
+          expect(logout_service[:@id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
+        end
 
-    context 'when public media object' do
-      let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+        context 'when public media object' do
+          let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
 
-      it "does not provide an auth service" do
-        expect(presenter.display_content.first.auth_service).to be_nil
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
+      end
+
+      context '2.0' do
+        subject { presenter.display_content.first.auth_service&.second }
+
+        before do
+          @auth_service = subject[:service].find { |s| s[:type] == 'AuthAccessService2' } if subject.present?
+        end
+
+        it 'provides an auth service' do
+          expect(@auth_service[:id]).to eq Rails.application.routes.url_helpers.new_user_session_url(login_popup: 1)
+        end
+
+        it 'provides a token service' do
+          token_service = @auth_service[:service].find { |s| s[:type] == "AuthAccessTokenService2" }
+          expect(token_service[:id]).to eq Rails.application.routes.url_helpers.iiif_auth_token_url(id: master_file.id)
+        end
+
+        it 'provides a logout service' do
+          logout_service = @auth_service[:service].find { |s| s[:type] == "AuthLogoutService2" }
+          expect(logout_service[:id]).to eq Rails.application.routes.url_helpers.destroy_user_session_url
+        end
+
+        context 'when public media object' do
+          let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Related issue: #5239

TODO:
* Make auth probe its own endpoint instead of piggybacking on hls_manifest? Auth 2.0 probes are supposed to be GET requests, not HEAD requests so we would need to find another way to differentiate. May be easiest to use a separate method/endpoint.
* ~~Make auth service changes in the playlist workflow (playlists_controller, iiif_playlist models, etc)~~
* ~~Add auth 2 context info to top level manifest context~~
* ~~Fix and add spec tests~~
* Find a iiif auth 2 client to test against and test against Ramp once it has been updated for iiif auth 2.
* Discussion on whether we want to make any changes to the headers and messages of the auth service.
* We use I18n translations for the headers and messages. Should we be using { "en": ["message"] } for these entries? It should be within spec to have the language marked "none", maybe that is better than specifying a specific language. Or maybe we can pull the default locale information?

There are a couple minor changes to `iiif_manifest` that may be necessary. The `auth_service` method expects a simple hash so passing in an array of hashes results in `[[{service}, {service}]]`. Adjusting how the gem serializes `auth_service` may be desirable, or we may need to find a way to flatten the service definition. Additionally, we need to add a value to the top level manifest context. This is currently done in Avalon but it may be desirable to add a way to pass the value to `iiif_manifest` (or maybe there's already a way and I just missed it).