### PR TITLE
Convert script elements to javascript_tag helpers

### DIFF
--- a/app/views/admin/collections/_form.html.erb
+++ b/app/views/admin/collections/_form.html.erb
@@ -49,7 +49,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   function inject_alert(message) {
     let alertElement = getById('alerts');
     // Remove alert with previous errors
@@ -98,5 +98,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     }
     resetButton('.btn-stateful-loading');
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -148,9 +148,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render "form", modal_title: "Edit Collection Information" %>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   window.addEventListener('DOMContentLoaded', function () {
     add_cropper_handler('<%= attach_poster_admin_collection_path(@collection.id) %>');
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -96,7 +96,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   query('.select-groups').addEventListener('change', function () {
     const isChecked = this.checked;
     queryAll('input[id^=user_ids_]').forEach(function(checkbox) {
@@ -126,5 +126,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       button.setAttribute('disabled', 'disabled');
     });
   }
-</script>
+<% end %>
 <% end %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -94,7 +94,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   queryAll('.close').forEach(function(closeBtn) {
     closeBtn.addEventListener('click', function() {
       this.parentElement.remove();
@@ -130,5 +130,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     getById('remove-ability').classList.add('disabled');
     query('.delete').setAttribute('disabled', 'disabled');
   }
-</script>
+<% end %>
 <% end %>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -40,7 +40,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   function inject_alert(message) {
     let alertElement = $('#alerts');
     // Remove alert with previous errors
@@ -82,5 +82,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     }
     resetButton('.btn-stateful-loading');
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/admin/units/show.html.erb
+++ b/app/views/admin/units/show.html.erb
@@ -135,9 +135,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render "form", modal_title: "Edit Unit Information" %>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   window.addEventListener('DOMContentLoaded', function () {
     add_cropper_handler('<%= attach_poster_admin_unit_path(@unit.id) %>');
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/bookmarks/update_access_control.html.erb
+++ b/app/views/bookmarks/update_access_control.html.erb
@@ -134,5 +134,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
   <% end %>
 
-  <script src="<%= asset_path('pop_help.js') %>" nonce="<%= content_security_policy_nonce %>"></script>
+  <%= javascript_include_tag asset_path('pop_help.js'), nonce: true %>
 </div>

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -70,11 +70,11 @@ Unless required by applicable law or agreed to in writing, software distributed
 
   <% if request.fullpath.include?('login_popup') %>
     <% content_for :page_scripts do %>
-      <script nonce="<%= content_security_policy_nonce %>">
+      <%= javascript_tag nonce: true do %>
         function closePopup() {
           window.close();
         }
-      </script>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/master_files/_authenticate.html.erb
+++ b/app/views/master_files/_authenticate.html.erb
@@ -45,7 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     }
   </style>
 
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
 
     window.onload = function(){
       window["authterval"] = window.setInterval(function(){
@@ -84,5 +84,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       }), 1000);
     }
 
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/master_files/iiif_auth_token_error.html.erb
+++ b/app/views/master_files/iiif_auth_token_error.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <html>
   <body>
-    <script nonce="<%= content_security_policy_nonce %>">
+    <%= javascript_tag nonce: true do %>
     window.parent.postMessage(
       {
         "@context": "http://iiif.io/api/auth/2/context.json", 
@@ -25,6 +25,6 @@ Unless required by applicable law or agreed to in writing, software distributed
         "messageId": "<%= message_id %>"
       }
     );
-    </script>
+    <% end %>
   </body>
 </html>

--- a/app/views/media_objects/_destroy_checkout.html.erb
+++ b/app/views/media_objects/_destroy_checkout.html.erb
@@ -48,7 +48,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function () {
       let interval = null;
       /* Calculate remaining days and time for the lending perriod */
@@ -101,5 +101,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         }
       }
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -316,7 +316,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     queryAll('.filedata').forEach(fileInput => {
       fileInput.addEventListener('change', function(e) {
         e.preventDefault();
@@ -333,5 +333,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       });
     });
 
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/media_objects/_intercom_push_form.html.erb
+++ b/app/views/media_objects/_intercom_push_form.html.erb
@@ -54,7 +54,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   document.addEventListener('DOMContentLoaded', function() {
     const pushButton = getById('intercom_push_submit_button');
     if (pushButton) {
@@ -67,5 +67,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       });
     }
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -70,7 +70,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     // When viewing video on smaller devices scroll to page content to fully
     // display the video player
     document.addEventListener('DOMContentLoaded', function () {
@@ -172,5 +172,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         }
       }
     });
-</script>
+<% end %>
 <% end %>

--- a/app/views/media_objects/_structure.html.erb
+++ b/app/views/media_objects/_structure.html.erb
@@ -111,7 +111,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   document.addEventListener('DOMContentLoaded', function() {
     const filedataElements = queryAll('.filedata');
     filedataElements.forEach(function(filedata) {
@@ -120,5 +120,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       });
     });
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -59,7 +59,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   document.cookie = 'test_cookie=true'
   if(!document.cookie.match(/^(.*;)?\s*test_cookie\s*=\s*[^;]+(.*)?$/)){
     const cookielessAlert = getById('cookieless');
@@ -69,5 +69,5 @@ Unless required by applicable law or agreed to in writing, software distributed
   } else{
     document.cookie = 'test_cookie=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
   }
-</script>
+<% end %>
 <% end %>

--- a/app/views/modules/_google_analytics.html.erb
+++ b/app/views/modules/_google_analytics.html.erb
@@ -14,11 +14,11 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 <% if Settings.google_analytics_tracking_id.present? %>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Settings.google_analytics_tracking_id %>" nonce="<%= content_security_policy_nonce %>"></script>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{Settings.google_analytics_tracking_id}", async: true, nonce: true %>
+  <%= javascript_tag nonce: true do %>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', '<%= Settings.google_analytics_tracking_id %>');
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/playlists/_action_buttons.html.erb
+++ b/app/views/playlists/_action_buttons.html.erb
@@ -38,9 +38,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% end %>
 
 <% content_for :page_scripts do %>
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   document.addEventListener('DOMContentLoaded', function() {
     window.add_copy_playlist_button_event()
   });
-</script>
+<% end %>
 <% end %>

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -176,7 +176,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
 
     function toggleState(ele, text, state) {
       ele.innerHTML = text;
@@ -349,6 +349,6 @@ Unless required by applicable law or agreed to in writing, software distributed
         });
       });
     });
