### PR TITLE
Fixes JS loading issue by modifying what get passed to babel-loader

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = (env, argv) => {
         },
         {
           test: /\.(js|jsx)$/,
-          exclude: /node_modules/,
+          exclude: /node_modules\/(?!(peaks\.js|waveform-data)\/).*/,
           use: {
             loader: 'babel-loader',
           }


### PR DESCRIPTION
Supersedes #6937 

Resolves issue with precompiled JS having a syntax error in application_bundle that breaks all react and probably other site JS.