### PR TITLE
Consider inheritance when determining if auth service needs to be included on the canvas

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -511,7 +511,7 @@ class MediaObjectsController < ApplicationController
     authorize! :read, @media_object
 
     # TODO: Add a rake task to clear expired items from the cache?
-    cached_manifest = Rails.cache.fetch([@media_object.cache_key_with_version, 'iiif_manifest'], expires_in: 1.week) do
+    cached_manifest = Rails.cache.fetch([@media_object.cache_key_with_version, @media_object.active_visibility, 'iiif_manifest'], expires_in: 1.week) do
       stream_info_hash = secure_stream_infos(master_file_presenters, [@media_object])
       canvas_presenters = master_file_presenters.collect { |mf| IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info_hash[mf.id]) }
       presenter = IiifManifestPresenter.new(media_object: @media_object, master_files: canvas_presenters, lending_enabled: lending_enabled?(@media_object))

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -262,16 +262,6 @@ class Admin::Collection < ActiveFedora::Base
     end
   end
 
-  def default_visibility
-    if default_read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
-      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-    elsif default_read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
-      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-    else
-      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-    end
-  end
-
   def default_visibility_changed?
     !!@default_visibility_will_change
   end

--- a/app/models/concerns/admin_collection_behavior.rb
+++ b/app/models/concerns/admin_collection_behavior.rb
@@ -61,4 +61,14 @@ module AdminCollectionBehavior
   def inherited_virtual_read_groups
     unit.default_virtual_read_groups
   end
+
+  def default_visibility
+    if default_read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    elsif default_read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    else
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+  end
 end

--- a/app/models/concerns/media_object_behavior.rb
+++ b/app/models/concerns/media_object_behavior.rb
@@ -159,4 +159,8 @@ module MediaObjectBehavior
     return false unless collection
     collection.default_visibility
   end
+
+  def active_visibility
+    disable_inheritance? ? visibility : inherited_visibility
+  end
 end

--- a/app/models/iiif_canvas_presenter.rb
+++ b/app/models/iiif_canvas_presenter.rb
@@ -241,11 +241,10 @@ class IiifCanvasPresenter
       thumbnail: [{ id: thumbnail_url, type: 'Image' }]
     }.compact
 
-    if master_file.media_object.visibility == 'public'
-      media_hash
-    else
+    if master_file.media_object.active_visibility != 'public'
       media_hash.merge!(auth_service: auth_service(quality))
     end
+    media_hash
   end
 
   def supplemental_attributes(file, type: nil)

--- a/app/models/iiif_playlist_canvas_presenter.rb
+++ b/app/models/iiif_playlist_canvas_presenter.rb
@@ -205,11 +205,10 @@ class IiifPlaylistCanvasPresenter
         thumbnail: [{ id: thumbnail_url, type: 'Image' }]
       }.compact
 
-      if master_file.media_object.visibility == 'public'
-        media_hash
-      else
+      if master_file.media_object.active_visibility != 'public'
         media_hash.merge!(auth_service: auth_service(quality))
       end
+      media_hash
     end
 
     def placeholder_attributes(label_content)

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -2520,12 +2520,29 @@ describe MediaObjectsController, type: :controller do
 
     context 'read from solr' do
       let!(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
-      let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
-      it 'should not read from fedora' do
-        perform_enqueued_jobs(only: MediaObjectIndexingJob)
-        WebMock.reset_executed_requests!
-        get 'manifest', params: { id: media_object.id, format: 'json' }
-        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+
+      context 'with disable inheritance' do
+        let(:collection) { FactoryBot.create(:collection, default_visibility: 'private') }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, visibility: 'public', disable_inheritance: true) }
+
+        it 'should not read from fedora' do
+          perform_enqueued_jobs(only: MediaObjectIndexingJob)
+          WebMock.reset_executed_requests!
+          get 'manifest', params: { id: media_object.id, format: 'json' }
+          expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+        end
+      end
+
+      context 'with inheritance' do
+        let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+        let(:media_object) { FactoryBot.create(:published_media_object, collection: collection, visibility: 'private', disable_inheritance: false) }
+
+        it 'should not read from fedora' do
+          perform_enqueued_jobs(only: MediaObjectIndexingJob)
+          WebMock.reset_executed_requests!
+          get 'manifest', params: { id: media_object.id, format: 'json' }
+          expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+        end
       end
     end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -2547,16 +2547,24 @@ describe MediaObjectsController, type: :controller do
     end
 
     context 'caching' do
