### PR TITLE
Allow for enabling temprorary encryption config properties for migration using ENVVAR

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,9 +56,12 @@ module Avalon
     config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
     config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
 
-    # Uncomment these if existing API tokens need to be persisted.
-    # config.active_record.encrpytion.support_unencrypted_data = true
-    # config.active_record.encryption.extend_queries = true
+    # Conditionally enable these for migration
+    # ```ApiToken.all.each { |t| t.encrypt }```
+    if ENV['ACTIVE_RECORD_ENCRYPTION_MIGRATION'] == 'true'
+      config.active_record.encryption.support_unencrypted_data = true
+      config.active_record.encryption.extend_queries = true
+    end
 
     # Rails recommends having this set to false, especially in zeitwerk mode. However, that
     # currently causes issues with the Samvera gems (hydra-head, Blacklight)


### PR DESCRIPTION
In Avalon 8.2 API tokens are encrypted in the DB (#6289).  By default ActiveRecord disallows reading from existing records with unencrypted values.  In order to make migrating existing API tokens easier this PR wraps config properties that enable reading unencrypted values with an ENVVAR.  This way `config/application.rb` doesn't need to be edited, which is harder in a docker environment.  The migration then looks like:
```
ACTIVE_RECORD_ENCRYPTION_MIGRATION=true bundle exec rails r 'ApiToken.all.each(&:encrypt)'
```
After the migration is run then the special temporary properties are not needed.