### PR TITLE
Use official tag for hls docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - ./solr/conf:/opt/solr/avalon_conf
 
   hls:
-    image: avalonmediasystem/nginx:noble-s3authv4
+    image: avalonmediasystem/nginx:avalon-8.2
     environment:
       - AVALON_DOMAIN=http://avalon:3000
       - AVALON_STREAMING_BUCKET_URL=http://minio:9000/derivatives/


### PR DESCRIPTION
This image includes all of the aws auth changes in https://github.com/avalonmediasystem/avalon-docker/pull/99