### PR TITLE
Users cannot read items with public visibility if inheriting private visibility

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -388,13 +388,13 @@ class Ability
   end
 
   def is_exclusively_inherited_from_parent?(media_object)
-    # User isn't in item's read users or item's read groups (not explicitly granted access to item) AND
-    # User isn't in item's read users and is inherited from parent (exclusively inherited user) OR
-    # User isn't in item's read groups and is in a read group inherited from parent (exclusively inherited group)
-    # Short form: NOT explicitly granted access to item AND (explicitly inherited user OR explicitly inherited group)
-    !(@user.in?(media_object.read_users) || !(@user_groups & media_object.read_groups).empty?) &&
-    ((!@user.in?(media_object.read_users) && @user.in?(media_object.inherited_read_users)) ||
-      ((@user_groups & media_object.read_groups).empty? && !(@user_groups & media_object.inherited_read_groups).empty?))
+    # NOT granted access from item and its leases AND granted access from policies
+    lease_read_users = media_object.leases.collect { |l| read_users_from_policy(l.id) }.flatten
+    lease_read_groups = media_object.leases.collect { |l| read_groups_from_policy(l.id) }.flatten
+    media_object_read_users = read_users(media_object.id) + lease_read_users
+    media_object_read_groups = read_groups(media_object.id) + lease_read_groups
+    access_from_media_object = !(user_groups & media_object_read_groups).empty? || media_object_read_users.include?(current_user.user_key)
+    !access_from_media_object && test_read_from_policy(media_object.id)
   end
 
   def is_member_of_any_collection?
@@ -430,6 +430,9 @@ class Ability
   end
 
   def test_non_disabled_read_media_object(media_object)
+    # Use #read_groups and #read_users from blacklight-access_controls because they pull the permission document from solr which
+    # includes more than media_object.read_groups like cidr IP range expansion
+    # Also include #test_read_from_policy to make sure that collection, unit, and leases apply as well
     media_object_read_groups_without_visibility = read_groups(media_object.id) - media_object.send(:represented_visibility)
     group_intersection = user_groups & media_object_read_groups_without_visibility
     !group_intersection.empty? || read_users(media_object.id).include?(current_user.user_key) || test_read_from_policy(media_object.id)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -211,7 +211,10 @@ class Ability
       # end
 
       cannot :read, [MediaObject, SpeedyAF::Proxy::MediaObject] do |media_object|
-        media_object.disable_inheritance? && is_exclusively_inherited_from_parent?(media_object) && !is_member_of?(media_object.collection)
+        # Block read when inheriting and only granted access from media object visibility and not a member of the parent
+        # OR when disabling inheritance and only granted access from parent and not a member of the parent
+        (!media_object.disable_inheritance? && !test_non_disabled_read_media_object(media_object) && !is_member_of?(media_object.collection)) ||
+        (media_object.disable_inheritance? && is_exclusively_inherited_from_parent?(media_object) && !is_member_of?(media_object.collection))
       end
 
       cannot :update, [MediaObject, SpeedyAF::Proxy::MediaObject] do |media_object|
@@ -424,5 +427,11 @@ class Ability
 
   def has_administrative_access?
     is_administrator? || is_unit_admin_of_any_unit? || is_manager_of_any_collection? || is_member_of_any_unit? || is_member_of_any_collection?
+  end
+
+  def test_non_disabled_read_media_object(media_object)
+    media_object_read_groups_without_visibility = read_groups(media_object.id) - media_object.send(:represented_visibility)
+    group_intersection = user_groups & media_object_read_groups_without_visibility
+    !group_intersection.empty? || read_users(media_object.id).include?(current_user.user_key) || test_read_from_policy(media_object.id)
   end
 end

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -186,7 +186,7 @@ class Admin::Collection < ActiveFedora::Base
       solr_doc["name_uniq_si"] = self.name.downcase.gsub(/\s+/,'') if self.name.present?
       solr_doc["has_poster_bsi"] = !(poster.content.nil? || poster.content == '')
       solr_doc["inheritable_read_access_person_ssim"] = default_read_users
-      solr_doc["inheritable_read_access_group_ssim"] = default_read_groups
+      solr_doc["inheritable_read_access_group_ssim"] = default_read_groups + collect_ips_for_index(default_ip_read_groups)
     end
   end
 
@@ -389,5 +389,13 @@ class Admin::Collection < ActiveFedora::Base
 
     def unpublished_count
       media_objects.count - published_count
