### PR TITLE
Respond to external valid stream requests

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -250,7 +250,15 @@ class MasterFilesController < ApplicationController
       end
     elsif auth_token.present?
       return render json: iiif_auth_probe_resp(success: false), status: :unauthorized unless StreamToken.valid_token?(auth_token, @master_file.id) || can?(:read, @master_file)
-      render json: iiif_auth_probe_resp(success: true), status: :ok
+      if request.headers['Accept']&.include?('application/json')
+        render json: iiif_auth_probe_resp(success: true), status: :ok
+      else
+        @hls_streams = if quality == "auto"
+                       gather_hls_streams(@master_file)
+                     else
+                       hls_stream(@master_file, quality)
+                     end
+      end
     else
       return head :unauthorized if cannot?(:read, @master_file)
       @hls_streams = if quality == "auto"


### PR DESCRIPTION
Related issue: https://github.com/samvera-labs/ramp/issues/978

Respond to valid external stream requests with the requested HLS manifest instead of a JSON. This allows IIIF auth 2.0 flow to authorize and stream restricted-access media from outside of Avalon using media object's IIIF Manifest.

Note: to make use of this change, IIIF Manifests for restricted-access media objects need be allowed to read without authorization. 
To test this locally in Ramp demo site I commented the authorization behind the `/manifest` request for media object as follows:
```
def manifest
    @media_object = SpeedyAF::Proxy::MediaObject.find(params[:id])
    # authorize! :read, @media_object
    .....
```
in `controllers/media_objects_controller.rb` [file](https://github.com/avalonmediasystem/avalon/blob/main/app/controllers/media_objects_controller.rb#L509).

However, I didn't add this change to this PR because this seems to be something that needs a team discussion :) (and probably there's a more elegant way to handle this!).