### PR TITLE
Reduce the size of the initial solr request for improved performance on the majority of end user requests

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -409,7 +409,7 @@ protected
   end
 
   def set_masterfile_proxy
-    @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id], load_reflections: true)
+    @master_file = SpeedyAF::Proxy::MasterFile.find(params[:id], load_reflections: [:media_object, :derivatives])
     set_masterfile if @master_file.nil?
     @master_file
   rescue SpeedyAF::RecordNotFound


### PR DESCRIPTION
Thumbnail and poster requests are common requests and caching is setup around the call to the master file that would usually cause a fetch from fedora/solr to load the child file object.  But the speedy_af proxy loaded in a before_action requests all of its reflections in a single solr request including the thumbnail and poster.  Thus the caching isn't really providing any benefit.  If we don't load all of the reflections but only commonly used reflections then we can strike a balance between overhead of multiple solr requests and likelihood of needing the additional data including the additional strain put on solr and the additional data having to go across the network.

I did some simplified testing on our staging server and found that across a large number of requests this approach saves time for thumbnail requests.

```
# Baseline: fetch a master file with all reflections (x1000)
avalon(prod)> Benchmark.measure { 1000.times {  SpeedyAF::Proxy::MasterFile.find('s4655q00k', load_reflections: true) } }
=> #<Benchmark::Tms:0x00007f0d152304c8 @cstime=0.0, @cutime=0.0, @label="", @real=64.8495262019569, @stime=1.029974, @total=9.577423, @utime=8.547449>

# Fetch a master file with all reflections and load thumbnail from cache (x1000)
avalon(prod)> Benchmark.measure { 1000.times {  SpeedyAF::Proxy::MasterFile.find('s4655q00k', load_reflections: true); Rails.cache.fetch([mf_proxy.cache_key_with_version, 'thumbnail']) } }
=> #<Benchmark::Tms:0x00007f0d2cc31dc0 @cstime=0.0, @cutime=0.0, @label="", @real=60.38730342697818, @stime=0.903289, @total=9.246357999999997, @utime=8.343068999999996>

# Fetch a master file with limited reflections and load thumbnail from cache (x1000)
avalon(prod)> Benchmark.measure { 1000.times {  SpeedyAF::Proxy::MasterFile.find('s4655q00k', load_reflections: [:derivatives, :media_object]); Rails.cache.fetch([mf_proxy.cache_key_with_version, 'thumbnail']) } }
=> #<Benchmark::Tms:0x00007f0d15485660 @cstime=0.0, @cutime=0.0, @label="", @real=33.26430437900126, @stime=0.7148379999999999, @total=6.896681000000001, @utime=6.181843000000001>
```