### PR TITLE
Explicitly enable S3 auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=minio123
       - S3_SERVER=localhost:9000
+      - S3_AUTH=true
     volumes:
       - ./log/nginx:/var/log/nginx
     ports:


### PR DESCRIPTION
Required by new build of container image (see https://github.com/avalonmediasystem/avalon-docker/pull/104)