### PR TITLE
Gated discovery speedup part deux

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -35,6 +35,7 @@ class Admin::CollectionsController < ApplicationController
       end
       builder.user = user
     end
+    builder.with_discovery_permissions([:edit])
     response = repository.search(builder)
 
     # Query solr for facet values for collection media object counts and pass into presenter to avoid making 2 solr queries per collection

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -22,7 +22,7 @@ class Admin::DashboardController < ApplicationController
     # Allow the number of collections to be greater than 100
     blacklight_config.max_per_page = 100_000
     builder = ::CollectionSearchBuilder.new([:add_access_controls_to_solr_params_if_not_admin, :only_wanted_models, :add_paging_to_solr], self).rows(100_000)
-    
+    builder.with_discovery_permissions([:edit])
     response = repository.search(builder)
 
     # Query solr for facet values for collection media object counts and pass into presenter to avoid making 2 solr queries per collection
@@ -48,7 +48,7 @@ class Admin::DashboardController < ApplicationController
     # Allow the number of units to be greater than 100
     blacklight_config.max_per_page = 100_000
     builder = ::UnitSearchBuilder.new([:add_access_controls_to_solr_params_if_not_admin, :only_wanted_models, :add_paging_to_solr], self).rows(100_000)
-    
+    builder.with_discovery_permissions([:edit])
     response = repository.search(builder)
 
     # Query solr for facet values for unit media object counts and pass into presenter to avoid making 2 solr queries per unit

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -229,6 +229,10 @@ class Ability
         (not (full_login? || is_api_request?)) || !is_manager_of?(media_object.collection)
       end
 
+      cannot :read, [Admin::Collection, SpeedyAF::Proxy::Admin::Collection] do |collection|
+        !is_member_of?(collection)
+      end
+
       cannot :update, [Admin::Collection, SpeedyAF::Proxy::Admin::Collection] do |collection|
         # Editors and Depositors should not be able to edit collection level information
         (not (full_login? || is_api_request?)) || !is_manager_of?(collection)

--- a/config/initializers/presenter_config.rb
+++ b/config/initializers/presenter_config.rb
@@ -72,12 +72,16 @@ Rails.application.config.to_prepare do
 
     sp.config Admin::Collection do
       self.defaults = {
-                        cdl_enabled: nil
+                        cdl_enabled: nil,
+                        collection_managers: []
                       }
       include AdminCollectionBehavior
     end
 
     sp.config Admin::Unit do
+      self.defaults = {
+                        collection_managers: []
+                      }
       include AdminUnitBehavior
     end
 

--- a/lib/hydra/multiple_policy_aware_ability.rb
+++ b/lib/hydra/multiple_policy_aware_ability.rb
@@ -17,29 +17,17 @@ module Hydra::MultiplePolicyAwareAbility
   extend ActiveSupport::Concern
   include Hydra::PolicyAwareAbility
 
-  # Returns the id of policy object (is_governed_by) for the specified object
-  # Assumes that the policy object is associated by an is_governed_by relationship
-  # (which is stored as "is_governed_by_ssim" in object's solr document)
-  # Returns nil if no policy associated with the object
-  def policy_ids_for(object_id)
-    policy_ids = policy_id_cache[object_id]
-    return policy_ids if policy_ids
-    solr_results = ActiveFedora::SolrService.query("id:#{object_id} OR _query_:\"{!join to=id from=isGovernedBy_ssim}id:#{object_id}\"", fl: [governed_by_solr_field], rows: 1000)
-    return unless solr_results.any?(&:present?)
-    policy_id_cache[object_id] = policy_ids = solr_results.collect {|solr_result| solr_result[governed_by_solr_field] }.flatten.compact
-  end
-
+  # Returns the ids of policy objects (is_governed_by) for the specified object
+  # Assumes that the policy objects are associated by an is_governed_by relationship
+  # (which is stored as "is_governed_by_ssim" in object's solr document) or one level
+  # removed through an is_governed_by relationship.
+  # Returns nil if no policies are associated with the object
   def active_policy_ids_for(object_id)