-  </script>
+  <% end %>
 
 <% end %>

--- a/app/views/playlists/_share.html.erb
+++ b/app/views/playlists/_share.html.erb
@@ -25,7 +25,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% content_for :page_scripts do %>
 
-<script nonce="<%= content_security_policy_nonce %>">
+<%= javascript_tag nonce: true do %>
   document.addEventListener('DOMContentLoaded', function() {
     setInterval(shareResourceListener, 500);
 
@@ -66,6 +66,6 @@ Unless required by applicable law or agreed to in writing, software distributed
       });
     }
   })
-</script>
+<% end %>
 
 <% end %>

--- a/app/views/playlists/_show_playlist_details.html.erb
+++ b/app/views/playlists/_show_playlist_details.html.erb
@@ -78,7 +78,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 
   <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     function setPopoverContent(target, new_content) {
       target._config.content = new_content;
       target.setContent();
@@ -157,5 +157,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         getNewLink.hide();
       });
     }
-  </script>
+  <% end %>
   <% end %>

--- a/app/views/playlists/_tag_form.html.erb
+++ b/app/views/playlists/_tag_form.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <input id="taglist" name="playlist[tags]" type="hidden" />
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],
@@ -66,5 +66,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       const tagsArray = Array.isArray(initialTags) ? initialTags : [initialTags];
       document.getElementById('taglist').value = JSON.stringify(tagsArray);
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -55,7 +55,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render partial: 'copy_playlist_modal', locals: { with_refresh: true } %>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       const filedataElements = queryAll('.filedata');
       filedataElements.forEach(function(filedata) {
@@ -64,5 +64,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         });
       });
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/timelines/_show_timeline_details.html.erb
+++ b/app/views/timelines/_show_timeline_details.html.erb
@@ -29,7 +29,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   </div>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     function setPopoverContent(target, new_content) {
       target._config.content = new_content;
       target.setContent();
@@ -136,5 +136,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         getNewLink.hide();
       });
     }
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/timelines/_tag_form.html.erb
+++ b/app/views/timelines/_tag_form.html.erb
@@ -24,7 +24,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <input id="taglist" name="timeline[tags]" type="hidden" aria-label="timeline tags" />
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       const tagSelect = new TomSelect(getById('tag-select'), {
         plugins: ['remove_button'],
@@ -66,5 +66,5 @@ Unless required by applicable law or agreed to in writing, software distributed
       const tagsArray = Array.isArray(initialTags) ? initialTags : [initialTags];
       document.getElementById('taglist').value = JSON.stringify(tagsArray);
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -53,7 +53,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <%= render partial: 'copy_timeline_modal', locals: { with_refresh: true } %>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       const filedataElements = queryAll('.filedata');
       filedataElements.forEach(function(filedata) {
@@ -62,5 +62,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         });
       });
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 </div>
 
 <% content_for :page_scripts do %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       // Push footer to the bottom of the page content
       const footer = getById('footer');
@@ -26,5 +26,5 @@ Unless required by applicable law or agreed to in writing, software distributed
         footer.style.top = (document.documentElement.scrollHeight + 5) + 'px';
       }
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/users/sessions/omniauth_new.html.erb
+++ b/app/views/users/sessions/omniauth_new.html.erb
@@ -20,7 +20,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 <body onLoad="doSave()">
 <%= button_to 'Login', user_omniauth_authorize_path(Avalon::Authentication::VisibleProviders.first[:provider], params.slice(:provider).permit!), form: { name: 'form1' } %>
 </body>
-<script nonce="<%= content_security_policy_nonce %>">
+<%=javascript_tag nonce: true do %>
   function doSave() { document.form1.submit() }
-</script>
+<% end %>
 </html>


### PR DESCRIPTION
Related issue: #6936

Utilizing the built in Rails helpers provides a much easier and more concise interface for providing nonce values to all of our inline scripts.