### PR TITLE
Fix underscoring of keys in MediaConvert presets

### DIFF
--- a/config/initializers/active_encode.rb
+++ b/config/initializers/active_encode.rb
@@ -13,7 +13,9 @@ Rails.application.config.to_prepare do
     media_convert_client = Aws::MediaConvert::Client.new
     existing_presets = media_convert_client.list_presets(category: "avalon", list_by: "NAME").presets.map(&:name)
     Dir[Settings.encoding.presets_path + "/*.json"].each do |file|
-      json = JSON.parse(File.read(file)).deep_transform_keys! {|k| k.underscore.to_sym }
+      json = JSON.parse(File.read(file)).deep_transform_keys! do |k|
+        k.gsub(/([a-z])(\d)/, '\1_\2').underscore.to_sym
+      end
       next if existing_presets.include?(json[:name])
 
       media_convert_client.create_preset(json)


### PR DESCRIPTION
The ActiveSupport `String#underscore` method turns `M3u8Settings` into `m3u8_settings`, while `Aws::MediaConvert::Client#create_preset` expects `m3u_8_settings`. The same holds true for other instances where a lowercase letter is followed by a digit - the SDK expects `vc_3_settings`, `vp_8_settings`, etc., but the default underscoring changes them into `vc3_settings` and `vp8_settings`.

My temporary workaround was to change the key to `M3u_8Settings` in my preset JSON, but this fix will make sure Avalon can convert an unmodified preset export into a valid SDK call.