### PR TITLE
Scope stream route to avoid conflict with other endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,7 @@ Rails.application.routes.draw do
       get :captions
       get :waveform
       match ':quality.m3u8', to: 'master_files#hls_manifest', via: [:get], as: :hls_manifest
-      match ':quality', to: 'master_files#stream', via: [:get], as: :stream
+      match '/stream/:quality', to: 'master_files#stream', via: [:get], as: :stream
       get 'structure', to: 'master_files#structure', constraints: { format: 'json' }
       post 'structure', to: 'master_files#set_structure', constraints: { format: 'json' }
       delete 'structure', to: 'master_files#delete_structure', constraints: { format: 'json' }

--- a/spec/routing/master_files_routing_spec.rb
+++ b/spec/routing/master_files_routing_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe MasterFilesController, type: :routing do
     end
 
     it "routes to stream" do
-      expect(get: "/master_files/abc1234/high").to route_to("master_files#stream", id: 'abc1234', quality: 'high')
+      expect(get: "/master_files/abc1234/stream/high").to route_to("master_files#stream", id: 'abc1234', quality: 'high')
     end
   end
 end


### PR DESCRIPTION
Resolves #6930 
Related to #6921 

This PR proposes fixing the routing conflict by making the stream endpoint be namespaced (e.g. `/master_file/<id>/high` would become `/master_file/<id>/stream/high`).  This does make it different from the existing hls manifest endpoint (e.g. `master_file/<id>/high.m3u8`).  I couldn't think of a different change that would be clear, flexible, and still retain the proximity to the hls manifest endpoint.

This route change should be safe to make since the stream route was added recently and hasn't made it into a release yet.