-    policy_ids = policy_ids_for(object_id)
-    return nil if policy_ids.nil?
-
-    ids = policy_classes.collect do |policy_class|
-      id_clause = "(#{policy_ids.collect {|id| escape_filter("id", id)}.join(" OR ")})"
-      policy_class_clause = policy_class_clause(policy_class)
-      active_policy_ids = policy_class.search_with_conditions(id_clause + policy_class_clause, fl: "id", rows: policy_class.count )
-      active_policy_ids.collect {|h| h.values }.flatten
-    end
-    ids.flatten
+    id_clause = "_query_:\"{!join to=id from=isGovernedBy_ssim}id:#{object_id}\" OR _query_:\"{!join to=id from=isGovernedBy_ssim}{!join to=id from=isGovernedBy_ssim}id:#{object_id}\""
+    klasses_fq = policy_classes.collect { |klass| "(has_model_ssim:\"#{klass.name}\" #{policy_class_clause(klass)})" }.join(" OR ")
+    result = ActiveFedora::Base.search_with_conditions(id_clause, fq: [klasses_fq], fl: [:id], rows: 100_000 )
+    ids = result.collect {|h| h.values }.flatten
+    ids.blank? ? nil : ids
   end
 
   # Tests whether the object's governing policy object grants edit access for the current user
@@ -112,5 +100,4 @@ module Hydra::MultiplePolicyAwareAbility
   def escape_filter(key, value)
     [key, value.gsub(/[ :\/]/, ' ' => '\ ', '/' => '\/', ':' => '\:')].join(':')
   end
-
 end

--- a/lib/hydra/multiple_policy_aware_access_controls_enforcement.rb
+++ b/lib/hydra/multiple_policy_aware_access_controls_enforcement.rb
@@ -34,20 +34,19 @@ module Hydra::MultiplePolicyAwareAccessControlsEnforcement
 
   # find all the policies that grant discover/read/edit permissions to this user or any of its groups
   def policies_with_access(permission_types: discovery_permissions)
-    clauses = policy_classes.collect do |policy_class|
-      user_access_filters = []
-      # Grant access based on user id & group
-      policy_class_clause = policy_class_clause(policy_class)
-      user_access_filters += apply_policy_group_permissions(permission_types, policy_class_clause)
-      user_access_filters += apply_policy_user_permissions(permission_types, policy_class_clause)
-      "(has_model_ssim:\"#{policy_class.name}\" AND (#{user_access_filters.join(" OR ")}))"
-    end
-    Rails.logger.debug "get policies query: #{clauses.join(" OR ")}\n\n"
-    result = ActiveFedora::Base.search_with_conditions( clauses.join(" OR "), :fl => "id", :rows => 100_000 )
+    user_access_filters = []
+    # Grant access based on user id & group
+    user_access_filters += apply_policy_group_permissions(permission_types)
+    user_access_filters += apply_policy_user_permissions(permission_types)
+    klasses_fq = policy_classes.collect { |klass| "(has_model_ssim:\"#{klass.name}\" #{policy_class_clause(klass)})" }.join(" OR ")
+    Rails.logger.debug "get policies query: #{user_access_filters.join(" OR ")}, fq: [#{klasses_fq}], fl: 'id', rows: 100_000\n\n"
+    result = ActiveFedora::Base.search_with_conditions( user_access_filters.join(" OR "), fq: [klasses_fq], fl: "id", rows: 100_000 )
     Rails.logger.debug "get policies: #{result}\n\n"
     ids = result.map {|h| h['id']}
     # Find collections governed by units returned in first query along with objects found in first query
