### PR TITLE
Downcase user values in all Staff Role and Special Access fields

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -23,6 +23,7 @@ class Admin::Collection < ActiveFedora::Base
   include Identifier
   include MigrationTarget
   include AdminCollectionBehavior
+  include UserNormalization
 
   belongs_to :governing_policy, class_name: 'ActiveFedora::Base', predicate: ActiveFedora::RDF::ProjectHydra.isGovernedBy
   belongs_to :unit, class_name: 'Admin::Unit', predicate: Avalon::RDFVocab::Bibframe.heldBy
@@ -78,7 +79,7 @@ class Admin::Collection < ActiveFedora::Base
   around_save :reindex_members, if: Proc.new { |c| c.name_changed? or c.unit_changed? }
   around_save :return_checkouts, if: Proc.new { |c| c.cdl_enabled_changed? && c.cdl_enabled == false }
   before_create :create_dropbox_directory!
-  before_save :normalize_read_users, if: proc { |c| c.default_read_users_changed? }
+  before_save :normalize_user_values
 
   before_destroy :destroy_dropbox_directory!
 
@@ -388,9 +389,5 @@ class Admin::Collection < ActiveFedora::Base
 
     def unpublished_count
       media_objects.count - published_count
-    end
-
-    def normalize_read_users
-      self.default_read_users = default_read_users.map(&:downcase)
     end
 end

--- a/app/models/admin/group.rb
+++ b/app/models/admin/group.rb
@@ -134,7 +134,10 @@ module Admin
 
     def users=(value)
       attribute_will_change!('users') if users != value and !@ignoring_changes
-      @users = value
+      # Group is set up differently from our other models where it isn't a subclass
+      # of ActiveFedora::Base or ActiveModel::Base. So we downcase here instead of
+      # in a callback.
+      @users = value.map(&:downcase)
     end
 
     def users_changed?

--- a/app/models/admin/unit.rb
+++ b/app/models/admin/unit.rb
@@ -21,6 +21,7 @@ class Admin::Unit < ActiveFedora::Base
   include Identifier
   include MigrationTarget
   include AdminUnitBehavior
+  include UserNormalization
 
   has_many :collections, class_name: 'Admin::Collection', predicate: Avalon::RDFVocab::Bibframe.heldBy
 
@@ -62,7 +63,7 @@ class Admin::Unit < ActiveFedora::Base
 
   has_subresource 'poster', class_name: 'IndexedFile'
 
-  before_save :normalize_read_users, if: proc { |u| u.default_read_users_changed? }
+  before_save :normalize_user_values
   around_save :reindex_members, if: proc { |u| u.name_changed? }
 
   def created_at
@@ -235,9 +236,5 @@ class Admin::Unit < ActiveFedora::Base
 
   def add_edit_user(name)
     self.default_permissions.build({ name: name, type: 'person', access: 'edit' })
-  end
-
-  def normalize_read_users
-    self.default_read_users = default_read_users.map(&:downcase)
   end
 end

--- a/app/models/concerns/user_normalization.rb
+++ b/app/models/concerns/user_normalization.rb
@@ -1,0 +1,39 @@
+# Copyright 2011-2026, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+module UserNormalization
+  # Method to normalize just read user fields.
+  def normalize_read_users
+    field = self.class == MediaObject ? :read_users : :default_read_users
+    user_array = send(field)
+    setter = "#{field}=".to_sym
+    send(setter, user_array.map(&:downcase))
+  end
+
+  # Method to normalize all fields containing usernames/emails
+  # TODO: Find consistent way to skip unchanged fields
+  def normalize_user_values
+    user_methods = methods.grep(/users$/).reject { |m| m.to_s.include?('set') }
+    user_methods += [:unit_administrators, :collection_managers]
+    user_methods.each do |field|
+      user_array = send(field)
+      setter = "#{field}=".to_sym
+      send(setter, user_array.map(&:downcase))
+    rescue
+      # Skip any methods that do not exist in the including class e.g. :unit_administrators
+      # when loaded into Admin::Collections
+      next
+    end
+  end
+end

--- a/app/models/concerns/user_normalization.rb
+++ b/app/models/concerns/user_normalization.rb
@@ -16,9 +16,7 @@ module UserNormalization
   # Method to normalize just read user fields.
   def normalize_read_users
     field = self.class == MediaObject ? :read_users : :default_read_users
-    user_array = send(field)
-    setter = "#{field}=".to_sym
-    send(setter, user_array.map(&:downcase))
+    set_user_values(field)
   end
 
   # Method to normalize all fields containing usernames/emails
@@ -27,13 +25,19 @@ module UserNormalization
     user_methods = methods.grep(/users$/).reject { |m| m.to_s.include?('set') }
     user_methods += [:unit_administrators, :collection_managers]
     user_methods.each do |field|
-      user_array = send(field)
-      setter = "#{field}=".to_sym
-      send(setter, user_array.map(&:downcase))
+      set_user_values(field)
     rescue
       # Skip any methods that do not exist in the including class e.g. :unit_administrators
       # when loaded into Admin::Collections
       next
     end
+  end
+
+  private
+
+  def set_user_values(field)
+    user_array = send(field)
+    setter = "#{field}=".to_sym
+    send(setter, user_array.map(&:downcase))
   end
 end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -27,6 +27,7 @@ class MediaObject < ActiveFedora::Base
   include SupplementalFileReadBehavior
   include SupplementalFileWriteBehavior
   include MediaObjectBehavior
+  include UserNormalization
   require 'avalon/controlled_vocabulary'
 
   include Kaminari::ActiveFedoraModelExtension
@@ -511,9 +512,5 @@ class MediaObject < ActiveFedora::Base
 
     def sections_with_rendering_files?(tags)
       tags.any? { |t| sections_with_files(tag: t).present? }
-    end
-
-    def normalize_read_users
-      self.read_users = read_users.map(&:downcase)
     end
 end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1275,7 +1275,7 @@ describe MediaObjectsController, type: :controller do
 
           context "from collection" do
             let(:inherited_group_member) { FactoryBot.create(:user) }
-            let(:inherited_group) { FactoryBot.create(:group, users: [inherited_group_member]) }
+            let(:inherited_group) { FactoryBot.create(:group, users: [inherited_group_member.username]) }
             let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection) }
             let(:collection) { FactoryBot.create(:collection, default_read_groups: [inherited_group.name]) }
 
@@ -1332,7 +1332,7 @@ describe MediaObjectsController, type: :controller do
 
           context "from unit" do
             let(:inherited_group_member) { FactoryBot.create(:user) }
-            let(:inherited_group) { FactoryBot.create(:group, users: [inherited_group_member]) }
+            let(:inherited_group) { FactoryBot.create(:group, users: [inherited_group_member.username]) }
             let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'private', collection: collection) }
             let(:collection) { FactoryBot.create(:collection, unit: unit) }
             let(:unit) { FactoryBot.create(:unit, default_read_groups: [inherited_group.name]) }


### PR DESCRIPTION
Related issue: #6792

For some reason some fields do not consistently show up in the `changed`
array, so we have to run the normalize against all user fields on every
save. This should not have much performance impact in most
circumstances, but an item with a lot of assigned roles and/or special
access may see some slow down on saves.

As far as I could tell, playlists and timelines retrieve user values via
the user_id, so downcasing is handled by the retrieval methods in the
User model.

This branch is built off the existing special access downcase branch, so putting it in draft until that prior work is merged.