### PR TITLE
Support static variable bitrate HLS manifests

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -256,11 +256,14 @@ class MasterFilesController < ApplicationController
       render json: iiif_auth_probe_resp(success: true), status: :ok
     else
       return head :unauthorized if cannot?(:read, @master_file)
-      @hls_streams = if quality == "auto"
-                       gather_hls_streams(@master_file)
-                     else
-                       hls_stream(@master_file, quality)
-                     end
+      stream = hls_stream(@master_file, quality).first
+      case stream
+      when nil
+        render plain: 'Not Found', status: :not_found unless quality == 'auto'
+        @hls_streams = gather_hls_streams(@master_file)
+      else
+        redirect_to(stream[:url], allow_other_host: true)
+      end
     end
   end
 

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -766,16 +766,29 @@ describe MasterFilesController do
       expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:unauthorized)
     end
 
-    it 'returns the dynamic bitrate HLS manifest' do
+    it 'returns an auto-generated variable bitrate HLS manifest' do
       login_as :administrator
       expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:ok)
       expect(response.content_type).to eq 'application/x-mpegURL; charset=utf-8'
     end
 
-    it 'returns a single quality HLS manifest' do
+    it 'returns not found (404) if the requested quality does not exist' do
       login_as :administrator
-      expect(get('hls_manifest', params: { id: master_file.id, quality: 'high' })).to have_http_status(:ok)
-      expect(response.content_type).to eq 'application/x-mpegURL; charset=utf-8'
+      expect(get('hls_manifest', params: { id: master_file.id, quality: 'high' })).to have_http_status(:not_found)
+    end
+
+    it 'redirects to a static variable bitrate HLS manifest if available' do
+      derivative = FactoryBot.create(:derivative, master_file: master_file, quality: 'auto')
+      login_as :administrator
+      expect(get('hls_manifest', params: { id: master_file.id, quality: 'auto' })).to have_http_status(:found)
+      expect(response.location).to start_with(derivative.hls_url)
+    end
+
+    it 'redirects to a single quality HLS manifest' do
+      derivative = FactoryBot.create(:derivative, master_file: master_file, quality: 'high')
+      login_as :administrator
+      expect(get('hls_manifest', params: { id: master_file.id, quality: 'high' })).to have_http_status(:found)
+      expect(response.location).to start_with(derivative.hls_url)
     end
 
     it 'returns a manifest if public' do


### PR DESCRIPTION
When we migrated our older Avalon instance to v7, we had a lot of preexisting variable bitrate manifests (with Derivatives) already in the system. This PR allows Avalon to recognize when there's an existing `auto` quality derivative and redirect to its streaming URL in response to a request for an `auto` quality HLS manifest, or fall back to building one on the fly if there isn't one. It also makes two small changes to other behaviors when requesting single quality manifests:

- Instead of building a one-off manifest containing the requested quality, it simply redirects to it
- If the requested quality doesn't exist, it returns a `404 Not Found` instead of delivering an empty manifest