+    end
+
+    def collect_ips_for_index ip_strings
+      ips = ip_strings.collect do |ip|
+        addr = IPAddr.new(ip) rescue next
+        addr.to_range.map(&:to_s)
+      end
+      ips.flatten.compact.uniq || []
     end
 end

--- a/app/models/admin/unit.rb
+++ b/app/models/admin/unit.rb
@@ -186,7 +186,7 @@ class Admin::Unit < ActiveFedora::Base
       solr_doc["name_uniq_si"] = self.name.downcase.gsub(/\s+/, '') if self.name.present?
       solr_doc["has_poster_bsi"] = !(poster.content.nil? || poster.content == '')
       solr_doc["inheritable_read_access_person_ssim"] = default_read_users
-      solr_doc["inheritable_read_access_group_ssim"] = default_read_groups
+      solr_doc["inheritable_read_access_group_ssim"] = default_read_groups + collect_ips_for_index(default_ip_read_groups)
     end
   end
 
@@ -236,5 +236,13 @@ class Admin::Unit < ActiveFedora::Base
 
   def add_edit_user(name)
     self.default_permissions.build({ name: name, type: 'person', access: 'edit' })
+  end
+
+  def collect_ips_for_index ip_strings
+    ips = ip_strings.collect do |ip|
+      addr = IPAddr.new(ip) rescue next
+      addr.to_range.map(&:to_s)
+    end
+    ips.flatten.compact.uniq || []
   end
 end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -705,7 +705,7 @@ describe MasterFilesController do
   describe '#hls_manifest' do
     let(:media_object) { FactoryBot.create(:published_media_object) }
     let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
-    let(:public_media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let(:public_media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
     let(:public_master_file) { FactoryBot.create(:master_file, media_object: public_media_object) }
 
     context 'with head request' do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -25,7 +25,7 @@ describe MediaObjectsController, type: :controller do
 
   describe 'security' do
     let(:media_object) { FactoryBot.create(:media_object) }
-    let(:published_media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let(:published_media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
     let(:private_media_object) { FactoryBot.create(:published_media_object, visibility: 'private') }
     describe 'ingest api' do
       before do
@@ -1065,7 +1065,7 @@ describe MediaObjectsController, type: :controller do
   end
 
   describe "#show" do
-    let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
 
     context "Known items should be retrievable" do
       context 'with fedora 3 pid' do
@@ -1439,7 +1439,7 @@ describe MediaObjectsController, type: :controller do
     end
 
     context "Conditional Share partials should be rendered" do
-      let!(:media_object) { FactoryBot.create(:published_media_object, :with_master_file, visibility: 'public') }
+      let!(:media_object) { FactoryBot.create(:published_media_object, :with_master_file, visibility: 'public', disable_inheritance: true) }
       let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
       let(:cache) { Rails.cache }
 

--- a/spec/controllers/playlist_items_controller_spec.rb
+++ b/spec/controllers/playlist_items_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PlaylistItemsController, type: :controller do
   let(:playlist) { FactoryBot.create(:playlist, user: playlist_owner) }
   let(:playlist_item) { FactoryBot.create(:playlist_item, playlist: playlist, clip: clip) }
   let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
-  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
   let(:clip) { AvalonClip.create(master_file: master_file) }
 
   describe 'security' do

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -534,7 +534,7 @@ RSpec.describe PlaylistsController, type: :controller do
     let(:playlist_item_2) { FactoryBot.create(:playlist_item, clip: clip) }
     let(:clip) { FactoryBot.create(:avalon_clip, master_file: master_file) }
     let(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
-    let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+    let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
 
     it "returns a IIIF manifest" do
       get :manifest, format: 'json', params: { id: playlist.id }, session: valid_session

--- a/spec/factories/checkouts.rb
+++ b/spec/factories/checkouts.rb
@@ -15,7 +15,7 @@
 FactoryBot.define do
   factory :checkout do
     user { FactoryBot.create(:user) }
-    media_object_id { FactoryBot.create(:published_media_object, visibility: 'public').id }
+    media_object_id { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true).id }
     checkout_time { DateTime.now }
     return_time { DateTime.now + 2.weeks }
   end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -15,10 +15,11 @@
 FactoryBot.define do
   factory :group, class: Admin::Group do
     name { Faker::Lorem.unique.word }
-    after(:create) do |g|
-      group = Admin::Group.find(g.name)
-      group.users = [FactoryBot.build(:user).user_key]
-      group.save
+    users { [FactoryBot.create(:user).user_key] }
+    after(:create) do |group|
+      # For some reason factory bot's create doesn't go through the normal save
+      # so the users don't get fully set
+      Avalon::RoleControls.assign_users(group.users, group.name)
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -244,4 +244,80 @@ describe Ability, type: :model do
       end
     end
   end
+
+  describe 'disable_inheritance?' do
+    let(:media_object_proxy) { SpeedyAF::Base.find(media_object.id) }
+    let(:collection) { FactoryBot.create(:collection) }
+    let(:session) { {} }
+    let(:user) { nil }
+    subject(:admin_ability) { Ability.new(user, session) }
+
+    context 'with inheritance' do
+      context 'and media object with public visibility' do
+        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: false) }
+
+        it 'does not allow read' do
+          expect(subject.can?(:read, media_object)).to eq false
+          expect(subject.can?(:read, media_object_proxy)).to eq false
+        end
+
+        context 'and user with access' do
+          let(:user) { FactoryBot.create(:user) }
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+      end
+    end
+
+    context 'with inheritance disabled' do
+      context 'and media object with public visibility' do
+        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: true) }
+
+        it 'allows read' do
+          expect(subject.can?(:read, media_object)).to eq true
+          expect(subject.can?(:read, media_object_proxy)).to eq true
+        end
+
+        context 'and user with access' do
+          let(:user) { FactoryBot.create(:user) }
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+      end
+
+      context 'and media object with private visibility' do
+        let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'private', disable_inheritance: true) }
+
+        it 'does not allows read' do
+          expect(subject.can?(:read, media_object)).to eq false
+          expect(subject.can?(:read, media_object_proxy)).to eq false
+        end
+
+        context 'and collection member' do
+          let(:user) { User.find_by(username: collection.depositors.first) }
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and user with access' do
+          let(:user) { FactoryBot.create(:user) }
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -15,6 +15,8 @@
 require 'rails_helper'
 
 describe Ability, type: :model do
