### PR TITLE
Update rubocop file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,8 @@ inherit_gem:
   bixby: bixby_default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
-  TargetRailsVersion: 5.1
+  TargetRubyVersion: 4.0
+  TargetRailsVersion: 8.0
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'
@@ -26,7 +26,7 @@ AllCops:
 Rails:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/ClassLength:


### PR DESCRIPTION
Update the rubocop config to point to current ruby/rails versions and change cop name to match more recent versions of rubocop.

While we no longer have linting setup in our CI pipeline, this will facilitate having a baseline working rubocop config available for developers who want to run linting locally.