### PR TITLE
Remove trailing whitespace from id parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,7 @@ class ApplicationController < ActionController::Base
   around_action :handle_api_request, if: proc{|c| request.format.json? || request.format.atom? || request.headers['Avalon-Api-Key'].present? }
   before_action :rewrite_v4_ids, if: proc{|c| request.method_symbol == :get && [params[:id], params[:content]].flatten.compact.any? { |i| i =~ /^[a-z]+:[0-9]+$/}}
   before_action :set_no_cache_headers, if: proc{|c| request.xhr? }
+  prepend_before_action :rstrip_id_param
   prepend_before_action :remove_zero_width_chars
 
   rescue_from RSolr::Error::ConnectionRefused, :with => :handle_solr_connection_error
@@ -284,6 +285,10 @@ class ApplicationController < ActionController::Base
 
     def application_name
       Settings.name || 'Avalon Media System'
+    end
+
+    def rstrip_id_param
+      Array(params[:id]).map(&:rstrip!)
     end
 
     def remove_zero_width_chars

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -274,4 +274,19 @@ describe ApplicationController do
       expect(controller.params[:key][:subkey]).to eq "value"
     end
   end
+
+  describe 'rstrip_id_param' do
+    it 'removes trailing whitespace' do
+      get :show, params: { id: 'abc1234' }
+      expect(controller.params[:id]).to eq 'abc1234'
+      get :show, params: { id: "abc1234 " }
+      expect(controller.params[:id]).to eq 'abc1234'
+      get :show, params: { id: "abc1234\t" }
+      expect(controller.params[:id]).to eq 'abc1234'
+      get :show, params: { id: "abc1234\n" }
+      expect(controller.params[:id]).to eq 'abc1234'
+      get :show, params: { id: ["abc1234 ", "def5678 "] }
+      expect(controller.params[:id]).to eq ['abc1234', 'def5678']
+    end
+  end
 end


### PR DESCRIPTION
This addresses honeybadger errors most likely coming from copy and pasted urls.
(E.g. https://app.honeybadger.io/projects/54117/faults/133798246)