-      let!(:media_object) { FactoryBot.create(:published_media_object, visibility: 'public') }
+      let(:collection) { FactoryBot.create(:collection, default_visibility: 'public') }
+      let!(:media_object) { FactoryBot.create(:published_media_object, collection: collection) }
+      let!(:master_file) { FactoryBot.create(:master_file, :with_derivative, media_object: media_object) }
       let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-      subject { Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/iiif_manifest") }
+      subject { Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/#{media_object.active_visibility}/iiif_manifest") }
 
       before do
         allow(Rails).to receive(:cache).and_return(memory_store)
         # Range ids are randomly generated. Force the id to a known value so we can equality match.
         allow_any_instance_of(IIIFManifest::V3::ManifestBuilder::RangeBuilder).to receive(:path).and_return('range')
-        presenter = IiifManifestPresenter.new(media_object: media_object, master_files: [])
+        stream_info_hash = { media_object.section_ids.first => {stream_hls: [{quality: master_file.derivatives.first.quality, mimetype: master_file.derivatives.first.mime_type, url: master_file.derivatives.first.hls_url}]} }
+        allow_any_instance_of(MediaObjectsController).to receive(:secure_stream_infos).and_return(stream_info_hash)
+        allow_any_instance_of(IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage).to receive(:index).and_return(1)
+        allow_any_instance_of(IIIFManifest::V3::ManifestBuilder::IIIFManifest::Annotation).to receive(:index).and_return(1)
+        @canvas_presenters = media_object.sections.collect { |mf| IiifCanvasPresenter.new(master_file: mf, stream_info: stream_info_hash[mf.id]) }
+        presenter = IiifManifestPresenter.new(media_object: media_object, master_files: @canvas_presenters)
         @manifest = IIIFManifest::V3::ManifestFactory.new(presenter).to_h
+        @manifest["thumbnail"] = [{ "id" => presenter.thumbnail, "type" => 'Image' }] if presenter.thumbnail
         @manifest["@context"] = @manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
       end
 
@@ -2574,11 +2582,29 @@ describe MediaObjectsController, type: :controller do
         old_manifest = subject
         media_object.title = 'Test'
         media_object.save!
-        new_presenter = IiifManifestPresenter.new(media_object: media_object, master_files: [])
+        @canvas_presenters.first.master_file.reload
+        new_presenter = IiifManifestPresenter.new(media_object: media_object, master_files: @canvas_presenters)
         new_manifest = IIIFManifest::V3::ManifestFactory.new(new_presenter).to_h
+        new_manifest["thumbnail"] = [{ "id" => new_presenter.thumbnail, "type" => 'Image' }] if new_presenter.thumbnail
         new_manifest["@context"] = new_manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
         get 'manifest', params: { id: media_object.id, format: 'json' }
-        new_cache = Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/iiif_manifest")
+        new_cache = Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/#{media_object.active_visibility}/iiif_manifest")
+        expect(new_cache).to_not eq(old_manifest)
+        expect(new_cache).to eq(new_manifest.to_json)
+      end
+
+      it 'should update the cache when the collection default_visibility is updated' do
+        get 'manifest', params: { id: media_object.id, format: 'json' }
+        old_manifest = subject
+        media_object.collection.default_visibility = 'private'
+        media_object.collection.save!
+        @canvas_presenters.first.master_file.reload
+        new_presenter = IiifManifestPresenter.new(media_object: media_object, master_files: @canvas_presenters)
+        new_manifest = IIIFManifest::V3::ManifestFactory.new(new_presenter).to_h
+        new_manifest["thumbnail"] = [{ "id" => new_presenter.thumbnail, "type" => 'Image' }] if new_presenter.thumbnail
+        new_manifest["@context"] = new_manifest["@context"].insert(1, "http://iiif.io/api/auth/2/context.json")
+        get 'manifest', params: { id: media_object.id, format: 'json' }
+        new_cache = Rails.cache.read("#{SpeedyAF::Proxy::MediaObject.find(media_object.id).cache_key_with_version}/#{media_object.active_visibility}/iiif_manifest")
         expect(new_cache).to_not eq(old_manifest)
         expect(new_cache).to eq(new_manifest.to_json)
       end

--- a/spec/models/iiif_canvas_presenter_spec.rb
+++ b/spec/models/iiif_canvas_presenter_spec.rb
@@ -15,7 +15,8 @@
 require 'rails_helper'
 
 describe IiifCanvasPresenter do
-  let(:media_object) { FactoryBot.build(:media_object, visibility: 'private') }
+  let (:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+  let(:media_object) { FactoryBot.build(:media_object, collection: collection) }
   let(:derivative) { FactoryBot.build(:derivative) }
   let(:master_file) { FactoryBot.build(:master_file, media_object: media_object, derivatives: [derivative]) }
   let(:stream_info) { master_file.stream_details }
@@ -40,10 +41,35 @@ describe IiifCanvasPresenter do
       end
 
       context 'when public media object' do
-        let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+        context 'via disable inheritance' do
+          let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'public', disable_inheritance: true) }
 
-        it "does not provide an auth service" do
-          expect(presenter.display_content.first.auth_service).to be_nil
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
+        context 'via inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
+      end
+      context 'when private media object' do
+        context 'via disable inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+          let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'private', disable_inheritance: true) }
+
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_present
+          end
+        end
+        context 'via inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_present
+          end
         end
       end
     end
@@ -70,10 +96,35 @@ describe IiifCanvasPresenter do
       end
 
       context 'when public media object' do
-        let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+        context 'via disable inheritance' do
+          let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'public', disable_inheritance: true) }
 
