### PR TITLE
Remove lsof check from file upload step

### DIFF
--- a/app/models/file_upload_step.rb
+++ b/app/models/file_upload_step.rb
@@ -22,12 +22,7 @@ class FileUploadStep < BasicStep
     super
   end
 
-  # For file uploads the process of setting the context is easy. We
-  # just need to ask the dropbox if there are any files. If so load
-  # them into a variable that can be referred to later
   def before_step context
-    dropbox_files = context[:media_object].collection.dropbox.all
-    context[:dropbox_files] = dropbox_files
     context
   end
 


### PR DESCRIPTION
Related issue: #6069

As far as could be determined, it looks like we do not actually use the output of the dropbox lsof check during the file upload step. Dropbox is handled by Browse Everything, which has its own file gathering in place.