-    result = ActiveFedora::Base.search_with_conditions("_query_:\"{!terms f=id}#{ids.join(',')}\" OR _query_:\"{!terms f=isGovernedBy_ssim}#{ids.join(',')}\"", :fl => "id", :rows => 100_000 );
+    expanded_query = "_query_:\"{!terms f=id}#{ids.join(',')}\" OR _query_:\"{!terms f=isGovernedBy_ssim}#{ids.join(',')}\""
+    Rails.logger.debug "get policies query: #{expanded_query}, fq: [#{klasses_fq}], fl: 'id', rows: 100_000\n\n"
+    result = ActiveFedora::Base.search_with_conditions(expanded_query, fq: [klasses_fq], fl: "id", rows: 100_000 );
     Rails.logger.debug "get policies: #{result}\n\n"
     result.map {|h| h['id']}
   end

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -60,6 +60,36 @@ describe Admin::CollectionsController, type: :controller do
           expect(get :poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
         end
       end
+      context "with user with separate administrative access who has special access applied at unit" do
+        let(:user) { FactoryBot.create(:user) }
+        let!(:other_unit) { FactoryBot.create(:unit, unit_admins: [user.user_key]) }
+
+        before do
+          collection.unit.default_read_users += [user.user_key]
+          collection.unit.save
+          login_user user.user_key
+        end
+        # New is isolated here due to issues caused by the controller instance not being regenerated
+        it "should show new collection form" do
+          expect(get :new).to render_template('admin/collections/new')
+        end
+        it "some routes redirect to restricted content page" do
+          expect(get :index).not_to render_template('errors/restricted_pid')
+          expect(get :show, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :edit, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :remove, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          # Failed create collection will redirect to new form with flash message
+          post :create, params: { admin_collection: { name: "Collection in different unit", unit_id: collection.unit.id }}
+          expect(flash[:error]).to include("You do not have sufficient rights to create a collection in unit")
+          expect(response).to render_template('admin/collections/new')
+          expect(put :update, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(patch :update, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(delete :destroy, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(post :attach_poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(delete :remove_poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
+          expect(get :poster, params: { id: collection.id }).to render_template('errors/restricted_pid')
+        end
+      end
     end
   end
 

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -43,6 +43,43 @@ RSpec.describe "/admin/dashboard", type: :request do
         end
       end
 
+      context 'collection member' do
+        let(:user) { User.where(username: collection.editors.first).first }
+
+        it "returns collection data and no unit data" do
+          get admin_dashboard_url
+          expect(response).to be_successful
+          expect(response).to render_template(:index)
+
+          get admin_dashboard_url(format: :json)
+          json = JSON.parse(response.body)
+          expect(json['collections'].map { |c| c['name'] }).to include('Test Collection')
+          expect(json['units']).to be_empty
+        end
+
+        context "with separate administrative access who has special access applied at unit" do
+          let(:user) { FactoryBot.create(:user) }
+          let!(:other_collection) { FactoryBot.create(:collection, name: 'Other Collection', editors: [user.user_key]) }
+
+          before do
+            collection.unit.default_read_users += [user.user_key]
+            collection.unit.save
+          end
+
+          it "returns correct collection data" do
+            get admin_dashboard_url
+            expect(response).to be_successful
+            expect(response).to render_template(:index)
+
+            get admin_dashboard_url(format: :json)
+            json = JSON.parse(response.body)
+            expect(json['collections'].map { |c| c['name'] }).to include('Other Collection')
+            expect(json['collections'].map { |c| c['name'] }).not_to include('Test Collection')
+            expect(json['units']).to be_empty
+          end
+        end
+      end
+
       context 'collection manager' do
         let(:user) { User.where(username: collection.managers.first).first }
 


### PR DESCRIPTION
Continues #6875 
Related to #6729 

TODO:
- ~Fix: admin/collection show page is visible to inherited read users~
- ~write tests for above~
- ~write tests for admin/dashboard json for non-admin users -> nothing more, nothing less in unit/collection lists~
- ~Fix: `Reifying Admin::Unit because collection_managers called from /srv/services/avalon_mco-stage-8130/avalon/releases/20260622214422/app/models/concerns/admin_unit_behavior.rb:22:in 'AdminUnitBehavior#managers'`~