### PR TITLE
Provide a default CSP policy and add nonces to our JS

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -68,7 +68,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if login_popup?
       flash[:success] = nil
-      render inline: '<html><head><script>window.close();</script></head><body></body><html>'.html_safe
+      render inline: "<html><head><script nonce='#{content_security_policy_nonce}'>window.close();</script></head><body></body><html>".html_safe
     else
       redirect_to find_redirect_url(auth_type, lti_group: user_session&.dig(:lti_group))
     end

--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -49,7 +49,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   function inject_alert(message) {
     let alertElement = getById('alerts');
     // Remove alert with previous errors

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -148,7 +148,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render "form", modal_title: "Edit Collection Information" %>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   window.addEventListener('DOMContentLoaded', function () {
     add_cropper_handler('<%= attach_poster_admin_collection_path(@collection.id) %>');
   });

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -96,7 +96,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   query('.select-groups').addEventListener('change', function () {
     const isChecked = this.checked;
     queryAll('input[id^=user_ids_]').forEach(function(checkbox) {

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -94,7 +94,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   queryAll('.close').forEach(function(closeBtn) {
     closeBtn.addEventListener('click', function() {
       this.parentElement.remove();

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -40,7 +40,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   function inject_alert(message) {
     let alertElement = $('#alerts');
     // Remove alert with previous errors

--- a/app/views/admin/units/show.html.erb
+++ b/app/views/admin/units/show.html.erb
@@ -135,7 +135,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render "form", modal_title: "Edit Unit Information" %>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   window.addEventListener('DOMContentLoaded', function () {
     add_cropper_handler('<%= attach_poster_admin_unit_path(@unit.id) %>');
   });

--- a/app/views/bookmarks/update_access_control.html.erb
+++ b/app/views/bookmarks/update_access_control.html.erb
@@ -134,5 +134,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
   <% end %>
 
-  <script src="<%= asset_path('pop_help.js') %>"></script>
+  <script src="<%= asset_path('pop_help.js') %>" nonce="<%= content_security_policy_nonce %>"></script>
 </div>

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -27,10 +27,11 @@ Unless required by applicable law or agreed to in writing, software distributed
   <meta property="og:image" content=<%= @poster_url || request.base_url + image_path("AvalonMediaSystem_Logo_Large.png") %> />
 
   <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <%= favicon_link_tag %>
-  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <%= javascript_include_tag "application_bundle", "data-turbo-track": "reload", type: "module", defer: false %>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload", nonce: true %>
+  <%= javascript_include_tag "application_bundle", "data-turbo-track": "reload", type: "module", defer: false, nonce: true %>
   <%= yield :page_styles %>
   <%= yield :additional_head_content %>
   <%= render "modules/google_analytics" %>
@@ -69,7 +70,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <% if request.fullpath.include?('login_popup') %>
     <% content_for :page_scripts do %>
-      <script>
+      <script nonce="<%= content_security_policy_nonce %>">
         function closePopup() {
           window.close();
         }
@@ -81,7 +82,7 @@ Unless required by applicable law or agreed to in writing, software distributed
          if they are included here. That means the important content will
          load first; the page will not gag on trying to pull down files
          from a CDN -->
-  <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag 'application', nonce: true %>
   <%= yield :page_scripts %>
 </body>
 

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -21,9 +21,10 @@ Unless required by applicable law or agreed to in writing, software distributed
     <title><%= render_page_title %></title>
 
    <%= csrf_meta_tags %>
+   <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= favicon_link_tag %>
-    <%= javascript_include_tag "embed", "data-turbo-track": "reload", type: "module" %>
+    <%= javascript_include_tag "embed", "data-turbo-track": "reload", type: "module", nonce: true %>
     <%= yield :page_styles %>
     <%= yield :additional_head_content %>
     <%= render "modules/google_analytics" %>

--- a/app/views/master_files/_authenticate.html.erb
+++ b/app/views/master_files/_authenticate.html.erb
@@ -45,7 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     }
   </style>
 
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
 
     window.onload = function(){
       window["authterval"] = window.setInterval(function(){

--- a/app/views/master_files/iiif_auth_token.html.erb
+++ b/app/views/master_files/iiif_auth_token.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <html>
   <body>
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
     window.parent.postMessage(
       {
         <%# TODO: Determine if context and type cause issue with the auth 1 flow or

--- a/app/views/master_files/iiif_auth_token_error.html.erb
+++ b/app/views/master_files/iiif_auth_token_error.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <html>
   <body>
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
     window.parent.postMessage(
       {
         "@context": "http://iiif.io/api/auth/2/context.json", 

--- a/app/views/media_objects/_destroy_checkout.html.erb
+++ b/app/views/media_objects/_destroy_checkout.html.erb
@@ -48,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function () {
       let interval = null;
       /* Calculate remaining days and time for the lending perriod */

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -316,7 +316,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     queryAll('.filedata').forEach(fileInput => {
       fileInput.addEventListener('change', function(e) {
         e.preventDefault();

--- a/app/views/media_objects/_intercom_push_form.html.erb
+++ b/app/views/media_objects/_intercom_push_form.html.erb
@@ -54,7 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   document.addEventListener('DOMContentLoaded', function() {
     const pushButton = getById('intercom_push_submit_button');
     if (pushButton) {

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -70,7 +70,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     // When viewing video on smaller devices scroll to page content to fully
     // display the video player
     document.addEventListener('DOMContentLoaded', function () {

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -111,7 +111,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   document.addEventListener('DOMContentLoaded', function() {
     const filedataElements = queryAll('.filedata');
     filedataElements.forEach(function(filedata) {

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -59,7 +59,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   document.cookie = 'test_cookie=true'
   if(!document.cookie.match(/^(.*;)?\s*test_cookie\s*=\s*[^;]+(.*)?$/)){
     const cookielessAlert = getById('cookieless');

--- a/app/views/modules/_google_analytics.html.erb
+++ b/app/views/modules/_google_analytics.html.erb
@@ -14,8 +14,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if Settings.google_analytics_tracking_id.present? %>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Settings.google_analytics_tracking_id %>"></script>
-  <script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Settings.google_analytics_tracking_id %>" nonce="<%= content_security_policy_nonce %>"></script>
+  <script nonce="<%= content_security_policy_nonce %>">
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());

--- a/app/views/playlists/_action_buttons.html.erb
+++ b/app/views/playlists/_action_buttons.html.erb
@@ -38,7 +38,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   document.addEventListener('DOMContentLoaded', function() {
     window.add_copy_playlist_button_event()
   });

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -176,7 +176,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
 
     function toggleState(ele, text, state) {
       ele.innerHTML = text;

--- a/app/views/playlists/_share.html.erb
+++ b/app/views/playlists/_share.html.erb
@@ -25,7 +25,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   document.addEventListener('DOMContentLoaded', function() {
     setInterval(shareResourceListener, 500);
 

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -78,7 +78,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 
   <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     function setPopoverContent(target, new_content) {
       target._config.content = new_content;
       target.setContent();

--- a/app/views/playlists/_tag_form.html.erb
+++ b/app/views/playlists/_tag_form.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <input id="taglist" name="playlist[tags]" type="hidden" />
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -55,7 +55,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render partial: 'copy_playlist_modal', locals: { with_refresh: true } %>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       const filedataElements = queryAll('.filedata');
       filedataElements.forEach(function(filedata) {

--- a/app/views/timelines/_show_timeline_details.html.erb
+++ b/app/views/timelines/_show_timeline_details.html.erb
@@ -29,7 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     function setPopoverContent(target, new_content) {
       target._config.content = new_content;
       target.setContent();

--- a/app/views/timelines/_tag_form.html.erb
+++ b/app/views/timelines/_tag_form.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <input id="taglist" name="timeline[tags]" type="hidden" aria-label="timeline tags" />
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -53,7 +53,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render partial: 'copy_timeline_modal', locals: { with_refresh: true } %>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       const filedataElements = queryAll('.filedata');
       filedataElements.forEach(function(filedata) {

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       // Push footer to the bottom of the page content
       const footer = getById('footer');

--- a/app/views/users/sessions/omniauth_new.html.erb
+++ b/app/views/users/sessions/omniauth_new.html.erb
@@ -20,7 +20,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <body onLoad="doSave()">
 <%= button_to 'Login', user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider], params.slice(:provider).permit!), form: { name: 'form1' } %>
 </body>
-<script>
+<script nonce="<%= content_security_policy_nonce %>">
   function doSave() { document.form1.submit() }
 </script>
 </html>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,43 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    # Rails defaults
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+
+    # Custom policies
+    # JQuery requires this for compatibility with Firefox
+    # TODO: Test removal after JQuery fully excised
+    policy.script_src_attr :unsafe_inline
+    # There are many inline styles that are difficult, or unable, to provide
+    # the nonce value for. Leave unsafe for now.
+    # TODO: Clean up inline styles and provide nonce for any that cant be changed
+    policy.style_src   :unsafe_inline, :self, :https
+    # Blob required for media streaming. worker_src from firefox, media_src from chrome
+    policy.media_src   :self, :https, :blob
+    policy.worker_src  :self, :https, :blob
+    if Rails.env.development?
+      # :http is set for convenience in dev environment.
+      policy.connect_src :self, :http
+      # unsafe_eval is necessary for dev environment. DO NOT enable in prod.
+      policy.script_src  :self, :https, :unsafe_eval
+    else
+      policy.connect_src :self, :https
+      policy.script_src  :self, :https
+    end
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # TODO: Assess feasibility of adding stlye-src to nonce directives
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -71,9 +71,10 @@ describe Users::OmniauthCallbacksController, type: :controller do
 
     context 'when login_popup param is present' do
       let(:params) {{ login_popup: 1 }}
-      let(:self_closing_html) { '<html><head><script>window.close();</script></head><body></body><html>' }
+      let(:self_closing_html) { "<html><head><script nonce='nonce'>window.close();</script></head><body></body><html>" }
 
       it 'returns self-closing page' do
+        allow(controller).to receive(:content_security_policy_nonce).and_return("nonce")
         post :identity, params: params
         expect(response.content_type).to eq 'text/html; charset=utf-8'
         expect(response.body).to eq self_closing_html


### PR DESCRIPTION
Related issue: #4401

Avalon previously has required implementers to keep script and style directives in CSPs set to `unsafe-inline`. This commit adds a nonce value to all Javascript to allow at least script-src to be locked down tighter. Unfortunately, there are A LOT of inline styles throughout the codebase and some of our dependencies so locking down style-src is still not tenable at this moment. This work should provide better baseline security and provides implementers a basic default configuration that they can tighten or loosen as needed.

Manual testing performed in most recent Firefox and Chrome, currently untested in Safari

Tested working with this policy:
* File, Dropbox, and sharepoint uploading
* Derivative download from Minio
* Media Object, Playlist, Timeline, and Embed playback
* API requests
* Catalog index and search