### PR TITLE
Add catch for blacklight search errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,7 @@ class ApplicationController < ActionController::Base
   rescue_from RSolr::Error::Timeout, :with => :handle_solr_connection_error
   rescue_from Blacklight::Exceptions::ECONNREFUSED, :with => :handle_solr_connection_error
   rescue_from Faraday::ConnectionFailed, :with => :handle_fedora_connection_error
+  rescue_from Blacklight::Exceptions::InvalidRequest, with: :handle_search_error
 
   # Enable profiling
   if ActiveModel::Type::Boolean.new.cast(ENV['AVALON_PROFILING'])
@@ -229,11 +230,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  rescue_from Blacklight::Exceptions::InvalidRequest do |exception|
-    flash[:error] = (I18n.t('errors.search_error') % [Settings.email.support, Settings.email.support]).html_safe
-    redirect_to(root_path)
-  end
-
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up) do |user_params|
       user_params.permit(:username, :email, :password, :password_confirmation)
@@ -323,6 +319,15 @@ class ApplicationController < ActionController::Base
         render '/errors/fedora_connection', status: :service_unavailable
       else
         render json: { errors: [exception.message] }, status: :service_unavailable
+      end
+    end
+
+    def handle_search_error(exception)
+      if request.path == '/'
+        raise exception
+      else
+        flash[:error] = (I18n.t('errors.search_error') % [Settings.email.support, Settings.email.support]).html_safe
+        redirect_to(root_path)
       end
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -229,6 +229,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from Blacklight::Exceptions::InvalidRequest do |exception|
+    flash[:error] = (I18n.t('errors.search_error') % [Settings.email.support, Settings.email.support]).html_safe
+    redirect_to(root_path)
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up) do |user_params|
       user_params.permit(:username, :email, :password, :password_confirmation)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,10 @@ en:
     accessibility_enforcement_error: |
       This item is unable to be published. Accessibility requirements such as a transcript or
       caption file are missing.
+    search_error: |
+      <p>There was an error with this search. This is usually caused by abnormal combinations of
+      special characters, e.x. "query,. term". Check your query and try again.</p><p>If the problem
+      persists please contact support to report this error: <a href="mailto:%s">%s</a><p>
   media_object:
     empty_share_link: ""
     empty_share_link_notice: "After processing has started the embedded link will be available."

--- a/lib/avalon/transcript_search.rb
+++ b/lib/avalon/transcript_search.rb
@@ -65,6 +65,7 @@ module Avalon
         target = Rails.application.routes.url_helpers.transcripts_master_file_supplemental_file_url(master_file.id, transcript_id)
 
         text_matches = matches["transcript_tsim"]
+        next if text_matches.blank?
 
         formatted_response += process_items(text_matches, mime_type, canvas, target)
       end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -135,6 +135,16 @@ describe ApplicationController do
       end
     end
 
+    context 'search error' do
+      it 'redirects to homepage' do
+        allow(controller).to receive(:create).and_raise(Blacklight::Exceptions::InvalidRequest)
+        expect { get :create, params: { id: 'abc1234' } }.to_not raise_error
+        expect(response.status).to be 302
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq(I18n.t('errors.search_error') % [Settings.email.support, Settings.email.support])
+      end
+    end
+
     context 'raise_on_connection_error disabled' do
       let(:request_context) { { uri: Addressable::URI.parse("http://example.com"), body: "request_context" } }
       let(:e) { { body: "error_response" } }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -485,9 +485,10 @@ describe CatalogController do
           end
         end
 
-        it 'should raise error on other non-quote related invalid request' do
+        it 'should not raise error on other non-quote related invalid request' do
           allow_any_instance_of(Blacklight::SearchService).to receive(:search_results).and_raise(Blacklight::Exceptions::InvalidRequest)
-          expect { get 'index', params: { q: 'Test' } }.to raise_error(Blacklight::Exceptions::InvalidRequest)
+          expect(get 'index', params: { q: 'Test' }).to redirect_to(root_path)
+          expect(flash[:error]).to be_present
         end
       end
     end


### PR DESCRIPTION
Related issue: #6013

This commit also includes a small fix for the transcript search. In certain (rare) circumstances, there can be matches returned by the search that have a blank `transcripts_tsim`. This caused the processing step to break. We should be able to safely skip these blank entries and keep the search from bombing.