### PR TITLE
Fix improper 'forced' validation check

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -43,7 +43,6 @@ class SupplementalFilesController < ApplicationController
       raise Avalon::BadRequest, "Missing required Content-type headers" unless request.headers["Content-Type"] == 'application/json'
     end
     raise Avalon::BadRequest, "Missing required parameters" unless validate_params
-    raise Avalon::BadRequest, "Forced attribute is already assigned to another caption. Ensure no other captions are forced before setting attribute." unless validate_forced
 
     @supplemental_file = SupplementalFile.new(**metadata_from_params)
 
@@ -107,7 +106,6 @@ class SupplementalFilesController < ApplicationController
       raise Avalon::BadRequest, "Missing required Accept headers" unless request.headers["Accept"] == 'application/json'
     end
     raise Avalon::BadRequest, "Missing required parameters" unless validate_params
-    raise Avalon::BadRequest, "Forced attribute is already assigned to another caption. Ensure no other captions are forced before setting attribute." unless validate_forced
 
     find_supplemental_file
 
@@ -211,11 +209,11 @@ class SupplementalFilesController < ApplicationController
 
 
     def handle_error(message:, status:)
-      if request.format == :json || request.headers['Avalon-Api-Key'].present?
-        render json: { errors: message }, status: status
-      else
+      if request.format == :html
         flash[:error] = message
         redirect_to edit_structure_path
+      else
+        render json: { errors: message}, status: status
       end
     end
 
@@ -262,14 +260,6 @@ class SupplementalFilesController < ApplicationController
           @supplemental_file.tags -= [tag]
         end
       end
-    end
-
-    def validate_forced
-      return true unless params["forced_#{params[:id]}".to_sym]
-      forced_files = @object.supplemental_files(tag: 'forced')
-      return false if forced_files.length.positive?
-
-      true
     end
 
     def metadata_from_params

--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -209,12 +209,10 @@ class SupplementalFilesController < ApplicationController
 
 
     def handle_error(message:, status:)
-      if request.format == :html
-        flash[:error] = message
-        redirect_to edit_structure_path
-      else
-        render json: { errors: message}, status: status
-      end
+      return render json: { errors: message}, status: status unless request.format == :html && request.headers['Avalon-Api-Key'].blank?
+      
+      flash[:error] = message
+      redirect_to edit_structure_path
     end
 
     def edit_structure_path

--- a/app/models/supplemental_file.rb
+++ b/app/models/supplemental_file.rb
@@ -17,6 +17,7 @@ require 'avalon/transcript_parser'
 class SupplementalFile < ApplicationRecord
   has_one_attached :file
 
+  scope :from_object, ->(id) { where(parent_id: id) }
   scope :with_tag, ->(tag_filter) { where("tags LIKE ?", "%\n- #{tag_filter}\n%") }
 
   # TODO: the empty tag should represent a generic supplemental file
@@ -33,6 +34,7 @@ class SupplementalFile < ApplicationRecord
   after_update_commit :update_index, prepend: true
   after_destroy_commit :remove_from_index
   before_save :default_label
+  before_save :validate_forced, if: -> { tags.include?('forced') }
 
   # If using io: true, new_file MUST be a FileLocator instance initialized with the filename opt
   def attach_file(new_file, io: false)
@@ -181,5 +183,11 @@ class SupplementalFile < ApplicationRecord
 
   def default_label
     self.label = file.filename.to_s if self.label.blank?
+  end
+
+  def validate_forced
+    related_files = SupplementalFile.from_object(self.parent_id).with_tag('forced').reject { |sf| self.id == sf.id }
+    return if related_files.empty?
+    raise Avalon::BadRequest, "Forced attribute is already assigned to another caption. Ensure no other captions are forced before setting attribute."
   end
 end

--- a/spec/support/supplemental_files_controller_examples.rb
+++ b/spec/support/supplemental_files_controller_examples.rb
@@ -507,7 +507,9 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
             let(:media_object) { FactoryBot.create(:media_object, supplemental_files: [supplemental_file, forced_caption]) }
 
             it 'error message to display' do
-              put :update, params: { class_id => object.id, id: supplemental_file.id, forced_param => 1, supplemental_file: valid_update_attributes, format: :html }, session: valid_session
+              expect {
+                put :update, params: { class_id => object.id, id: supplemental_file.id, forced_param => 1, supplemental_file: valid_update_attributes, format: :html }, session: valid_session
+              }.to_not change { supplemental_file.tags }
               expect(flash[:error]).not_to be_empty
               expect(flash[:error]).to include 'Forced attribute is already assigned to another caption. Ensure no other captions are forced before setting attribute.'
             end
@@ -519,6 +521,13 @@ RSpec.shared_examples 'a nested controller for' do |object_class|
             expect {
               put :update, params: { class_id => object.id, id: supplemental_file.id, forced_param => 1, supplemental_file: valid_update_attributes, format: :html }, session: valid_session
             }.to not_change { master_file.reload.supplemental_files.first.tags }.from(['caption', 'forced'])
+          end
+
+          it "does not trigger error from forced validation" do
+            expect {
+              put :update, params: { class_id => object.id, id: supplemental_file.id, forced_param => 1, supplemental_file: valid_update_attributes, format: :html }, session: valid_session
+            }.to change { master_file.reload.supplemental_files.first.label }.from(supplemental_file.label).to('new label')
+            expect(flash[:error]).to be_nil
           end
         end
         context "removing forced designation" do


### PR DESCRIPTION
Related issue: #6893

We validate that only one caption file on a master file may have the 'forced' attribute at a time. The validation to enforce this behavior was improperly setup such that the validation would raise the error for any save on a caption marked 'forced'.

This commit also includes a small change to the `SupplementalFilesController#handle_error` method because updates to supplemental files are handled via javascript. The order we had the if...else block in resulted in every action generating a success message, regardless of whether it succeeded or not. The edit page should now reflect when an error has occurred while trying to save supplemental files.