### PR TITLE
Reduce number of queries as well as optimize queries used for gated discovery

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -30,14 +30,14 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def only_published_items(_permission_types = discovery_permissions, _ability = current_ability)
-    [policy_clauses(permission_types: [:edit]), 'workflow_published_sim:"Published"'].compact.join(" OR ")
+    [edit_policy_clauses, 'workflow_published_sim:"Published"'].compact.join(" OR ")
   end
 
   def limit_to_non_hidden_items(_permission_types = discovery_permissions, _ability = current_ability)
     media_object_hidden_clause = "hidden_bsi:true"
     collection_hidden_clause = "{!join from=id to=isGovernedBy_ssim}default_hidden_bsi:true"
 
-    [policy_clauses(permission_types: [:edit]), "(*:* AND NOT #{media_object_hidden_clause} AND (disable_inheritance_bsi:true OR (*:* AND NOT #{collection_hidden_clause})))"].compact.join(" OR ")
+    [edit_policy_clauses, "(*:* AND NOT #{media_object_hidden_clause} AND (disable_inheritance_bsi:true OR (*:* AND NOT #{collection_hidden_clause})))"].compact.join(" OR ")
   end
 
   def limit_to_inheritance_enabled_items(_permission_types = discovery_permissions, ability = current_ability)
@@ -47,7 +47,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     read_access_clauses = []
     read_access_clauses += ["read_access_person_ssim:#{RSolr.solr_escape(current_user)}"] if current_user.present?
     read_access_clauses += ["_query_:\"{!terms f=read_access_group_ssim}#{RSolr.solr_escape(user_groups.join(','))}\""] if user_groups.present?
-    [policy_clauses(permission_types: [:edit]), "(*:* AND NOT disable_inheritance_bsi:true AND (#{(Array(policy_clauses(permission_types: [:read])) + read_access_clauses).join(" OR ")}))", "(disable_inheritance_bsi:true AND (#{(read_access_clauses + ["read_access_group_ssim:(#{user_visibility_groups.join(" OR ")})"]).join(" OR ")}))"].compact.join(" OR ")
+    [edit_policy_clauses, "(*:* AND NOT disable_inheritance_bsi:true AND (#{(Array(read_policy_clauses) + read_access_clauses).join(" OR ")}))", "(disable_inheritance_bsi:true AND (#{(read_access_clauses + ["read_access_group_ssim:(#{user_visibility_groups.join(" OR ")})"]).join(" OR ")}))"].compact.join(" OR ")
   end
 
   # Overridden to skip for admin users
@@ -115,5 +115,15 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_parameters["sections.transcripts.defType"] = "lucene"
     solr_parameters["sections.transcripts.rows"] = 1_000_000
     solr_parameters["sections.transcripts.q"] = "{!terms f=isPartOf_ssim v=$row.id}{!join to=id from=isPartOf_ssim}"
+  end
+
+  private
+
+  def edit_policy_clauses
+    @edit_policy_clauses ||= policy_clauses(permission_types: [:edit])
+  end
+
+  def read_policy_clauses
+    @read_policy_clauses ||= policy_clauses(permission_types: [:read])
   end
 end

--- a/lib/hydra/multiple_policy_aware_access_controls_enforcement.rb
+++ b/lib/hydra/multiple_policy_aware_access_controls_enforcement.rb
@@ -28,32 +28,35 @@ module Hydra::MultiplePolicyAwareAccessControlsEnforcement
   def policy_clauses(permission_types: discovery_permissions)
     policy_ids = policies_with_access(permission_types: permission_types)
     return nil if policy_ids.empty?
-    # find objects with policies connected to the object or once removed (Units -> Collections -> MediaObjects)
-    '(' + policy_ids.map {|id| [ActiveFedora::SolrQueryBuilder.construct_query_for_rel(isGovernedBy: id), "_query_:\"{!join from=id to=isGovernedBy_ssim}{!raw f=isGovernedBy_ssim}#{id}\""].join(' OR '.freeze) }.join(' OR '.freeze) + ')'
+    # find objects with policies connected to the object
+    "_query_:\"{!terms f=isGovernedBy_ssim}#{policy_ids.join(',')}\""
   end
 
   # find all the policies that grant discover/read/edit permissions to this user or any of its groups
   def policies_with_access(permission_types: discovery_permissions)
-    policy_classes.collect do |policy_class|
-      #### TODO -- Memoize this and put it in the session?
+    clauses = policy_classes.collect do |policy_class|
       user_access_filters = []
       # Grant access based on user id & group
       policy_class_clause = policy_class_clause(policy_class)
       user_access_filters += apply_policy_group_permissions(permission_types, policy_class_clause)
       user_access_filters += apply_policy_user_permissions(permission_types, policy_class_clause)
-      result = policy_class.search_with_conditions( user_access_filters.join(" OR "), :fl => "id", :rows => policy_class.count )
-      Rails.logger.debug "get policies: #{result}\n\n"
-      result.map {|h| h['id']}
-    end.flatten.uniq
+      "(has_model_ssim:\"#{policy_class.name}\" AND (#{user_access_filters.join(" OR ")}))"
+    end
+    Rails.logger.debug "get policies query: #{clauses.join(" OR ")}\n\n"
+    result = ActiveFedora::Base.search_with_conditions( clauses.join(" OR "), :fl => "id", :rows => 100_000 )
+    Rails.logger.debug "get policies: #{result}\n\n"
+    ids = result.map {|h| h['id']}
+    # Find collections governed by units returned in first query along with objects found in first query
+    result = ActiveFedora::Base.search_with_conditions("_query_:\"{!terms f=id}#{ids.join(',')}\" OR _query_:\"{!terms f=isGovernedBy_ssim}#{ids.join(',')}\"", :fl => "id", :rows => 100_000 );
+    Rails.logger.debug "get policies: #{result}\n\n"
+    result.map {|h| h['id']}
   end
 
   def apply_policy_group_permissions(permission_types = discovery_permissions, policy_class_clause = "")
       # for groups
       user_access_filters = []
-      current_ability.user_groups.each_with_index do |group, i|
-        permission_types.each do |type|
-          user_access_filters << "(" + escape_filter(Hydra.config.permissions.inheritable[type.to_sym].group, group) + policy_class_clause + ")"
-        end
+      permission_types.each do |type|
+        user_access_filters << "(_query_:\"{!terms f=#{Hydra.config.permissions.inheritable[type.to_sym].group}}#{RSolr.solr_escape(current_ability.user_groups.join(','))}\"" + policy_class_clause + ")"
       end
       user_access_filters
   end


### PR DESCRIPTION
Avalon 8.2 changes for permission inheritance do not scale for the number of units and collections in MCO.  On mco-staging non-admin searches timed out at 3 minutes.  The first change bringing the query down to 12s was to switch from the many joins in `policy_clauses` to a single join with a `terms` query.  Switching from that to a follow up query in `policies_with_access` to resolve units to collections brought the query down to 3s.  The rest of the changes in this PR remove small queries (~10ms each) and condense some queries to possibly save ~200ms.  Terms queries were also added in other places to reduce the number of boolean clauses.  

Further visual cleanup of the query could be to use [local params](https://solr.apache.org/guide/solr/latest/query-guide/local-params.html) to avoid having to reference the user groups multiple times.