### PR TITLE
Refactor `contains_media_object`

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -840,6 +840,6 @@ class MasterFile < ActiveFedora::Base
   end
 
   def update_playlists
-    Playlist.contains_master_file(id).each(&:touch)
+    Playlist.contains_master_file(id).touch_all
   end
 end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -66,7 +66,7 @@ class MediaObject < ActiveFedora::Base
 
   after_save :update_dependent_permalinks_job, if: Proc.new { |mo| mo.persisted? && mo.published? }
   after_save :remove_bookmarks
-  after_save :update_playlists
+  after_update :update_playlists
   after_update_index :enqueue_long_indexing
 
   # Call custom validation methods to ensure that required fields are present and
@@ -514,6 +514,6 @@ class MediaObject < ActiveFedora::Base
     end
 
     def update_playlists
-      Playlist.contains_media_object(id).each(&:touch)
+      Playlist.contains_media_object(self).touch_all
     end
 end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -22,6 +22,11 @@ class Playlist < ActiveRecord::Base
   end
   scope :with_tag, ->(tag_filter) { where("tags LIKE ?", "%\n- #{tag_filter}\n%") }
   scope :contains_master_file, ->(master_file_id) { joins(:clips).merge(AvalonClip.from_master_file(master_file_id)).distinct }
+  scope :contains_media_object, lambda { |media_object|
+    sections = media_object.section_ids || []
+    # Initialize from blank ActiveRecord relation to avoid unnecessary loading into memory
+    sections.reduce(Playlist.none) { |r, s| r.or(Playlist.contains_master_file(s)) }
+  }
 
   validates :user, presence: true
   validates :title, presence: true
@@ -124,12 +129,6 @@ class Playlist < ActiveRecord::Base
     # Find the i18n default playlist name
     def default_folder_name
       I18n.translate(:'playlists.default_playlist_name')
-    end
-
-    # MediaObject is not directly associated with playlist/clips.
-    # Use class method for scoping instead of ActiveRecord scope.
-    def contains_media_object(id)
-      all.select { |playlist| playlist.media_objects.map(&:id).include?(id) }
     end
   end # class << self
 end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Playlist, type: :model do
       let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
 
       it 'returns all playlists containing specified media object' do
-        expect(Playlist.contains_media_object(media_object.id)).to eq [playlist, playlist3]
+        expect(Playlist.contains_media_object(media_object)).to eq [playlist, playlist3]
       end
     end
   end


### PR DESCRIPTION
Related issue: #6898

Improvements:
* Use `after_update` callback on media object since association with playlist will not exist for newly created media objects
* Use media object in Playlist scope. The object is loaded into memory already because it is being updated. Don't waste bandwidth loading the proxy.
* Use `reduce` to iterate over sections ids and generate a single SQL statement to pull playlists containing the media object's child master files.
* Use `.touch_all` to update all the playlists in a single SQL action instead of iterating through each individually.