+  include ActiveJob::TestHelper
+
   describe 'non-logged in users' do
     it 'only belongs to the public group' do
       expect(Ability.new(nil).user_groups).to eq ["public"]
@@ -250,11 +252,11 @@ describe Ability, type: :model do
     let(:collection) { FactoryBot.create(:collection) }
     let(:session) { {} }
     let(:user) { nil }
-    subject(:admin_ability) { Ability.new(user, session) }
+    subject(:ability) { Ability.new(user, session) }
 
     context 'with inheritance' do
       context 'and media object with public visibility' do
-        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: false) }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, visibility: 'public', disable_inheritance: false) }
 
         it 'does not allow read' do
           expect(subject.can?(:read, media_object)).to eq false
@@ -262,6 +264,7 @@ describe Ability, type: :model do
         end
 
         context 'and user with access' do
+          let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: false) }
           let(:user) { FactoryBot.create(:user) }
 
           it 'allows read' do
@@ -269,12 +272,179 @@ describe Ability, type: :model do
             expect(subject.can?(:read, media_object_proxy)).to eq true
           end
         end
+
+        context 'and group granting user access' do
+          let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_groups: [group.name], visibility: 'public', disable_inheritance: false) }
+          # Need to make sure the after_create callback of the group happens before the ability subject
+          let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+          let(:user) { FactoryBot.create(:user) }
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and ip range granting user access' do
+          # Need to make sure that media_object is created before perform_enqueued_jobs to ensure ip expansion happens in solr
+          let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_groups: ['172.16.0.0/30'], visibility: 'public', disable_inheritance: false) }
+          let(:user) { FactoryBot.create(:user) }
+          let(:session) { { remote_ip: '172.16.0.3' } }
+
+          it 'allows read' do
+            perform_enqueued_jobs(only: MediaObjectIndexingJob)
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_users: [user.user_key]) }
+          let(:user) { FactoryBot.create(:user) }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease with group granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_groups: [group.name]) }
+          let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+          let(:user) { FactoryBot.create(:user) }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease with ip range granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_groups: ['172.16.0.0/30']) }
+          let(:user) { FactoryBot.create(:user) }
+          let(:session) { { remote_ip: '172.16.0.3' } }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            perform_enqueued_jobs(only: MediaObjectIndexingJob)
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'from collection' do
+          context 'with user access' do
+            let(:collection) { FactoryBot.create(:collection, default_read_users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'with group access' do
+            let(:collection) { FactoryBot.create(:collection, default_read_groups: [group.name]) }
+            # Need to make sure the after_create callback of the group happens before the ability subject
+            let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'and ip range granting user access' do
+            let(:collection) { FactoryBot.create(:collection, default_read_groups: ['172.16.0.0/30']) }
+            let(:user) { FactoryBot.create(:user) }
+            let(:session) { { remote_ip: '172.16.0.3' } }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'with collection member' do
+            let(:user) { User.find_by(username: collection.depositors.first) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+        end
+
+        context 'from unit' do
+          context 'with user access' do
+            let(:unit) { FactoryBot.create(:unit, default_read_users: [user.user_key]) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'with group access' do
+            let(:unit) { FactoryBot.create(:unit, default_read_groups: [group.name]) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            # Need to make sure the after_create callback of the group happens before the ability subject
+            let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'and ip range granting user access' do
+            let(:unit) { FactoryBot.create(:unit, default_read_groups: ['172.16.0.0/30']) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            let(:user) { FactoryBot.create(:user) }
+            let(:session) { { remote_ip: '172.16.0.3' } }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+
+          context 'with unit member' do
+            let(:user) { User.find_by(username: collection.unit.depositors.first) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+        end
       end
     end
 
     context 'with inheritance disabled' do
       context 'and media object with public visibility' do
-        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: true) }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'public', disable_inheritance: true) }
 
         it 'allows read' do
           expect(subject.can?(:read, media_object)).to eq true
@@ -293,15 +463,16 @@ describe Ability, type: :model do
 
       context 'and media object with private visibility' do
         let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
-        let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'private', disable_inheritance: true) }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, visibility: 'private', disable_inheritance: true) }
 
