### PR TITLE
Various enhancements and fixes from Northwestern's Avalon implementation

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,6 +22,7 @@ class CatalogController < ApplicationController
   include BlacklightHelperReloadFix
 
   # These before_actions apply the hydra access controls
+  before_action :block_invalid_sort_params, only: :index
   before_action :enforce_show_permissions, only: :show
   before_action :load_home_page_collections, only: :index, if: proc { helpers.current_page? root_path }
 
@@ -234,6 +235,14 @@ class CatalogController < ApplicationController
   end
 
   private
+
+    def block_invalid_sort_params
+      sort_val = params[:sort]
+      return unless sort_val      
+      if !blacklight_config.sort_fields.has_key?(URI.decode_www_form_component(sort_val))
+        render plain: "Requested illegal sort val: #{sort_val}", status: :bad_request
+      end
+    end
 
     def load_home_page_collections
       featured_collections = Settings.home_page&.featured_collections

--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -95,7 +95,7 @@ const MediaObjectRamp = ({
             : (<Fragment>
               {has_sections &&
                 <Fragment>
-                  <MediaPlayer enableFileDownload={false} enablePlaybackRate={true} resumeCache={{ enable: true }} />
+                  <MediaPlayer enableFileDownload={false} enablePlaybackRate={true} resumeCache={{ enable: true }} withCredentials={true} />
                   <div className="ramp--rails-title">
                     {<div className="object-title" dangerouslySetInnerHTML={{ __html: title.content }} />}
                   </div>

--- a/app/javascript/components/ReactButtonContainer.jsx
+++ b/app/javascript/components/ReactButtonContainer.jsx
@@ -93,7 +93,9 @@ class ReactButtonContainer extends Component {
               {...this.state.smeProps}
               structureIsSaved={this.getStructureStatus}
               /* Enable text editor for JSON structure */
-              showTextEditor={true} />
+              showTextEditor={true}
+              /* Include cookies in streaming requests */
+              withCredentials={true} />
           </Modal.Body>
         </Modal>
       </div>

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -593,6 +593,7 @@ class MasterFile < ActiveFedora::Base
 
     source = FileLocator.new(working_file_path&.first || file_location)
     options[:non_temp_file] = true
+    options[:master] = true
     if source.source.blank? or (source.uri.scheme == 's3' and not source.exist?)
       source = FileLocator.new(self.derivatives.where(quality_ssi: 'high').first.absolute_location)
       options[:non_temp_file] = true

--- a/app/services/security_service.rb
+++ b/app/services/security_service.rb
@@ -22,7 +22,8 @@ class SecurityService
       uri = Addressable::URI.parse(url)
       case context[:protocol]
       when :stream_hls
-        Addressable::URI.join(Settings.streaming.http_base,uri.path).to_s
+        # Only encode spaces; all the built-in encoding methods will encode the slashes, which will break the URL.
+        Addressable::URI.join(Settings.streaming.http_base,uri.path).to_s.gsub(' ', '%20')
       else
         url
       end

--- a/app/services/waveform_service.rb
+++ b/app/services/waveform_service.rb
@@ -29,17 +29,13 @@ class WaveformService
       bits: @bit_res
     )
 
-    peaks = if uri.scheme == 's3'
-              begin
-                local_file = FileLocator::S3File.new(uri).local_file
-                get_normalized_peaks(local_file.path)
-              ensure
-                local_file.close!
-              end
-            else
-              get_normalized_peaks(uri)
-            end
+    uri = Addressable::URI.parse(uri)
+    if uri.scheme == 's3'
+      s3_file = FileLocator::S3File.new(uri)
+      uri = Addressable::URI.parse(s3_file.object.presigned_url(:get))
+    end
 
+    peaks = get_normalized_peaks(uri)
     peaks.each { |peak| waveform.append(peak[0], peak[1]) }
     return nil if waveform.size.zero?
     waveform.to_json

--- a/app/views/master_files/hls_manifest.m3u8.erb
+++ b/app/views/master_files/hls_manifest.m3u8.erb
@@ -16,5 +16,5 @@ Unless required by applicable law or agreed to in writing, software distributed
 #EXTM3U
 <% @hls_streams.each do |hls| %>
 #EXT-X-STREAM-INF:BANDWIDTH=<%= hls[:bitrate] %>
-<%= hls[:url] %>
+<%= hls[:url].html_safe %>
 <% end %>

--- a/lib/avalon/batch/ingest.rb
+++ b/lib/avalon/batch/ingest.rb
@@ -58,8 +58,11 @@ module Avalon
         # Otherwise this should be set
         # Validate the package if a side package is passed in
         unless package.nil?
-          return unless valid_package?
           @current_package = package
+          unless valid_package?
+            @current_package = nil
+            return
+          end
         end
 
         # We have a valid batch so we can go ahead and delete the manifest file

--- a/spec/services/security_service_spec.rb
+++ b/spec/services/security_service_spec.rb
@@ -39,6 +39,7 @@ Lw03eHTNQghS0A==
 
   describe '.rewrite_url' do
     let(:url) { "http://example.com/streaming/id" }
+    let(:url_with_spaces) { "http://example.com/streaming/file with spaces" }
     let(:context) {{ session: {}, target: 'abcd1234', protocol: :stream_hls }}
 
     context 'when AWS streaming server' do
@@ -53,6 +54,10 @@ Lw03eHTNQghS0A==
       context 'when hls' do
         it 'changes it into an hls url' do
           expect(subject.rewrite_url(url, context)).to eq "http://localhost:3000/streaming/id"
+        end
+
+        it 'encodes spaces in the URL' do
+          expect(subject.rewrite_url(url_with_spaces, context)).to eq "http://localhost:3000/streaming/file%20with%20spaces"
         end
       end
       context 'when not hls' do

--- a/spec/services/waveform_service_spec.rb
+++ b/spec/services/waveform_service_spec.rb
@@ -30,15 +30,14 @@ describe WaveformService, type: :service do
 
     context "s3 file" do
       let(:uri) { Addressable::URI.parse("s3://path/to/video.mp4") }
-      let(:tmpfile) { Tempfile.new }
 
       before do
-        allow(Tempfile).to receive(:new).and_return tmpfile
+        allow(Tempfile).to receive(:new).and_return double('tempfile', path: '/tmp/fakepath')
       end
 
-      it "should clean up Tempfile" do
+      it "does not use a Tempfile" do
         service.get_waveform_json(uri)
-        expect(tmpfile.path).to eq nil
+        expect(Tempfile).not_to have_received(:new)
       end
     end
 


### PR DESCRIPTION
This PR contains multiple small fixes we've applied on top of several versions of Avalon while applying our own branding and additional in-house features to the base version. They include:

- A fix for a situation where poster generation would raise an exception if `master_file.file_location` was `nil` (e.g., when the MasterFile management strategy is set to `delete`)
- A fix for streaming URLs with spaces in them (e.g., when a MasterFile is ingested with spaces in the filename and goes through the whole pipeline like that). (This _might_ only apply to AWS CloudFront streaming, but shouldn't break any others)
- A fix to allow the MediaPlayer component to send credentials (cookies and/or auth headers) with streaming requests
- A `CatalogController` `before_action` to validate sort params before allowing the request to continue
- A fix to prevent HTML encoding of URLs inside dynamically generated HLS manifests
- An enhancement to allow `WaveformJob` to generate waveforms from an AWS S3 source by streaming it instead of downloading the entire file to temp storage
- A fix for batch ingest that makes sure that the ingest object's `@current_package` instance variable always gets set correctly

I left them as separate commits to make them easier to cherry pick, but I didn't want to submit 7 separate tiny PRs.