### PR TITLE
[8.2.1 RC2] Redirect master_files#transcript to supplemental_files#show

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -321,12 +321,6 @@ class MasterFilesController < ApplicationController
     redirect_to edit_media_object_path(current_media_object)
   end
 
-  def transcript
-    authorize! :read, @master_file, message: "You do not have sufficient privileges"
-    @supplemental_file = SupplementalFile.find(params[:t_id])
-    send_data @supplemental_file.file.download, filename: @supplemental_file.file.filename.to_s, type: @supplemental_file.file.content_type, disposition: 'inline'
-  end
-
   def download_derivative
     authorize! :download, @master_file
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ Rails.application.routes.draw do
       post 'structure', to: 'master_files#set_structure', constraints: { format: 'json' }
       delete 'structure', to: 'master_files#delete_structure', constraints: { format: 'json' }
       post 'move'
-      get 'transcript/:t_id', to: 'master_files#transcript'
+      get 'transcript/:t_id', :to => redirect('/master_files/%{id}/supplemental_files/%{t_id}')
       get :search
       
       if Settings.derivative.allow_download
@@ -193,7 +193,7 @@ Rails.application.routes.draw do
       member do
         get 'captions'
         get 'transcripts', :to => redirect('/master_files/%{master_file_id}/supplemental_files/%{id}')
-        get 'descriptions', :to => redirect('master_files/%{master_file_id}/supplemental_files/%{id}')
+        get 'descriptions', :to => redirect('/master_files/%{master_file_id}/supplemental_files/%{id}')
       end
       get :index, constraints: { format: 'json' }, on: :collection
     end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -39,7 +39,6 @@ describe MasterFilesController do
           expect(get :captions, params: { id: master_file.id }).to render_template('errors/restricted_pid')
           expect(get :waveform, params: { id: master_file.id }).to render_template('errors/restricted_pid')
           expect(post :attach_structure, params: { id: master_file.id }).to render_template('errors/restricted_pid')
-          expect(get :transcript, params: { id: master_file.id, t_id: '1' }).to render_template('errors/restricted_pid')
           expect(post :move, params: { id: master_file.id }).to render_template('errors/restricted_pid')
         end
         it "json routes should return 401" do
@@ -69,7 +68,6 @@ describe MasterFilesController do
           expect(get :captions, params: { id: master_file.id }).to render_template('errors/restricted_pid')
           expect(get :waveform, params: { id: master_file.id }).to render_template('errors/restricted_pid')
           expect(post :attach_structure, params: { id: master_file.id }).to render_template('errors/restricted_pid')
-          expect(get :transcript, params: { id: master_file.id, t_id: '1' }).to render_template('errors/restricted_pid')
           expect(post :move, params: { id: master_file.id }).to render_template('errors/restricted_pid')
         end
         it "json routes should return 401" do
@@ -932,32 +930,6 @@ describe MasterFilesController do
       expect(master_file.poster_offset).to eq 3000
       expect(master_file.date_digitized).to eq "2020-08-27T00:00:00Z"
       expect(master_file.permalink).to eq "https://perma.link"
-    end
-  end
-
-  describe "#transcript" do
-    let(:supplemental_file) { FactoryBot.create(:supplemental_file) }
-    let(:master_file) { FactoryBot.create(:master_file, supplemental_files: [supplemental_file]) }
-    let(:supplemental_file) { FactoryBot.create(:supplemental_file, :with_transcript_file, :with_transcript_tag, label: 'transcript') }
-
-    it 'serves transcript file content' do
-      login_as :administrator
-      expect(master_file.supplemental_files.first['tags']).to eq (["transcript"])
-      get('transcript', params: { use_route: 'master_files/:id/transcript', id: master_file.id, t_id: supplemental_file.id })
-      expect(response.headers['Content-Type']).to eq('text/vtt')
-      expect(response).to have_http_status(:ok)
-      expect(response.body.include? "Example captions").to be_truthy
-    end
-
-    context 'read from solr' do
-      it 'should not read from fedora' do
-        master_file
-        perform_enqueued_jobs(only: MediaObjectIndexingJob)
-        WebMock.reset_executed_requests!
-        login_as :administrator
-        get('transcript', params: { use_route: 'master_files/:id/transcript', id: master_file.id, t_id: supplemental_file.id })
-        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
-      end
     end
   end
 

--- a/spec/requests/master_files_spec.rb
+++ b/spec/requests/master_files_spec.rb
@@ -1,0 +1,51 @@
+# Copyright 2011-2026, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+require 'rails_helper'
+
+describe '/master_files/' do
+  describe "#transcript" do
+    let(:user) { FactoryBot.create(:administrator) }
+    let(:master_file) { FactoryBot.create(:master_file, supplemental_files: [supplemental_file]) }
+    let(:supplemental_file) { FactoryBot.create(:supplemental_file, :with_transcript_file, :with_transcript_tag, label: 'transcript') }
+
+    before do
+      allow(Settings.supplemental_files).to receive(:proxy).and_return(true)
+    end
+
+    it 'serves transcript file content' do
+      sign_in(user)
+      expect(master_file.supplemental_files.first['tags']).to eq (["transcript"])
+      get "/master_files/#{master_file.id}/transcript/#{supplemental_file.id}"
+      expect(response).to have_http_status(301)
+      follow_redirect! # Redirect to supplemental files path
+      expect(response.headers['Content-Type']).to eq('text/vtt')
+      expect(response).to have_http_status(:ok)
+      expect(response.body.include? "Example captions").to be_truthy
+    end
+
+    context 'read from solr' do
+      it 'should not read from fedora' do
+        master_file
+        perform_enqueued_jobs(only: MediaObjectIndexingJob)
+        WebMock.reset_executed_requests!
+        sign_in(user)
+        get "/master_files/#{master_file.id}/transcript/#{supplemental_file.id}"
+        expect(response).to have_http_status(301)
+        follow_redirect! # Redirect to supplemental files path
+        expect(a_request(:any, /#{ActiveFedora.fedora.base_uri}/)).not_to have_been_made
+      end
+    end
+  end
+end

--- a/spec/routing/master_files_routing_spec.rb
+++ b/spec/routing/master_files_routing_spec.rb
@@ -27,5 +27,10 @@ RSpec.describe MasterFilesController, type: :routing do
     it "routes to stream" do
       expect(get: "/master_files/abc1234/stream/high").to route_to("master_files#stream", id: 'abc1234', quality: 'high')
     end
+
+    it 'routes #transcript to supplemental files', type: :request do
+      get "/master_files/abc1234/transcript/1"
+      expect(response).to redirect_to("/master_files/abc1234/supplemental_files/1")
+    end
   end
 end


### PR DESCRIPTION
It appears that the transcript endpoint isn't referenced anymore and is purely for backwards compatibility. Instead of maintaining two implementations turn the route into a redirect.