-        it 'does not allows read' do
+        it 'does not allow read' do
           expect(subject.can?(:read, media_object)).to eq false
           expect(subject.can?(:read, media_object_proxy)).to eq false
         end
 
-        context 'and collection member' do
-          let(:user) { User.find_by(username: collection.depositors.first) }
+        context 'and user with access' do
+          let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_users: [user&.user_key], visibility: 'private', disable_inheritance: true) }
+          let(:user) { FactoryBot.create(:user) }
 
           it 'allows read' do
             expect(subject.can?(:read, media_object)).to eq true
@@ -309,12 +480,157 @@ describe Ability, type: :model do
           end
         end
 
-        context 'and user with access' do
+        context 'and group granting user access' do
+          let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, read_groups: [group.name], visibility: 'private', disable_inheritance: true) }
+          # Need to make sure the after_create callback of the group happens before the ability subject
+          let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
           let(:user) { FactoryBot.create(:user) }
 
           it 'allows read' do
             expect(subject.can?(:read, media_object)).to eq true
             expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_users: [user.user_key]) }
+          let(:user) { FactoryBot.create(:user) }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease with group granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_groups: [group.name]) }
+          let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+          let(:user) { FactoryBot.create(:user) }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'and lease with ip range granting user access' do
+          let(:lease) { FactoryBot.create(:lease, inherited_read_groups: ['172.16.0.0/30']) }
+          let(:user) { FactoryBot.create(:user) }
+          let(:session) { { remote_ip: '172.16.0.3' } }
+
+          before do
+            media_object.governing_policies += [lease]
+            media_object.save!
+            media_object.reload
+          end
+
+          it 'allows read' do
+            perform_enqueued_jobs(only: MediaObjectIndexingJob)
+            expect(subject.can?(:read, media_object)).to eq true
+            expect(subject.can?(:read, media_object_proxy)).to eq true
+          end
+        end
+
+        context 'from collection' do
+          context 'with user access' do
+            let(:collection) { FactoryBot.create(:collection, default_read_users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'with group access' do
+            let(:collection) { FactoryBot.create(:collection, default_read_groups: [group.name]) }
+            # Need to make sure the after_create callback of the group happens before the ability subject
+            let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'and ip range' do
+            let(:collection) { FactoryBot.create(:collection, default_read_groups: ['172.16.0.0/30']) }
+            let(:user) { FactoryBot.create(:user) }
+            let(:session) { { remote_ip: '172.16.0.3' } }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'with collection member' do
+            let(:user) { User.find_by(username: collection.depositors.first) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
+          end
+        end
+
+        context 'from unit' do
+          context 'with user access' do
+            let(:unit) { FactoryBot.create(:unit, default_read_users: [user.user_key]) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'with group access' do
+            let(:unit) { FactoryBot.create(:unit, default_read_groups: [group.name]) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            # Need to make sure the after_create callback of the group happens before the ability subject
+            let!(:group) { FactoryBot.create(:group, users: [user.user_key]) }
+            let(:user) { FactoryBot.create(:user) }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'and ip range' do
+            let(:unit) { FactoryBot.create(:unit, default_read_groups: ['172.16.0.0/30']) }
+            let(:collection) { FactoryBot.create(:collection, unit: unit) }
+            let(:user) { FactoryBot.create(:user) }
+            let(:session) { { remote_ip: '172.16.0.3' } }
+
+            it 'does not allow read' do
+              expect(subject.can?(:read, media_object)).to eq false
+              expect(subject.can?(:read, media_object_proxy)).to eq false
+            end
+          end
+
+          context 'with unit member' do
+            let(:user) { User.find_by(username: collection.unit.depositors.first) }
+
+            it 'allows read' do
+              expect(subject.can?(:read, media_object)).to eq true
+              expect(subject.can?(:read, media_object_proxy)).to eq true
+            end
           end
         end
       end

--- a/spec/models/avalon_marker_spec.rb
+++ b/spec/models/avalon_marker_spec.rb
@@ -49,7 +49,7 @@ describe AvalonMarker, type: :model do
       end
 
       context 'when master file is readable by user' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it { is_expected.to be_able_to(:read, avalon_marker) }
@@ -68,7 +68,7 @@ describe AvalonMarker, type: :model do
       end
 
       context 'when master file is readable by user' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it { is_expected.to be_able_to(:read, avalon_marker) }
@@ -101,7 +101,7 @@ describe AvalonMarker, type: :model do
       end
 
       context 'when master file is readable by public' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it { is_expected.to be_able_to(:read, avalon_marker) }

--- a/spec/models/playlist_item_spec.rb
+++ b/spec/models/playlist_item_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe PlaylistItem, type: :model do
       end
 
       context 'when master file is readable by user' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it{ is_expected.to be_able_to(:read, playlist_item) }
@@ -71,7 +71,7 @@ RSpec.describe PlaylistItem, type: :model do
       end
 
       context 'when master file is readable by user' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it{ is_expected.to be_able_to(:read, playlist_item) }
@@ -91,7 +91,7 @@ RSpec.describe PlaylistItem, type: :model do
       end
 
       context 'when master file is readable by public' do
-        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
         let(:master_file) { FactoryBot.create(:master_file, media_object: media_object) }
 
         it{ is_expected.to be_able_to(:read, playlist_item) }

--- a/spec/requests/checkouts_spec.rb
+++ b/spec/requests/checkouts_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "/checkouts", type: :request do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:user) { FactoryBot.create(:user) }
-  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
   let(:checkout) { FactoryBot.create(:checkout, user: user, media_object_id: media_object.id) }
 
   # This should return the minimal set of attributes required to create a valid
@@ -212,7 +212,8 @@ RSpec.describe "/checkouts", type: :request do
       end
 
       context "with inherited lending period" do
-        let(:media_object) { FactoryBot.create(:published_media_object, lending_period: 86400, visibility: 'public') }
+        let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, lending_period: 86400) }
         before { freeze_time }
         after { travel_back }
         it "sets the return time based on the inherited lending period of the parent" do

--- a/spec/requests/oembed_spec.rb
+++ b/spec/requests/oembed_spec.rb
@@ -15,7 +15,7 @@
 require 'rails_helper'
 
 describe 'oembed', type: :request do
-  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+  let(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public', disable_inheritance: true) }
   let(:master_file) { FactoryBot.create(:master_file, media_object: media_object, title: 'Test Video') }
 
   before do


### PR DESCRIPTION
Resolves #6913

The issue here is that a media object can have a locally set visibility that is different than its parent.  We want to save that value even if it is inactive because inheritance is not disabled so that when it is disabled the user will restore the previous value.  The media object's visibility is stored in `read_groups` which is used in `test_read` (provided by `blacklight-access_controls`) to determine access.  Instead of overriding this I chose to add to the `cannot` clause that already exists to also override the access granted by default.  This PR blocks access if disable inheritance is not set and the user's groups don't overlap with the groups inherited from the collection, which includes visibility, and the special access groups which are still active.  (This is effectively a clone of `test_read` with a changed set of groups to test specific to this case.)

I also added more tests specific to this case.  Are there any more that should be added?

See #6913 for steps to reproduce.