-        it "does not provide an auth service" do
-          expect(presenter.display_content.first.auth_service).to be_nil
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
+        context 'via inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_nil
+          end
+        end
+      end
+      context 'when private media object' do
+        context 'via disable inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+          let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'private', disable_inheritance: true) }
+
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_present
+          end
+        end
+        context 'via inheritance' do
+          let (:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+          it "does not provide an auth service" do
+            expect(presenter.display_content.first.auth_service).to be_present
+          end
         end
       end
     end

--- a/spec/models/iiif_playlist_canvas_presenter_spec.rb
+++ b/spec/models/iiif_playlist_canvas_presenter_spec.rb
@@ -15,7 +15,8 @@
 require 'rails_helper'
 
 describe IiifPlaylistCanvasPresenter do
-  let(:media_object) { FactoryBot.build(:media_object, visibility: 'private') }
+  let(:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+  let(:media_object) { FactoryBot.build(:media_object, collection: collection) }
   let(:derivative) { FactoryBot.build(:derivative) }
   let(:master_file) { FactoryBot.build(:master_file, media_object: media_object, derivatives: [derivative]) }
   let(:playlist_item) { FactoryBot.build(:playlist_item, clip: playlist_clip) }
@@ -66,10 +67,35 @@ describe IiifPlaylistCanvasPresenter do
         end
 
         context 'when public media object' do
-          let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+          context 'via disable inheritance' do
+            let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'public', disable_inheritance: true) }
 
-          it "does not provide an auth service" do
-            expect(presenter.display_content.first.auth_service).to be_nil
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_nil
+            end
+          end
+          context 'via inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_nil
+            end
+          end
+        end
+        context 'when private media object' do
+          context 'via disable inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+            let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'private', disable_inheritance: true) }
+
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_present
+            end
+          end
+          context 'via inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_present
+            end
           end
         end
       end
@@ -96,10 +122,35 @@ describe IiifPlaylistCanvasPresenter do
         end
 
         context 'when public media object' do
-          let(:media_object) { FactoryBot.build(:media_object, visibility: 'public') }
+          context 'via disable inheritance' do
+            let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'public', disable_inheritance: true) }
 
-          it "does not provide an auth service" do
-            expect(presenter.display_content.first.auth_service).to be_nil
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_nil
+            end
+          end
+          context 'via inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_nil
+            end
+          end
+        end
+        context 'when private media object' do
+          context 'via disable inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'public') }
+            let(:media_object) { FactoryBot.build(:media_object, collection: collection, visibility: 'private', disable_inheritance: true) }
+
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_present
+            end
+          end
+          context 'via inheritance' do
+            let (:collection) { FactoryBot.build(:collection, default_visibility: 'private') }
+            it "does not provide an auth service" do
+              expect(presenter.display_content.first.auth_service).to be_present
+            end
           end
         end
       end


### PR DESCRIPTION
Related to #6914 

This is another instance where we were relying on `media_object.visibility` and didn't add checking of `disable_inheritance?`.  This PR resolves this by using a new `active_visibility` convenience method which checks `disabled_inheritance?` before providing the correct visibility.

@masaball With this change do you think we need to consider parent collection edits in manifest cache expiration?