### PR TITLE
Avoid encoding with html entities when using rails truncate helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,7 +158,7 @@ module ApplicationHelper
   def truncate_center label, output_label_length, end_length = 0
     end_length = output_label_length / 2 - 3 if end_length == 0
     end_length = 0 if end_length.negative?
-    truncate(label, length: output_label_length,
+    truncate(label, length: output_label_length, escape: false,
       omission: "...#{label.last(end_length)}")
   end
 

--- a/app/helpers/blacklight/local_blacklight_helper.rb
+++ b/app/helpers/blacklight/local_blacklight_helper.rb
@@ -19,7 +19,7 @@ module Blacklight::LocalBlacklightHelper
 
   def alternative_title_index_display args
     field = args[:document][args[:field]]
-    field.first(3).map { |f| truncate(f, length: 32) }.join("; ")
+    field.first(3).map { |f| truncate(f, length: 32, escape: false) }.join("; ")
   end
 
   def contributor_index_display args
@@ -33,7 +33,7 @@ module Blacklight::LocalBlacklightHelper
 
   def description_index_display args
     field = args[:document][args[:field]]
-    truncate(field, length: 200) unless field.blank?
+    truncate(field, length: 200, escape: false) unless field.blank?
   end
 
   def section_id_json_index_display args

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -94,6 +94,9 @@ describe ApplicationHelper do
     it "shouldn't truncate if not needed" do
       expect(helper.truncate_center("This string is short", 20)).to eq "This string is short"
     end
+    it "shouldn't percent encode" do
+      expect(helper.truncate_center("It doesn't have percent encoding", 20)).to eq "It doesn't...ncoding"
+    end
   end
 
   describe "#git_commit_info" do


### PR DESCRIPTION
Steps to Test:
- Create an object with an alternative title, a description, and a  with an apostrophe.
- Search for the object and make sure that the alternative title in the result does not have an html entity (`&#39;`)
- Go to the item view page and make sure both the alternative title and description do not have an html entity (`&#39;`)
- Also check with special characters in filenames on the Manage Files page as well as the Structure page